### PR TITLE
Local demo for CI bug

### DIFF
--- a/src.ts/account.ts
+++ b/src.ts/account.ts
@@ -97,6 +97,7 @@ export class Account {
                 throw error;
             }
         }
+        result = await this.retryTxResult(txHash);
 
         const flatLogs = result.logs.reduce((acc, it) => acc.concat(it.lines), []);
         if (transaction.hasOwnProperty('contractId')) {


### PR DESCRIPTION
`yarn test` should fail with `[-32700] Parse error: incorrect length for hash` for this POC

Need to figure out the actual problem as hash seems to actually be 32 bytes.

