### PR TITLE
feat: Exposed `JsonRpcProvider.sendJsonRpc` method to public to help playing with EXPERIMENTAL_* APIs in nearcore

### DIFF
--- a/lib/providers/json-rpc-provider.d.ts
+++ b/lib/providers/json-rpc-provider.d.ts
@@ -14,5 +14,5 @@ export declare class JsonRpcProvider extends Provider {
     query(path: string, data: string): Promise<any>;
     block(blockId: BlockId): Promise<BlockResult>;
     chunk(chunkId: ChunkId): Promise<ChunkResult>;
-    private sendJsonRpc;
+    sendJsonRpc(method: string, params: any[]): Promise<any>;
 }

--- a/src.ts/providers/json-rpc-provider.ts
+++ b/src.ts/providers/json-rpc-provider.ts
@@ -60,7 +60,7 @@ export class JsonRpcProvider extends Provider {
         return this.sendJsonRpc('chunk', [chunkId]);
     }
 
-    private async sendJsonRpc(method: string, params: any[]): Promise<any> {
+    async sendJsonRpc(method: string, params: any[]): Promise<any> {
         const request = {
             method,
             params,


### PR DESCRIPTION
We had a discussion about this change here: https://github.com/near/near-api-js/pull/245#discussion_r385943826