### PR TITLE
Setup separate entry point for browser build

### DIFF
--- a/browser-exports.js
+++ b/browser-exports.js
@@ -1,3 +1,3 @@
 require('error-polyfill');
-window.nearApi = require('./lib/index');
+window.nearApi = require('./lib/browser-index');
 window.Buffer = Buffer;

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "homepage": "https://github.com/near/near-api-js",
   "main": "lib/index.js",
+  "browser": "lib/browser-index.js",
   "types": "lib/index.d.ts",
   "dependencies": {
     "@types/bn.js": "^4.11.5",

--- a/src/browser-index.ts
+++ b/src/browser-index.ts
@@ -1,0 +1,37 @@
+'use strict';
+
+import * as providers from './providers';
+import * as utils from './utils';
+import * as keyStores from './key_stores/browser-index';
+import * as transactions from './transaction';
+
+import { Account } from './account';
+import * as accountCreator from './account_creator';
+import { Connection } from './connection';
+import { Signer, InMemorySigner } from './signer';
+import { Contract } from './contract';
+import { KeyPair } from './utils/key_pair';
+import { connect } from './near';
+
+// TODO: Deprecate and remove WalletAccount
+import { WalletAccount, WalletConnection } from './wallet-account';
+
+export {
+    accountCreator,
+    keyStores,
+    providers,
+    utils,
+    transactions,
+
+    Account,
+    Connection,
+    Contract,
+    InMemorySigner,
+    Signer,
+    KeyPair,
+
+    connect,
+
+    WalletAccount,
+    WalletConnection
+};

--- a/src/key_stores/browser-index.ts
+++ b/src/key_stores/browser-index.ts
@@ -1,0 +1,12 @@
+
+import { KeyStore } from './keystore';
+import { InMemoryKeyStore } from './in_memory_key_store';
+import { BrowserLocalStorageKeyStore } from './browser_local_storage_key_store';
+import { MergeKeyStore } from './merge_key_store';
+
+export {
+    KeyStore,
+    InMemoryKeyStore,
+    BrowserLocalStorageKeyStore,
+    MergeKeyStore,
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,7 @@
     },
     "files": [
         "src/index.ts",
+        "src/browser-index.ts",
     ],
     "typedocOptions": {
         "out": "docs/near-api-js",


### PR DESCRIPTION
This is needed to prevent web bundlers from failing with default config because `fs` module is not found. 