### PR TITLE
Fix remaining nearlib rename quirks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ storage
 node_modules
 *.map
 
-# Nearlib files & coverage
+# near-api-js files & coverage
 neardev/
 coverage/
 .nyc_output

--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,6 @@
 storage
 node_modules
 
-# Nearlib files & coverage
+# near-api-js files & coverage
 neardev/
 coverage/

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.com/near/near-api-js.svg?branch=master)](https://travis-ci.com/near/near-api-js)
 [![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/near/near-api-js) 
 
-nearlib is a JavaScript/TypeScript library for development of DApps on NEAR platform.
+near-api-js is a JavaScript/TypeScript library for development of DApps on NEAR platform.
 
 ## Install dependencies
 
@@ -41,7 +41,7 @@ Tests use sample contract from `near-hello` npm package, see https://github.com/
 
 Follow next steps:
 
-1. [Change hash for the commit with errors in the nearcore](https://github.com/nearprotocol/nearlib/blob/master/gen_error_types.js#L7-L9)
+1. [Change hash for the commit with errors in the nearcore](https://github.com/near/near-api-js/blob/master/gen_error_types.js#L7-L9)
 2. Generate new types for errors: `node gen_error_types.js`
 3. `yarn fix` fix any issues with linter.
 4. `yarn build` to update `lib/**.js` files

--- a/browser-exports.js
+++ b/browser-exports.js
@@ -1,3 +1,3 @@
 require('error-polyfill');
-window.nearlib = require('./lib/index');
+window.nearApi = require('./lib/index');
 window.Buffer = Buffer;

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "license": "MIT",
   "scripts": {
     "dist": "yarn browserify && yarn doc",
-    "browserify": "browserify browser-exports.js -i node-fetch -i http -i https -o dist/nearlib.js && browserify browser-exports.js -i node-fetch -g uglifyify -o dist/nearlib.min.js",
+    "browserify": "browserify browser-exports.js -i node-fetch -i http -i https -o dist/near-api-js.js && browserify browser-exports.js -i node-fetch -g uglifyify -o dist/near-api-js.min.js",
     "prebrowserify": "yarn build",
     "prepublish": "not-in-install && (yarn build && yarn browserify) || in-install",
     "compile": "tsc -p ./tsconfig.json",
@@ -66,7 +66,7 @@
   "bundlewatch": {
     "files": [
       {
-        "path": "dist/nearlib.min.js",
+        "path": "dist/near-api-js.min.js",
         "maxSize": "85kB"
       }
     ]

--- a/src/account.ts
+++ b/src/account.ts
@@ -14,7 +14,7 @@ import { parseRpcError } from './utils/rpc_errors';
 // incurred while running the contract execution. The unused amount will be refunded back to
 // the originator.
 // Default value is set to equal to max_prepaid_gas as discussed here:
-// https://github.com/nearprotocol/nearlib/pull/191#discussion_r369671912
+// https://github.com/near/near-api-js/pull/191#discussion_r369671912
 const DEFAULT_FUNC_CALL_GAS = new BN('10000000000000000');
 
 // Default number of retries before giving up on a transactioin.

--- a/src/near.ts
+++ b/src/near.ts
@@ -56,7 +56,7 @@ export class Near {
     }
 
     /**
-     * @deprecated Use `new nearlib.Contract(yourAccount, contractId, { viewMethods, changeMethods })` instead.
+     * @deprecated Use `new nearApi.Contract(yourAccount, contractId, { viewMethods, changeMethods })` instead.
      * @param contractId
      * @param options
      */

--- a/test/account.access_key.test.js
+++ b/test/account.access_key.test.js
@@ -1,5 +1,5 @@
 const BN = require('bn.js');
-const nearlib = require('../lib/index');
+const nearApi = require('../lib/index');
 const testUtils = require('./test-utils');
 
 let nearjs;
@@ -22,7 +22,7 @@ beforeEach(async () => {
 });
 
 test('make function call using access key', async() => {
-    const keyPair = nearlib.utils.KeyPair.fromRandom('ed25519');
+    const keyPair = nearApi.utils.KeyPair.fromRandom('ed25519');
     await workingAccount.addKey(keyPair.getPublicKey(), contractId, '', '100000000000000000000');
 
     // Override in the key store the workingAccount key to the given access key.
@@ -33,7 +33,7 @@ test('make function call using access key', async() => {
 });
 
 test('remove access key no longer works', async() => {
-    const keyPair = nearlib.utils.KeyPair.fromRandom('ed25519');
+    const keyPair = nearApi.utils.KeyPair.fromRandom('ed25519');
     let publicKey = keyPair.getPublicKey();
     await workingAccount.addKey(publicKey, contractId, '', 400000);
     await workingAccount.deleteKey(publicKey);
@@ -49,11 +49,11 @@ test('remove access key no longer works', async() => {
 });
 
 test('view account details after adding access keys', async() => {
-    const keyPair = nearlib.utils.KeyPair.fromRandom('ed25519');
+    const keyPair = nearApi.utils.KeyPair.fromRandom('ed25519');
     await workingAccount.addKey(keyPair.getPublicKey(), contractId, '', 1000000000);
 
     const contract2 = await testUtils.deployContract(workingAccount, 'test_contract2_' + Date.now());
-    const keyPair2 = nearlib.utils.KeyPair.fromRandom('ed25519');
+    const keyPair2 = nearApi.utils.KeyPair.fromRandom('ed25519');
     await workingAccount.addKey(keyPair2.getPublicKey(), contract2.contractId, '', 2000000000);
 
     const details = await workingAccount.getAccountDetails();
@@ -74,7 +74,7 @@ test('view account details after adding access keys', async() => {
 });
 
 test('loading account after adding a full key', async() => {
-    const keyPair = nearlib.utils.KeyPair.fromRandom('ed25519');
+    const keyPair = nearApi.utils.KeyPair.fromRandom('ed25519');
     // wallet calls this with an empty string for contract id and method
     await workingAccount.addKey(keyPair.getPublicKey(), '', '');
 

--- a/test/account.test.js
+++ b/test/account.test.js
@@ -1,5 +1,5 @@
 
-const nearlib = require('../lib/index');
+const nearApi = require('../lib/index');
 const testUtils  = require('./test-utils');
 const fs = require('fs');
 const BN = require('bn.js');
@@ -29,7 +29,7 @@ test('create account and then view account returns the created account', async (
     const newAccountName = testUtils.generateUniqueString('test');
     const newAccountPublicKey = '9AhWenZ3JddamBoyMqnTbp7yVbRuvqAv3zwfrWgfVRJE';
     await workingAccount.createAccount(newAccountName, newAccountPublicKey, testUtils.INITIAL_BALANCE);
-    const newAccount = new nearlib.Account(nearjs.connection, newAccountName);
+    const newAccount = new nearApi.Account(nearjs.connection, newAccountName);
     const state = await newAccount.state();
     expect(state.amount).toEqual(testUtils.INITIAL_BALANCE.toString());
 });
@@ -47,7 +47,7 @@ test('delete account', async() => {
     const sender = await testUtils.createAccount(workingAccount);
     const receiver = await testUtils.createAccount(workingAccount);
     await sender.deleteAccount(receiver.accountId);
-    const reloaded = new nearlib.Account(sender.connection, sender);
+    const reloaded = new nearApi.Account(sender.connection, sender);
     await expect(reloaded.state()).rejects.toThrow();
 });
 
@@ -89,7 +89,7 @@ describe('with deploy contract', () => {
         const newPublicKey = await nearjs.connection.signer.createKey(contractId, testUtils.networkId);
         const data = [...fs.readFileSync(HELLO_WASM_PATH)];
         await workingAccount.createAndDeployContract(contractId, newPublicKey, data, testUtils.INITIAL_BALANCE);
-        contract = new nearlib.Contract(workingAccount, contractId, {
+        contract = new nearApi.Contract(workingAccount, contractId, {
             viewMethods: ['hello', 'getValue', 'getAllKeys', 'returnHiWithLogs'],
             changeMethods: ['setValue', 'generateLogs', 'triggerAssert', 'testSetRemove']
         });
@@ -116,7 +116,7 @@ describe('with deploy contract', () => {
 
         const setCallValue = testUtils.generateUniqueString('setCallPrefix');
         const result2 = await workingAccount.functionCall(contractId, 'setValue', { value: setCallValue });
-        expect(nearlib.providers.getTransactionLastResult(result2)).toEqual(setCallValue);
+        expect(nearApi.providers.getTransactionLastResult(result2)).toEqual(setCallValue);
         expect(await workingAccount.viewFunction(contractId, 'getValue', {})).toEqual(setCallValue);
     });
 
@@ -193,14 +193,14 @@ describe('with deploy contract', () => {
     });
 
     test('can have view methods only', async () => {
-        const contract = new nearlib.Contract(workingAccount, contractId, {
+        const contract = new nearApi.Contract(workingAccount, contractId, {
             viewMethods: ['hello'],
         });
         expect(await contract.hello({ name: 'world' })).toEqual('hello world');
     });
 
     test('can have change methods only', async () => {
-        const contract = new nearlib.Contract(workingAccount, contractId, {
+        const contract = new nearApi.Contract(workingAccount, contractId, {
             changeMethods: ['hello'],
         });
         expect(await contract.hello({ name: 'world' })).toEqual('hello world');

--- a/test/fuzz/borsh-roundtrip.js
+++ b/test/fuzz/borsh-roundtrip.js
@@ -1,15 +1,15 @@
-const nearlib = require('../../lib/index');
+const nearApi = require('../../lib/index');
 
 exports.fuzz = input => {
     try {
-        const deserialized = nearlib.utils.serialize.deserialize(nearlib.transactions.SCHEMA, nearlib.transactions.Transaction, input);
-        const serialized = nearlib.utils.serialize.serialize(nearlib.transactions.SCHEMA, deserialized);
+        const deserialized = nearApi.utils.serialize.deserialize(nearApi.transactions.SCHEMA, nearApi.transactions.Transaction, input);
+        const serialized = nearApi.utils.serialize.serialize(nearApi.transactions.SCHEMA, deserialized);
         if (!serialized.equals(input)) {
             console.log(`Mismatching output:\n${serialized.toString('hex')}\nand input:\n${input.toString('hex')}`);
             throw new Error('Mismatching input and output');
         }
     } catch(e) {
-        if (e instanceof nearlib.utils.serialize.BorshError) {
+        if (e instanceof nearApi.utils.serialize.BorshError) {
             // Do nothing
         } else {
             throw e;

--- a/test/key_pair.test.js
+++ b/test/key_pair.test.js
@@ -1,33 +1,33 @@
 
-const nearlib = require('../lib/index');
+const nearApi = require('../lib/index');
 const { sha256 } = require('js-sha256');
 
 test('test sign and verify', async () => {
-    const keyPair = new nearlib.utils.key_pair.KeyPairEd25519('26x56YPzPDro5t2smQfGcYAPy3j7R2jB2NUb7xKbAGK23B6x4WNQPh3twb6oDksFov5X8ts5CtntUNbpQpAKFdbR');
+    const keyPair = new nearApi.utils.key_pair.KeyPairEd25519('26x56YPzPDro5t2smQfGcYAPy3j7R2jB2NUb7xKbAGK23B6x4WNQPh3twb6oDksFov5X8ts5CtntUNbpQpAKFdbR');
     expect(keyPair.publicKey.toString()).toEqual('ed25519:AYWv9RAN1hpSQA4p1DLhCNnpnNXwxhfH9qeHN8B4nJ59');
     const message = new Uint8Array(sha256.array('message'));
     const signature = keyPair.sign(message);
-    expect(nearlib.utils.serialize.base_encode(signature.signature)).toEqual('26gFr4xth7W9K7HPWAxq3BLsua8oTy378mC1MYFiEXHBBpeBjP8WmJEJo8XTBowetvqbRshcQEtBUdwQcAqDyP8T');
+    expect(nearApi.utils.serialize.base_encode(signature.signature)).toEqual('26gFr4xth7W9K7HPWAxq3BLsua8oTy378mC1MYFiEXHBBpeBjP8WmJEJo8XTBowetvqbRshcQEtBUdwQcAqDyP8T');
 });
 
 test('test sign and verify with random', async () => {
-    const keyPair = nearlib.utils.key_pair.KeyPairEd25519.fromRandom();
+    const keyPair = nearApi.utils.key_pair.KeyPairEd25519.fromRandom();
     const message = new Uint8Array(sha256.array('message'));
     const signature = keyPair.sign(message);
     expect(keyPair.verify(message, signature.signature)).toBeTruthy();
 });
 
 test('test from secret', async () => {
-    const keyPair = new nearlib.utils.key_pair.KeyPairEd25519('5JueXZhEEVqGVT5powZ5twyPP8wrap2K7RdAYGGdjBwiBdd7Hh6aQxMP1u3Ma9Yanq1nEv32EW7u8kUJsZ6f315C');
+    const keyPair = new nearApi.utils.key_pair.KeyPairEd25519('5JueXZhEEVqGVT5powZ5twyPP8wrap2K7RdAYGGdjBwiBdd7Hh6aQxMP1u3Ma9Yanq1nEv32EW7u8kUJsZ6f315C');
     expect(keyPair.publicKey.toString()).toEqual('ed25519:EWrekY1deMND7N3Q7Dixxj12wD7AVjFRt2H9q21QHUSW');
 });
 
 test('convert to string', async () => {
-    const keyPair = nearlib.utils.key_pair.KeyPairEd25519.fromRandom();
-    const newKeyPair = nearlib.utils.key_pair.KeyPair.fromString(keyPair.toString());
+    const keyPair = nearApi.utils.key_pair.KeyPairEd25519.fromRandom();
+    const newKeyPair = nearApi.utils.key_pair.KeyPair.fromString(keyPair.toString());
     expect(newKeyPair.secretKey).toEqual(keyPair.secretKey);
 
     const keyString = 'ed25519:2wyRcSwSuHtRVmkMCGjPwnzZmQLeXLzLLyED1NDMt4BjnKgQL6tF85yBx6Jr26D2dUNeC716RBoTxntVHsegogYw';
-    const keyPair2 = nearlib.utils.key_pair.KeyPair.fromString(keyString);
+    const keyPair2 = nearApi.utils.key_pair.KeyPair.fromString(keyString);
     expect(keyPair2.toString()).toEqual(keyString);
 });

--- a/test/key_stores/browser_keystore.test.js
+++ b/test/key_stores/browser_keystore.test.js
@@ -1,6 +1,6 @@
-const nearlib = require('../../lib/index');
+const nearApi = require('../../lib/index');
 
-const BrowserLocalStorageKeyStore = nearlib.keyStores.BrowserLocalStorageKeyStore;
+const BrowserLocalStorageKeyStore = nearApi.keyStores.BrowserLocalStorageKeyStore;
 
 describe('Browser keystore', () => {
     let ctx = {};

--- a/test/key_stores/in_memory_keystore.test.js
+++ b/test/key_stores/in_memory_keystore.test.js
@@ -1,6 +1,6 @@
-const nearlib = require('../../lib/index');
+const nearApi = require('../../lib/index');
 
-const InMemoryKeyStore = nearlib.keyStores.InMemoryKeyStore;
+const InMemoryKeyStore = nearApi.keyStores.InMemoryKeyStore;
 
 describe('In-memory keystore', () => {
     let ctx = {};

--- a/test/key_stores/keystore_common.js
+++ b/test/key_stores/keystore_common.js
@@ -1,7 +1,7 @@
 
-const nearlib = require('../../lib/index');
+const nearApi = require('../../lib/index');
 
-const KeyPair = nearlib.utils.KeyPairEd25519;
+const KeyPair = nearApi.utils.KeyPairEd25519;
 
 const NETWORK_ID_SINGLE_KEY = 'singlekeynetworkid';
 const ACCOUNT_ID_SINGLE_KEY = 'singlekey_accountid';

--- a/test/key_stores/merge_keystore.test.js
+++ b/test/key_stores/merge_keystore.test.js
@@ -1,9 +1,9 @@
-const nearlib = require('../../lib/index');
+const nearApi = require('../../lib/index');
 
-const KeyPair = nearlib.utils.KeyPairEd25519;
+const KeyPair = nearApi.utils.KeyPairEd25519;
 
-const MergeKeyStore = nearlib.keyStores.MergeKeyStore;
-const InMemoryKeyStore = nearlib.keyStores.InMemoryKeyStore;
+const MergeKeyStore = nearApi.keyStores.MergeKeyStore;
+const InMemoryKeyStore = nearApi.keyStores.InMemoryKeyStore;
 
 describe('Merge keystore', () => {
     let ctx = {};

--- a/test/key_stores/unencrypted_file_system_keystore.test.js
+++ b/test/key_stores/unencrypted_file_system_keystore.test.js
@@ -1,8 +1,8 @@
 
 const rimraf  = require('util').promisify(require('rimraf'));
 
-const nearlib = require('../../lib/index');
-const UnencryptedFileSystemKeyStore = nearlib.keyStores.UnencryptedFileSystemKeyStore;
+const nearApi = require('../../lib/index');
+const UnencryptedFileSystemKeyStore = nearApi.keyStores.UnencryptedFileSystemKeyStore;
 const { ensureDir } = require('../test-utils');
 
 const KEYSTORE_PATH = '../test-keys';

--- a/test/providers.test.js
+++ b/test/providers.test.js
@@ -1,9 +1,9 @@
 
-const nearlib = require('../lib/index');
+const nearApi = require('../lib/index');
 
 const withProvider = (fn) => {
     const config = Object.assign(require('./config')(process.env.NODE_ENV || 'test'));
-    const provider = new nearlib.providers.JsonRpcProvider(config.nodeUrl);
+    const provider = new nearApi.providers.JsonRpcProvider(config.nodeUrl);
     return () => fn(provider);
 };
 
@@ -45,7 +45,7 @@ test('final tx result', async() => {
             { id: '11113', outcome: { status: { SuccessValue: '' }, logs: [], receipt_ids: [], gas_burnt: 0 } }
         ]
     };
-    expect(nearlib.providers.getTransactionLastResult(result)).toEqual({});
+    expect(nearApi.providers.getTransactionLastResult(result)).toEqual({});
 });
 
 test('final tx result with null', async() => {
@@ -57,5 +57,5 @@ test('final tx result with null', async() => {
             { id: '11113', outcome: { status: { SuccessValue: '' }, logs: [], receipt_ids: [], gas_burnt: 0 } }
         ]
     };
-    expect(nearlib.providers.getTransactionLastResult(result)).toEqual(null);
+    expect(nearApi.providers.getTransactionLastResult(result)).toEqual(null);
 });

--- a/test/serialize.test.js
+++ b/test/serialize.test.js
@@ -1,15 +1,15 @@
 
 const fs = require('fs');
-const nearlib = require('../lib/index');
+const nearApi = require('../lib/index');
 
-class Test extends nearlib.utils.enums.Assignable {
+class Test extends nearApi.utils.enums.Assignable {
 }
 
 test('serialize object', async () => {
     const value = new Test({ x: 255, y: 20, z: '123', q: [1, 2, 3]});
     const schema = new Map([[Test, {kind: 'struct', fields: [['x', 'u8'], ['y', 'u64'], ['z', 'string'], ['q', [3]]] }]]);
-    let buf = nearlib.utils.serialize.serialize(schema, value);
-    let new_value = nearlib.utils.serialize.deserialize(schema, Test, buf);
+    let buf = nearApi.utils.serialize.serialize(schema, value);
+    let new_value = nearApi.utils.serialize.deserialize(schema, Test, buf);
     expect(new_value.x).toEqual(255);
     expect(new_value.y.toString()).toEqual('20');
     expect(new_value.z).toEqual('123');
@@ -17,35 +17,35 @@ test('serialize object', async () => {
 });
 
 test('serialize and sign multi-action tx', async() => {
-    const keyStore = new nearlib.keyStores.InMemoryKeyStore();
-    const keyPair = nearlib.utils.KeyPair.fromString('ed25519:2wyRcSwSuHtRVmkMCGjPwnzZmQLeXLzLLyED1NDMt4BjnKgQL6tF85yBx6Jr26D2dUNeC716RBoTxntVHsegogYw');
+    const keyStore = new nearApi.keyStores.InMemoryKeyStore();
+    const keyPair = nearApi.utils.KeyPair.fromString('ed25519:2wyRcSwSuHtRVmkMCGjPwnzZmQLeXLzLLyED1NDMt4BjnKgQL6tF85yBx6Jr26D2dUNeC716RBoTxntVHsegogYw');
     await keyStore.setKey('test', 'test.near', keyPair);
     const publicKey = keyPair.publicKey;
     const actions = [
-        nearlib.transactions.createAccount(),
-        nearlib.transactions.deployContract(new Uint8Array([1, 2, 3])),
-        nearlib.transactions.functionCall('qqq', new Uint8Array([1, 2, 3]), 1000, 1000000),
-        nearlib.transactions.transfer(123),
-        nearlib.transactions.stake(1000000, publicKey),
-        nearlib.transactions.addKey(publicKey, nearlib.transactions.functionCallAccessKey('zzz', ['www'], null)),
-        nearlib.transactions.deleteKey(publicKey),
-        nearlib.transactions.deleteAccount('123')
+        nearApi.transactions.createAccount(),
+        nearApi.transactions.deployContract(new Uint8Array([1, 2, 3])),
+        nearApi.transactions.functionCall('qqq', new Uint8Array([1, 2, 3]), 1000, 1000000),
+        nearApi.transactions.transfer(123),
+        nearApi.transactions.stake(1000000, publicKey),
+        nearApi.transactions.addKey(publicKey, nearApi.transactions.functionCallAccessKey('zzz', ['www'], null)),
+        nearApi.transactions.deleteKey(publicKey),
+        nearApi.transactions.deleteAccount('123')
     ];
-    const blockHash = nearlib.utils.serialize.base_decode('244ZQ9cgj3CQ6bWBdytfrJMuMQ1jdXLFGnr4HhvtCTnM');
-    let [hash, { transaction }] = await nearlib.transactions.signTransaction('123', 1, actions, blockHash, new nearlib.InMemorySigner(keyStore), 'test.near', 'test');
-    expect(nearlib.utils.serialize.base_encode(hash)).toEqual('Fo3MJ9XzKjnKuDuQKhDAC6fra5H2UWawRejFSEpPNk3Y');
-    const serialized = nearlib.utils.serialize.serialize(nearlib.transactions.SCHEMA, transaction);
+    const blockHash = nearApi.utils.serialize.base_decode('244ZQ9cgj3CQ6bWBdytfrJMuMQ1jdXLFGnr4HhvtCTnM');
+    let [hash, { transaction }] = await nearApi.transactions.signTransaction('123', 1, actions, blockHash, new nearApi.InMemorySigner(keyStore), 'test.near', 'test');
+    expect(nearApi.utils.serialize.base_encode(hash)).toEqual('Fo3MJ9XzKjnKuDuQKhDAC6fra5H2UWawRejFSEpPNk3Y');
+    const serialized = nearApi.utils.serialize.serialize(nearApi.transactions.SCHEMA, transaction);
     expect(serialized.toString('hex')).toEqual('09000000746573742e6e656172000f56a5f028dfc089ec7c39c1183b321b4d8f89ba5bec9e1762803cc2491f6ef80100000000000000030000003132330fa473fd26901df296be6adc4cc4df34d040efa2435224b6986910e630c2fef608000000000103000000010203020300000071717103000000010203e80300000000000040420f00000000000000000000000000037b0000000000000000000000000000000440420f00000000000000000000000000000f56a5f028dfc089ec7c39c1183b321b4d8f89ba5bec9e1762803cc2491f6ef805000f56a5f028dfc089ec7c39c1183b321b4d8f89ba5bec9e1762803cc2491f6ef800000000000000000000030000007a7a7a010000000300000077777706000f56a5f028dfc089ec7c39c1183b321b4d8f89ba5bec9e1762803cc2491f6ef80703000000313233');
 });
 
 function createTransferTx() {
     const actions = [
-        nearlib.transactions.transfer(1),
+        nearApi.transactions.transfer(1),
     ];
-    const blockHash = nearlib.utils.serialize.base_decode('244ZQ9cgj3CQ6bWBdytfrJMuMQ1jdXLFGnr4HhvtCTnM');
-    return nearlib.transactions.createTransaction(
+    const blockHash = nearApi.utils.serialize.base_decode('244ZQ9cgj3CQ6bWBdytfrJMuMQ1jdXLFGnr4HhvtCTnM');
+    return nearApi.transactions.createTransaction(
         'test.near',
-        nearlib.utils.PublicKey.fromString('Anu7LYDfpLtkP7E16LT9imXF694BdQaa9ufVkQiwTQxC'),
+        nearApi.utils.PublicKey.fromString('Anu7LYDfpLtkP7E16LT9imXF694BdQaa9ufVkQiwTQxC'),
         'whatever.near',
         1,
         actions,
@@ -58,13 +58,13 @@ test('serialize transfer tx', async() => {
     const serialized = transaction.encode();
     expect(serialized.toString('hex')).toEqual('09000000746573742e6e65617200917b3d268d4b58f7fec1b150bd68d69be3ee5d4cc39855e341538465bb77860d01000000000000000d00000077686174657665722e6e6561720fa473fd26901df296be6adc4cc4df34d040efa2435224b6986910e630c2fef6010000000301000000000000000000000000000000');
 
-    const deserialized = nearlib.transactions.Transaction.decode(serialized);
+    const deserialized = nearApi.transactions.Transaction.decode(serialized);
     expect(deserialized.encode()).toEqual(serialized);
 });
 
 async function createKeyStore() {
-    const keyStore = new nearlib.keyStores.InMemoryKeyStore();
-    const keyPair = nearlib.utils.KeyPair.fromString('ed25519:3hoMW1HvnRLSFCLZnvPzWeoGwtdHzke34B2cTHM8rhcbG3TbuLKtShTv3DvyejnXKXKBiV7YPkLeqUHN1ghnqpFv');
+    const keyStore = new nearApi.keyStores.InMemoryKeyStore();
+    const keyPair = nearApi.utils.KeyPair.fromString('ed25519:3hoMW1HvnRLSFCLZnvPzWeoGwtdHzke34B2cTHM8rhcbG3TbuLKtShTv3DvyejnXKXKBiV7YPkLeqUHN1ghnqpFv');
     await keyStore.setKey('test', 'test.near', keyPair);
     return keyStore;
 }
@@ -74,7 +74,7 @@ async function verifySignedTransferTx(signedTx) {
     const serialized = signedTx.encode();
     expect(serialized.toString('hex')).toEqual('09000000746573742e6e65617200917b3d268d4b58f7fec1b150bd68d69be3ee5d4cc39855e341538465bb77860d01000000000000000d00000077686174657665722e6e6561720fa473fd26901df296be6adc4cc4df34d040efa2435224b6986910e630c2fef601000000030100000000000000000000000000000000969a83332186ee9755e4839325525806e189a3d2d2bb4b4760e94443e97e1c4f22deeef0059a8e9713100eda6e19144da7e8a0ef7e539b20708ba1d8d021bd01');
     
-    const deserialized = nearlib.transactions.SignedTransaction.decode(serialized);
+    const deserialized = nearApi.transactions.SignedTransaction.decode(serialized);
     expect(deserialized.encode()).toEqual(serialized);
 }
 
@@ -82,7 +82,7 @@ test('serialize and sign transfer tx', async() => {
     const transaction = createTransferTx();
     const keyStore = await createKeyStore();
 
-    let [, signedTx] = await nearlib.transactions.signTransaction(transaction.receiverId, transaction.nonce, transaction.actions, transaction.blockHash, new nearlib.InMemorySigner(keyStore), 'test.near', 'test');
+    let [, signedTx] = await nearApi.transactions.signTransaction(transaction.receiverId, transaction.nonce, transaction.actions, transaction.blockHash, new nearApi.InMemorySigner(keyStore), 'test.near', 'test');
 
     verifySignedTransferTx(signedTx);
 });
@@ -91,7 +91,7 @@ test('serialize and sign transfer tx object', async() => {
     const transaction = createTransferTx();
     const keyStore = await createKeyStore();
 
-    let [, signedTx] = await nearlib.transactions.signTransaction(transaction, new nearlib.InMemorySigner(keyStore), 'test.near', 'test');
+    let [, signedTx] = await nearApi.transactions.signTransaction(transaction, new nearApi.InMemorySigner(keyStore), 'test.near', 'test');
 
     verifySignedTransferTx(signedTx);
 });
@@ -104,9 +104,9 @@ describe('roundtrip test', () => {
             const testDefinition = JSON.parse(fs.readFileSync(dataDir + '/'  + testFile));
             test(testFile, () => {
                 const data = Buffer.from(testDefinition.data, 'hex');
-                const type = Array.from(nearlib.transactions.SCHEMA.keys()).find(key => key.name === testDefinition.type);
-                const deserialized = nearlib.utils.serialize.deserialize(nearlib.transactions.SCHEMA, type, data);
-                const serialized = nearlib.utils.serialize.serialize(nearlib.transactions.SCHEMA, deserialized);
+                const type = Array.from(nearApi.transactions.SCHEMA.keys()).find(key => key.name === testDefinition.type);
+                const deserialized = nearApi.utils.serialize.deserialize(nearApi.transactions.SCHEMA, type, data);
+                const serialized = nearApi.utils.serialize.serialize(nearApi.transactions.SCHEMA, deserialized);
                 expect(serialized).toEqual(data);
             });
         }

--- a/test/signer.test.js
+++ b/test/signer.test.js
@@ -1,7 +1,7 @@
 
-const nearlib = require('../lib/index');
+const nearApi = require('../lib/index');
 
 test('test no key', async() => {
-    const signer = new nearlib.InMemorySigner(new nearlib.keyStores.InMemoryKeyStore());
+    const signer = new nearApi.InMemorySigner(new nearApi.keyStores.InMemoryKeyStore());
     await expect(signer.signMessage('message', 'user', 'network')).rejects.toThrow(/Key for user not found in network/);
 });

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -1,7 +1,7 @@
 const fs = require('fs').promises;
 const BN = require('bn.js');
 
-const nearlib = require('../lib/index');
+const nearApi = require('../lib/index');
 
 const networkId = 'unittest';
 const testAccountName = 'test.near';
@@ -10,14 +10,14 @@ const INITIAL_BALANCE = new BN('100000000000000000000000000');
 const HELLO_WASM_PATH = process.env.HELLO_WASM_PATH || 'node_modules/near-hello/dist/main.wasm';
 
 async function setUpTestConnection() {
-    const keyStore = new nearlib.keyStores.InMemoryKeyStore();
-    await keyStore.setKey(networkId, testAccountName, nearlib.utils.KeyPair.fromString('ed25519:2wyRcSwSuHtRVmkMCGjPwnzZmQLeXLzLLyED1NDMt4BjnKgQL6tF85yBx6Jr26D2dUNeC716RBoTxntVHsegogYw'));
+    const keyStore = new nearApi.keyStores.InMemoryKeyStore();
+    await keyStore.setKey(networkId, testAccountName, nearApi.utils.KeyPair.fromString('ed25519:2wyRcSwSuHtRVmkMCGjPwnzZmQLeXLzLLyED1NDMt4BjnKgQL6tF85yBx6Jr26D2dUNeC716RBoTxntVHsegogYw'));
     const config = Object.assign(require('./config')(process.env.NODE_ENV || 'test'), {
         networkId: networkId,
         deps: { keyStore },
     });
 
-    return nearlib.connect(config);
+    return nearApi.connect(config);
 }
 
 // Generate some unique string with a given prefix using the alice nonce.
@@ -30,14 +30,14 @@ async function createAccount(masterAccount, options = { amount: INITIAL_BALANCE,
     const newAccountName = generateUniqueString('test');
     const newPublicKey = await masterAccount.connection.signer.createKey(newAccountName, networkId);
     await masterAccount.createAccount(newAccountName, newPublicKey, options.amount);
-    return new nearlib.Account(masterAccount.connection, newAccountName);
+    return new nearApi.Account(masterAccount.connection, newAccountName);
 }
 
 async function deployContract(workingAccount, contractId, options = { amount: INITIAL_BALANCE.div(new BN(10)) }) {
     const newPublicKey = await workingAccount.connection.signer.createKey(contractId, networkId);
     const data = [...(await fs.readFile(HELLO_WASM_PATH))];
     await workingAccount.createAndDeployContract(contractId, newPublicKey, data, options.amount);
-    return new nearlib.Contract(workingAccount, contractId, {
+    return new nearApi.Contract(workingAccount, contractId, {
         viewMethods: ['getValue', 'getLastResult'],
         changeMethods: ['setValue', 'callPromise']
     });

--- a/test/utils/format.test.js
+++ b/test/utils/format.test.js
@@ -1,6 +1,6 @@
 // Unit tests for simple util code
 
-const nearlib = require('../../lib/index');
+const nearApi = require('../../lib/index');
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 50000;
 
@@ -28,7 +28,7 @@ test.each`
     ${'1000100000000000000000000000000'} | ${undefined} | ${'1,000,100'}
     ${'910000000000000000000000'}        | ${0}         | ${'1'}
 `('formatNearAmount($balance, $fracDigits) returns $expected', ({ balance, fracDigits, expected }) => {
-    expect(nearlib.utils.format.formatNearAmount(balance, fracDigits)).toEqual(expected);
+    expect(nearApi.utils.format.formatNearAmount(balance, fracDigits)).toEqual(expected);
 });
 
 test.each`
@@ -47,12 +47,12 @@ test.each`
     ${'000000.000001'}                | ${'1000000000000000000'}
     ${'1,000,000.1'}                  | ${'1000000100000000000000000000000'}
 `('parseNearAmount($amt) returns $expected', ({ amt, expected }) => {
-    expect(nearlib.utils.format.parseNearAmount(amt)).toEqual(expected);
+    expect(nearApi.utils.format.parseNearAmount(amt)).toEqual(expected);
 });
 
 test('parseNearAmount fails when parsing values with ≥25 decimal places', () => {
     expect(() => {
-        nearlib.utils.format.parseNearAmount('0.0000080990999998370878871');
+        nearApi.utils.format.parseNearAmount('0.0000080990999998370878871');
     }).toThrowError(
         'Cannot parse \'0.0000080990999998370878871\' as NEAR amount'
     );

--- a/test/utils/rpc-errors.test.js
+++ b/test/utils/rpc-errors.test.js
@@ -1,4 +1,4 @@
-const nearlib = require('../../lib/index');
+const nearApi = require('../../lib/index');
 const {
     parseRpcError,
     AccountAlreadyExists,
@@ -12,7 +12,7 @@ const {
     InvalidIteratorIndex,
     GasLimitExceeded,
     formatError
-} = nearlib.utils.rpc_errors;
+} = nearApi.utils.rpc_errors;
 describe('rpc-errors', () => {
     test('test AccountAlreadyExists error', async () => {
         let rpc_error = {

--- a/test/wallet-account.test.js
+++ b/test/wallet-account.test.js
@@ -8,12 +8,12 @@ global.window = {
 global.document = {
     title: 'documentTitle'
 };
-const nearlib = require('../lib/index');
+const nearApi = require('../lib/index');
 
 let history;
 let nearFake;
 let walletConnection;
-let keyStore = new nearlib.keyStores.InMemoryKeyStore();
+let keyStore = new nearApi.keyStores.InMemoryKeyStore();
 beforeEach(() => {
     nearFake = {
         config: {
@@ -22,7 +22,7 @@ beforeEach(() => {
             walletUrl: 'http://example.com/wallet',
         },
         connection: {
-            signer: new nearlib.InMemorySigner(keyStore)
+            signer: new nearApi.InMemorySigner(keyStore)
         }
     };
     newUrl = null;
@@ -38,7 +38,7 @@ beforeEach(() => {
             replaceState: (state, title, url) => history.push([state, title, url])
         }
     });
-    walletConnection = new nearlib.WalletConnection(nearFake);
+    walletConnection = new nearApi.WalletConnection(nearFake);
 });
 
 it('not signed in by default', () => {
@@ -65,7 +65,7 @@ it('can request sign in', async () => {
 });
 
 it('can complete sign in', async () => {
-    const keyPair = nearlib.KeyPair.fromRandom('ed25519');
+    const keyPair = nearApi.KeyPair.fromRandom('ed25519');
     global.window.location.href = `http://example.com/location?account_id=near.account&public_key=${keyPair.publicKey}`;
     await keyStore.setKey('networkId', 'pending_key' + keyPair.publicKey, keyPair);
 
@@ -79,14 +79,14 @@ it('can complete sign in', async () => {
 });
 
 const BLOCK_HASH = '244ZQ9cgj3CQ6bWBdytfrJMuMQ1jdXLFGnr4HhvtCTnM';
-const blockHash = nearlib.utils.serialize.base_decode(BLOCK_HASH);
+const blockHash = nearApi.utils.serialize.base_decode(BLOCK_HASH);
 function createTransferTx() {
     const actions = [
-        nearlib.transactions.transfer(1),
+        nearApi.transactions.transfer(1),
     ];
-    return nearlib.transactions.createTransaction(
+    return nearApi.transactions.createTransaction(
         'test.near',
-        nearlib.utils.PublicKey.fromString('Anu7LYDfpLtkP7E16LT9imXF694BdQaa9ufVkQiwTQxC'),
+        nearApi.utils.PublicKey.fromString('Anu7LYDfpLtkP7E16LT9imXF694BdQaa9ufVkQiwTQxC'),
         'whatever.near',
         1,
         actions,
@@ -108,7 +108,7 @@ it('can request transaction signing', async () => {
 
 it('requests transaction signing automatically when there is no local key', async () => {
     // TODO: Refactor copy-pasted common setup code
-    let keyPair = nearlib.KeyPair.fromRandom('ed25519');
+    let keyPair = nearApi.KeyPair.fromRandom('ed25519');
     walletConnection._authData = {
         allKeys: [ 'no_such_access_key', keyPair.publicKey.toString() ],
         accountId: 'signer.near'
@@ -139,7 +139,7 @@ it('requests transaction signing automatically when there is no local key', asyn
     };
 
     try {
-        await walletConnection.account().signAndSendTransaction('receiver.near', [nearlib.transactions.transfer(1)]);
+        await walletConnection.account().signAndSendTransaction('receiver.near', [nearApi.transactions.transfer(1)]);
         fail('expected to throw');
     } catch (e) {
         expect(e.message).toEqual('Failed to redirect to sign transaction');
@@ -154,9 +154,9 @@ it('requests transaction signing automatically when there is no local key', asyn
         }
     });
     const transactions = parsedUrl.query.transactions.split(',')
-        .map(txBase64 => nearlib.utils.serialize.deserialize(
-            nearlib.transactions.SCHEMA,
-            nearlib.transactions.Transaction,
+        .map(txBase64 => nearApi.utils.serialize.deserialize(
+            nearApi.transactions.SCHEMA,
+            nearApi.transactions.Transaction,
             Buffer.from(txBase64, 'base64')));
 
     expect(transactions).toHaveLength(1);


### PR DESCRIPTION
Cherry-picked some stuff from https://github.com/near/near-api-js/pull/287 and changed some other (e.g. using `nearApi` instead of `nearAPIJs`).

Local storage prefix cannot be changed this easily (we would effectively nuke existing accounts in wallet).