### PR TITLE
serve docs via GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,25 @@
+# This workflow builds the docs and deploys them to GitHub Pages on every commit to the master branch
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: Build & Deploy Docs
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '12.x'
+    - run: yarn install --frozen-lockfile
+    - uses: sterlingwes/gh-pages-deploy-action@v1.1
+      with:
+        access-token: ${{ secrets.ACCESS_TOKEN }}
+        source-directory: docs
+        build-command: typedoc src && touch docs/.nojekyll

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "semver": "^7.1.1",
     "ts-morph": "^7.0.0",
     "typedoc": "^0.17.1",
-    "typedoc-plugin-markdown": "^2.2.6",
     "typescript": "^3.5.1",
     "uglifyify": "^5.0.1"
   },
@@ -60,7 +59,6 @@
     "test": "jest test --runInBand",
     "lint": "eslint test && eslint src/**/*.ts",
     "fix": "eslint test --fix && eslint src/**/*.ts --fix",
-    "doc": "typedoc src/",
     "prefuzz": "yarn build",
     "fuzz": "jsfuzz test/fuzz/borsh-roundtrip.js test/fuzz/corpus/"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,16 +27,4 @@
         "src/index.ts",
         "src/browser-index.ts",
     ],
-    "typedocOptions": {
-        "out": "docs/near-api-js",
-        "theme": "docusaurus",
-        "skipSidebar": true,
-        "hideBreadcrumbs": true, 
-        "hideSources": true, 
-        "ignoreCompilerErrors": true,
-        "excludePrivate": true,
-        "excludeProtected": true,
-        "excludeExternals": true,
-        "stripInternal": true
-    }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2200,7 +2200,7 @@ gzip-size@^5.1.1:
     duplexer "^0.1.1"
     pify "^4.0.1"
 
-handlebars@^4.7.3, handlebars@^4.7.6:
+handlebars@^4.7.6:
   version "4.7.6"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.6.tgz#d4c05c1baf90e9945f77aa68a7a219aa4a7df74e"
   integrity sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==
@@ -4927,14 +4927,6 @@ typedoc-default-themes@^0.10.0:
   integrity sha512-FV3Fct86EXTuW8f6E7F4ntM/BrBD5u7E+b96MIfiDWh3S14V+b+nNO+XzL0pQTBzF7PT63qHuwhrEBUk8XuqKA==
   dependencies:
     lunr "^2.3.8"
-
-typedoc-plugin-markdown@^2.2.6:
-  version "2.2.17"
-  resolved "https://registry.yarnpkg.com/typedoc-plugin-markdown/-/typedoc-plugin-markdown-2.2.17.tgz#aaef7420e8268170e62c764f43740e10f842548d"
-  integrity sha512-eE6cTeqsZIbjur6RG91Lhx1vTwjR49OHwVPRlmsxY3dthS4FNRL8sHxT5Y9pkosBwv1kSmNGQEPHjMYy1Ag6DQ==
-  dependencies:
-    fs-extra "^8.1.0"
-    handlebars "^4.7.3"
 
 typedoc@^0.17.1:
   version "0.17.4"


### PR DESCRIPTION
Previously, we were copying the output of `yarn doc` from this repository and commiting it to the `docs` folder in https://github.com/nearprotocol/docs. Since `nearprotocol/docs` is a [docusaurus](https://docusaurus.io/) website, we used `typedoc-plugin-markdown` here in this repository to build documentation in the format expected by docusaurus.

Last week, realizing that this `yarn doc` output is an auto-generated artifact that we don't need to commit into either repository, I looked into automating this whole "build docs, copy to other repository" process; see https://github.com/nearprotocol/docs/pull/291. While attempting to finalize this approach with @amgando, we realized it had multiple issues:

* After about three days of effort, my script still had some major gaps that left the user experience lacking:

  * Building a proper sidebar for docs.nearprotocol.com was going to add additional complexity to the process
  * Getting "Edit this page" links to link to the proper spot would require extra effort

* Even if we spent time fixing those issues, we weren't going to be able to make a user experience for docs.nearprotocol.com that beat linking to an external docs website. Hosting docs at a consistent URL just doesn't give a big enough UX win to justify the maintenance burden this approach involves.

This last point ultimately made us scrap the approach. Why not keep high-level info on docs.nearprotocol.com, and put API Reference docs elsewhere? This allows each repository to maintain its own API Reference documentation, using a design aesthetic familiar to the language community of that repository. This seems like both a UX improvement and a maintainability improvement for `nearprotocol/docs`.

So, this commit adds the machinery we need to automatically build and deploy docs on every push to `master` here in `near-api-js`:

* remove `typedoc-plugin-markdown` package, as docs are no longer being exported to `nearprotocol/docs` repo and do not need to be built in docusaurus format
* remove configuration for `typedoc` command (`--out docs` is default)
* add github workflow for deploying docs on every commit to `master`
* remove `doc` script, as we only expect to run `typedoc` command via the automated workflow. Having an extra line in package.json seems like it clutters more than it clarifies, at this point.
* in addition to running `typedoc`, add `docs/.nojekyll` file to tell GitHub that this is not a Jekyll site, otherwise all paths that start with an underscore throw 404 errors

Note that we cannot test out the new workflow prior to merging it to `master`. Boo! However, also note that I've already built the docs locally and pushed to the `gh-pages` branch, so these docs are already live at https://near.github.io/near-api-js/