### PR TITLE
feat: export Near

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -8,6 +8,6 @@ import { Connection } from './connection';
 import { Signer, InMemorySigner } from './signer';
 import { Contract } from './contract';
 import { KeyPair } from './utils/key_pair';
-import { connect } from './near';
+import { connect, Near } from './near';
 import { WalletAccount, WalletConnection } from './wallet-account';
-export { accountCreator, keyStores, providers, utils, transactions, Account, Connection, Contract, InMemorySigner, Signer, KeyPair, connect, WalletAccount, WalletConnection };
+export { accountCreator, keyStores, providers, utils, transactions, Account, Connection, Contract, InMemorySigner, Signer, KeyPair, connect, Near, WalletAccount, WalletConnection };

--- a/lib/index.js
+++ b/lib/index.js
@@ -30,6 +30,7 @@ const key_pair_1 = require("./utils/key_pair");
 exports.KeyPair = key_pair_1.KeyPair;
 const near_1 = require("./near");
 exports.connect = near_1.connect;
+exports.Near = near_1.Near;
 // TODO: Deprecate and remove WalletAccount
 const wallet_account_1 = require("./wallet-account");
 exports.WalletAccount = wallet_account_1.WalletAccount;

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import { Connection } from './connection';
 import { Signer, InMemorySigner } from './signer';
 import { Contract } from './contract';
 import { KeyPair } from './utils/key_pair';
-import { connect } from './near';
+import { connect, Near } from './near';
 
 // TODO: Deprecate and remove WalletAccount
 import { WalletAccount, WalletConnection } from './wallet-account';
@@ -29,6 +29,7 @@ export {
     KeyPair,
 
     connect,
+    Near,
 
     WalletAccount,
     WalletConnection


### PR DESCRIPTION
`connect` is asynchronous, which limits the ways it can be used. The only reason it's asynchronous is to support `UnencryptedFileSystemKeyStore`. Browser-based apps will not need this.

If an app doesn't use the filesystem, let's give them a way to instantiate a `Near` instance synchronously, without using `connect`.