### PR TITLE
improve usability of contract functions

### DIFF
--- a/lib/contract.js
+++ b/lib/contract.js
@@ -6,6 +6,14 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const bn_js_1 = __importDefault(require("bn.js"));
 const providers_1 = require("./providers");
 const errors_1 = require("./utils/errors");
+// Makes `function.name` return given name
+function nameFunction(name, body) {
+    return {
+        [name](...args) {
+            return body(...args);
+        }
+    }[name];
+}
 /**
  * Defines a smart contract on NEAR including the mutable and non-mutable methods
  */
@@ -18,26 +26,26 @@ class Contract {
             Object.defineProperty(this, methodName, {
                 writable: false,
                 enumerable: true,
-                value: async function (args) {
-                    if (arguments.length > 1) {
+                value: nameFunction(methodName, async (args = {}, ...ignored) => {
+                    if (ignored.length || Object.prototype.toString.call(args) !== '[object Object]') {
                         throw new errors_1.PositionalArgsError();
                     }
-                    return this.account.viewFunction(this.contractId, methodName, args || {});
-                }
+                    return this.account.viewFunction(this.contractId, methodName, args);
+                })
             });
         });
         changeMethods.forEach((methodName) => {
             Object.defineProperty(this, methodName, {
                 writable: false,
                 enumerable: true,
-                value: async function (args, gas, amount) {
-                    if (arguments.length > 3) {
+                value: nameFunction(methodName, async (args = {}, gas, amount, ...ignored) => {
+                    if (ignored.length || Object.prototype.toString.call(args) !== '[object Object]') {
                         throw new errors_1.PositionalArgsError();
                     }
                     validateBNLike({ gas, amount });
-                    const rawResult = await this.account.functionCall(this.contractId, methodName, args || {}, gas, amount);
+                    const rawResult = await this.account.functionCall(this.contractId, methodName, args, gas, amount);
                     return providers_1.getTransactionLastResult(rawResult);
-                }
+                })
             });
         });
     }

--- a/test/account.test.js
+++ b/test/account.test.js
@@ -137,23 +137,6 @@ describe('with deploy contract', () => {
         expect(await contract.getValue()).toEqual(setCallValue);
     });
 
-    test('view call gives error message when accidentally using positional arguments', async() => {
-        await expect(contract.hello('trex')).rejects.toThrow(/Contract method calls expect named arguments wrapped in object.+/);
-        await expect(contract.hello({ a: 1 }, 'trex')).rejects.toThrow(/Contract method calls expect named arguments wrapped in object.+/);
-    });
-
-    test('change call gives error message when accidentally using positional arguments', async() => {
-        await expect(contract.setValue('whatever')).rejects.toThrow(/Contract method calls expect named arguments wrapped in object.+/);
-    });
-
-    test('change call gives error message for invalid gas argument', async() => {
-        await expect(contract.setValue({ a: 1}, 'whatever')).rejects.toThrow(/Expected number, decimal string or BN for 'gas' argument, but got.+/);
-    });
-
-    test('change call gives error message for invalid amount argument', async() => {
-        await expect(contract.setValue({ a: 1}, 1000, 'whatever')).rejects.toThrow(/Expected number, decimal string or BN for 'amount' argument, but got.+/);
-    });
-
     test('can get logs from method result', async () => {
         await contract.generateLogs();
         if (startFromVersion('0.4.11')) {

--- a/test/contract.test.js
+++ b/test/contract.test.js
@@ -1,0 +1,64 @@
+const { Contract } = require('../lib/contract');
+const { PositionalArgsError } = require('../lib/utils/errors');
+
+const account = {
+    viewFunction() {
+        return this;
+    },
+    functionCall() {
+        return this;
+    }
+};
+
+const contract = new Contract(account, null, {
+    viewMethods: ['viewMethod'],
+    changeMethods: ['changeMethod'],
+});
+
+['viewMethod', 'changeMethod'].forEach(method => {
+    describe(method, () => {
+        test('returns what you expect for .name', () => {
+            expect(contract[method].name).toBe(method);
+        });
+
+        test('maintains correct reference to `this` when passed around an application', async () => {
+            function callFuncInNewContext(fn) {
+                return fn();
+            }
+            expect(await callFuncInNewContext(contract[method]));
+        });
+
+        test('throws PositionalArgsError if first argument is not an object', () => {
+            return Promise.all([
+                1,
+                'lol',
+                [],
+                new Date(),
+                null,
+                new Set(),
+            ].map(async badArgs => {
+                try {
+                    await contract[method](badArgs);
+                    throw new Error(`Calling \`contract.${method}(${badArgs})\` worked. It shouldn't have worked.`);
+                } catch (e) {
+                    if (!(e instanceof PositionalArgsError)) throw e;
+                }
+            }));
+        });
+
+        test('throws PositionalArgsError if given too many arguments', () => {
+            return expect(contract[method]({}, 1, 0, 'oops')).rejects.toBeInstanceOf(PositionalArgsError);
+        });
+    });
+});
+
+describe('changeMethod', () => {
+    test('throws error message for invalid gas argument', () => {
+        return expect(contract.changeMethod({ a: 1}, 'whatever')).rejects.toThrow(/Expected number, decimal string or BN for 'gas' argument, but got.+/);
+    });
+
+    test('gives error message for invalid amount argument', () => {
+        return expect(contract.changeMethod({ a: 1}, 1000, 'whatever')).rejects.toThrow(/Expected number, decimal string or BN for 'amount' argument, but got.+/);
+    });
+
+});


### PR DESCRIPTION
This lays groundwork to improve the ergonomics of https://github.com/near-examples/guest-book/pull/79

Function Binding
----------------

When passing around contract functions throughout an app, I have ended
up in situations where `near-api-js` ends up throwing an error:

    TypeError: Cannot read property 'account' of undefined

Using arrow functions ensures correct binding of these functions, so
that `this` refers to what we expect.

`.name` behavior
----------------

If you call `someFunction.name`, JavaScript will show the name of the
function (see [mdn]). However, this doesn't work as expected with
functions defined using `Object.defineProperty`.

Using an approach found on [StackOverflow], this ensures that the
`.name` property works as expected for these contract functions.
Example:

    const contract = await new Contract(account, contractName, {
      viewMethods: ['getMessages']
    })
    console.log(conract.getMessages.name) // => 'getMessages'

  [mdn]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/name
  [StackOverflow]: https://stackoverflow.com/a/41854075/249801