### PR TITLE
add public_key field to key file

### DIFF
--- a/lib/key_stores/unencrypted_file_system_keystore.js
+++ b/lib/key_stores/unencrypted_file_system_keystore.js
@@ -60,7 +60,7 @@ class UnencryptedFileSystemKeyStore extends keystore_1.KeyStore {
      */
     async setKey(networkId, accountId, keyPair) {
         await ensureDir(`${this.keyDir}/${networkId}`);
-        const content = { account_id: accountId, private_key: keyPair.toString() };
+        const content = { account_id: accountId, public_key: keyPair.getPublicKey().toString(), private_key: keyPair.toString() };
         await writeFile(this.getKeyFilePath(networkId, accountId), JSON.stringify(content));
     }
     /**

--- a/src/key_stores/unencrypted_file_system_keystore.ts
+++ b/src/key_stores/unencrypted_file_system_keystore.ts
@@ -25,6 +25,7 @@ const mkdir = promisify(fs.mkdir);
  */
 interface AccountInfo {
     account_id: string;
+    public_key: string;
     private_key: string;
 }
 
@@ -67,7 +68,7 @@ export class UnencryptedFileSystemKeyStore extends KeyStore {
      */
     async setKey(networkId: string, accountId: string, keyPair: KeyPair): Promise<void> {
         await ensureDir(`${this.keyDir}/${networkId}`);
-        const content: AccountInfo = { account_id: accountId, private_key: keyPair.toString() };
+        const content: AccountInfo = { account_id: accountId, public_key: keyPair.getPublicKey().toString(), private_key: keyPair.toString() };
         await writeFile(this.getKeyFilePath(networkId, accountId), JSON.stringify(content));
     }
 

--- a/test/key_stores/unencrypted_file_system_keystore.test.js
+++ b/test/key_stores/unencrypted_file_system_keystore.test.js
@@ -3,7 +3,9 @@ const rimraf  = require('util').promisify(require('rimraf'));
 
 const nearApi = require('../../lib/index');
 const UnencryptedFileSystemKeyStore = nearApi.keyStores.UnencryptedFileSystemKeyStore;
+const KeyPair = nearApi.utils.KeyPairEd25519;
 const { ensureDir } = require('../test-utils');
+const fs = require('fs');
 
 const KEYSTORE_PATH = '../test-keys';
 
@@ -14,6 +16,21 @@ describe('Unencrypted file system keystore', () => {
         await rimraf(KEYSTORE_PATH);
         await ensureDir(KEYSTORE_PATH);
         ctx.keyStore = new UnencryptedFileSystemKeyStore(KEYSTORE_PATH);
+    });
+
+    it('test get key', async () => {
+        const key1 = KeyPair.fromRandom();
+        await ctx.keyStore.setKey('network', 'account', key1);
+        expect(await ctx.keyStore.getKey('network', 'account')).toEqual(key1);
+    });
+
+    it('test public key exists', async () => {
+        const key1 = KeyPair.fromRandom();
+        await ctx.keyStore.setKey('network', 'account', key1);
+        const keyFilePath = ctx.keyStore.getKeyFilePath('network', 'account');
+        const content = fs.readFileSync(keyFilePath);
+        const accountInfo = JSON.parse(content.toString());
+        expect(accountInfo.public_key).toEqual(key1.getPublicKey().toString());
     });
 
     require('./keystore_common').shouldStoreAndRetriveKeys(ctx);

--- a/test/key_stores/unencrypted_file_system_keystore.test.js
+++ b/test/key_stores/unencrypted_file_system_keystore.test.js
@@ -18,11 +18,7 @@ describe('Unencrypted file system keystore', () => {
         ctx.keyStore = new UnencryptedFileSystemKeyStore(KEYSTORE_PATH);
     });
 
-    it('test get key', async () => {
-        const key1 = KeyPair.fromRandom();
-        await ctx.keyStore.setKey('network', 'account', key1);
-        expect(await ctx.keyStore.getKey('network', 'account')).toEqual(key1);
-    });
+    require('./keystore_common').shouldStoreAndRetriveKeys(ctx);
 
     it('test public key exists', async () => {
         const key1 = KeyPair.fromRandom();
@@ -32,6 +28,4 @@ describe('Unencrypted file system keystore', () => {
         const accountInfo = JSON.parse(content.toString());
         expect(accountInfo.public_key).toEqual(key1.getPublicKey().toString());
     });
-
-    require('./keystore_common').shouldStoreAndRetriveKeys(ctx);
 });


### PR DESCRIPTION
Currently when we write a `UnencryptedFileSystemKeyStore` to file, we do not write the public key. This can cause problems as ed25519 public key is not recoverable from its private key. Also for nearcore compatibility it would be nice if the private key field is named "secret_key". @vgrichina do we have anything that depends on the field's name?