### PR TITLE
Fix retry on Timeout error

### DIFF
--- a/lib/account.js
+++ b/lib/account.js
@@ -74,6 +74,7 @@ class Account {
      * @returns {Promise<FinalExecutionOutcome>}
      */
     async retryTxResult(txHash, accountId) {
+        console.warn(`Retrying transaction ${accountId}:${serialize_1.base_encode(txHash)} as it has timed out`);
         let result;
         let waitTime = TX_STATUS_RETRY_WAIT;
         for (let i = 0; i < TX_STATUS_RETRY_NUMBER; i++) {

--- a/lib/account.js
+++ b/lib/account.js
@@ -78,8 +78,15 @@ class Account {
         let result;
         let waitTime = TX_STATUS_RETRY_WAIT;
         for (let i = 0; i < TX_STATUS_RETRY_NUMBER; i++) {
-            result = await this.connection.provider.txStatus(txHash, accountId);
-            if (typeof result.status === 'object' &&
+            try {
+                result = await this.connection.provider.txStatus(txHash, accountId);
+            }
+            catch (error) {
+                if (!error.message.match(/Transaction \w+ doesn't exist/)) {
+                    throw error;
+                }
+            }
+            if (result && typeof result.status === 'object' &&
                 (typeof result.status.SuccessValue === 'string' || typeof result.status.Failure === 'object')) {
                 return result;
             }

--- a/lib/providers/json-rpc-provider.js
+++ b/lib/providers/json-rpc-provider.js
@@ -148,7 +148,9 @@ class JsonRpcProvider extends provider_1.Provider {
             }
             else {
                 const errorMessage = `[${response.error.code}] ${response.error.message}: ${response.error.data}`;
-                if (errorMessage === '[-32000] Server error: send_tx_commit has timed out.') {
+                // NOTE: All this hackery is happening because structured errors not implemented
+                // TODO: Fix when https://github.com/nearprotocol/nearcore/issues/1839 gets resolved
+                if (response.error.data === 'Timeout') {
                     throw new errors_1.TypedError('send_tx_commit has timed out.', 'TimeoutError');
                 }
                 else {

--- a/src/account.ts
+++ b/src/account.ts
@@ -110,6 +110,7 @@ export class Account {
      * @returns {Promise<FinalExecutionOutcome>}
      */
     private async retryTxResult(txHash: Uint8Array, accountId: string): Promise<FinalExecutionOutcome> {
+        console.warn(`Retrying transaction ${accountId}:${base_encode(txHash)} as it has timed out`);
         let result;
         let waitTime = TX_STATUS_RETRY_WAIT;
         for (let i = 0; i < TX_STATUS_RETRY_NUMBER; i++) {

--- a/src/account.ts
+++ b/src/account.ts
@@ -114,8 +114,14 @@ export class Account {
         let result;
         let waitTime = TX_STATUS_RETRY_WAIT;
         for (let i = 0; i < TX_STATUS_RETRY_NUMBER; i++) {
-            result = await this.connection.provider.txStatus(txHash, accountId);
-            if (typeof result.status === 'object' &&
+            try {
+                result = await this.connection.provider.txStatus(txHash, accountId);
+            } catch (error) {
+                if (!error.message.match(/Transaction \w+ doesn't exist/)) {
+                    throw error;
+                }
+            }
+            if (result && typeof result.status === 'object' &&
                     (typeof result.status.SuccessValue === 'string' || typeof result.status.Failure === 'object')) {
                 return result;
             }

--- a/src/providers/json-rpc-provider.ts
+++ b/src/providers/json-rpc-provider.ts
@@ -165,7 +165,9 @@ export class JsonRpcProvider extends Provider {
                 }
             } else {
                 const errorMessage = `[${response.error.code}] ${response.error.message}: ${response.error.data}`;
-                if (errorMessage === '[-32000] Server error: send_tx_commit has timed out.') {
+                // NOTE: All this hackery is happening because structured errors not implemented
+                // TODO: Fix when https://github.com/nearprotocol/nearcore/issues/1839 gets resolved
+                if (response.error.data === 'Timeout') {
                     throw new TypedError('send_tx_commit has timed out.', 'TimeoutError');
                 } else {
                     throw new TypedError(errorMessage);


### PR DESCRIPTION
This is needed because nearcore fails to return proper structured error:
https://github.com/nearprotocol/nearcore/issues/1839

Related to https://github.com/near/near-api-js/issues/127
Fixes https://github.com/near/near-api-js/pull/280