### PR TITLE
hack to fix nearcore ci

### DIFF
--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -15,9 +15,10 @@ async function setUpTestConnection() {
         deps: { keyStore },
     });
 
-    if (config.masterAccount) {
-        await keyStore.setKey(networkId, config.masterAccount, nearApi.utils.KeyPair.fromString('ed25519:2wyRcSwSuHtRVmkMCGjPwnzZmQLeXLzLLyED1NDMt4BjnKgQL6tF85yBx6Jr26D2dUNeC716RBoTxntVHsegogYw'));
+    if (!config.masterAccount) {
+        config.masterAccount = 'test.near';
     }
+    await keyStore.setKey(networkId, config.masterAccount, nearApi.utils.KeyPair.fromString('ed25519:2wyRcSwSuHtRVmkMCGjPwnzZmQLeXLzLLyED1NDMt4BjnKgQL6tF85yBx6Jr26D2dUNeC716RBoTxntVHsegogYw'));
 
     return nearApi.connect(config);
 }


### PR DESCRIPTION
Nearcore CI is broken because after https://github.com/near/near-api-js/pull/285, there is no default master account for tests and because nearcore CI uses `local` as env, it will try to load key from `.near/validator_key.json`, which is not the right place since the unittest script uses `testdir` as the home directory. Not sure what the best way to fix it, but we can potentially add another environment `unittest`.