### PR TITLE
Record current directory in file system keystore

### DIFF
--- a/lib/key_stores/unencrypted_file_system_keystore.d.ts
+++ b/lib/key_stores/unencrypted_file_system_keystore.d.ts
@@ -1,7 +1,7 @@
 import { KeyPair } from '../utils/key_pair';
 import { KeyStore } from './keystore';
-export declare function loadJsonFile(path: string): Promise<any>;
-export declare function readKeyFile(path: string): Promise<[string, KeyPair]>;
+export declare function loadJsonFile(filename: string): Promise<any>;
+export declare function readKeyFile(filename: string): Promise<[string, KeyPair]>;
 export declare class UnencryptedFileSystemKeyStore extends KeyStore {
     readonly keyDir: string;
     constructor(keyDir: string);

--- a/lib/key_stores/unencrypted_file_system_keystore.js
+++ b/lib/key_stores/unencrypted_file_system_keystore.js
@@ -51,12 +51,7 @@ exports.readKeyFile = readKeyFile;
 class UnencryptedFileSystemKeyStore extends keystore_1.KeyStore {
     constructor(keyDir) {
         super();
-        // Check if path is absolute by resolving it and comparing to normailzed path.
-        if (path_1.default.resolve(keyDir) !== path_1.default.normalize(keyDir)) {
-            // If path is not absolute, add current working directory.
-            keyDir = path_1.default.join(process.cwd(), keyDir);
-        }
-        this.keyDir = keyDir;
+        this.keyDir = path_1.default.resolve(keyDir);
     }
     /**
      * Sets a storage item in a file, unencrypted

--- a/lib/key_stores/unencrypted_file_system_keystore.js
+++ b/lib/key_stores/unencrypted_file_system_keystore.js
@@ -5,6 +5,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.UnencryptedFileSystemKeyStore = exports.readKeyFile = exports.loadJsonFile = void 0;
 const fs_1 = __importDefault(require("fs"));
+const path_1 = __importDefault(require("path"));
 const util_1 = require("util");
 const key_pair_1 = require("../utils/key_pair");
 const keystore_1 = require("./keystore");
@@ -22,14 +23,14 @@ const writeFile = promisify(fs_1.default.writeFile);
 const unlink = promisify(fs_1.default.unlink);
 const readdir = promisify(fs_1.default.readdir);
 const mkdir = promisify(fs_1.default.mkdir);
-async function loadJsonFile(path) {
-    const content = await readFile(path);
+async function loadJsonFile(filename) {
+    const content = await readFile(filename);
     return JSON.parse(content.toString());
 }
 exports.loadJsonFile = loadJsonFile;
-async function ensureDir(path) {
+async function ensureDir(dir) {
     try {
-        await mkdir(path, { recursive: true });
+        await mkdir(dir, { recursive: true });
     }
     catch (err) {
         if (err.code !== 'EEXIST') {
@@ -37,8 +38,8 @@ async function ensureDir(path) {
         }
     }
 }
-async function readKeyFile(path) {
-    const accountInfo = await loadJsonFile(path);
+async function readKeyFile(filename) {
+    const accountInfo = await loadJsonFile(filename);
     // The private key might be in private_key or secret_key field.
     let privateKey = accountInfo.private_key;
     if (!privateKey && accountInfo.secret_key) {
@@ -50,6 +51,11 @@ exports.readKeyFile = readKeyFile;
 class UnencryptedFileSystemKeyStore extends keystore_1.KeyStore {
     constructor(keyDir) {
         super();
+        // Check if path is absolute by resolving it and comparing to normailzed path.
+        if (path_1.default.resolve(keyDir) !== path_1.default.normalize(keyDir)) {
+            // If path is not absolute, add current working directory.
+            keyDir = path_1.default.join(process.cwd(), keyDir);
+        }
         this.keyDir = keyDir;
     }
     /**

--- a/src/key_stores/unencrypted_file_system_keystore.ts
+++ b/src/key_stores/unencrypted_file_system_keystore.ts
@@ -58,12 +58,7 @@ export class UnencryptedFileSystemKeyStore extends KeyStore {
 
     constructor(keyDir: string) {
         super();
-        // Check if path is absolute by resolving it and comparing to normailzed path.
-        if (path.resolve(keyDir) !== path.normalize(keyDir)) {
-            // If path is not absolute, add current working directory.
-            keyDir = path.join(process.cwd(), keyDir);
-        }
-        this.keyDir = keyDir;
+        this.keyDir = path.resolve(keyDir);
     }
 
     /**

--- a/src/key_stores/unencrypted_file_system_keystore.ts
+++ b/src/key_stores/unencrypted_file_system_keystore.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import path from 'path';
 import { promisify as _promisify } from 'util';
 
 import { KeyPair } from '../utils/key_pair';
@@ -29,21 +30,21 @@ interface AccountInfo {
     private_key: string;
 }
 
-export async function loadJsonFile(path: string): Promise<any> {
-    const content = await readFile(path);
+export async function loadJsonFile(filename: string): Promise<any> {
+    const content = await readFile(filename);
     return JSON.parse(content.toString());
 }
 
-async function ensureDir(path: string): Promise<void> {
+async function ensureDir(dir: string): Promise<void> {
     try {
-        await mkdir(path, { recursive: true });
+        await mkdir(dir, { recursive: true });
     } catch (err) {
         if (err.code !== 'EEXIST') { throw err; }
     }
 }
 
-export async function readKeyFile(path: string): Promise<[string, KeyPair]> {
-    const accountInfo = await loadJsonFile(path);
+export async function readKeyFile(filename: string): Promise<[string, KeyPair]> {
+    const accountInfo = await loadJsonFile(filename);
     // The private key might be in private_key or secret_key field.
     let privateKey = accountInfo.private_key;
     if (!privateKey && accountInfo.secret_key) {
@@ -58,7 +59,7 @@ export class UnencryptedFileSystemKeyStore extends KeyStore {
     constructor(keyDir: string) {
         super();
         // Check if path is absolute by resolving it and comparing to normailzed path.
-        if (path.resolve(keyDir) !== path.normalize(yourPath)) {
+        if (path.resolve(keyDir) !== path.normalize(keyDir)) {
             // If path is not absolute, add current working directory.
             keyDir = path.join(process.cwd(), keyDir);
         }

--- a/src/key_stores/unencrypted_file_system_keystore.ts
+++ b/src/key_stores/unencrypted_file_system_keystore.ts
@@ -57,7 +57,7 @@ export class UnencryptedFileSystemKeyStore extends KeyStore {
 
     constructor(keyDir: string) {
         super();
-        this.keyDir = keyDir;
+        this.keyDir = path.join(process.cwd(), keyDir);
     }
 
     /**

--- a/src/key_stores/unencrypted_file_system_keystore.ts
+++ b/src/key_stores/unencrypted_file_system_keystore.ts
@@ -57,7 +57,12 @@ export class UnencryptedFileSystemKeyStore extends KeyStore {
 
     constructor(keyDir: string) {
         super();
-        this.keyDir = path.join(process.cwd(), keyDir);
+        // Check if path is absolute by resolving it and comparing to normailzed path.
+        if (path.resolve(keyDir) !== path.normalize(yourPath)) {
+            // If path is not absolute, add current working directory.
+            keyDir = path.join(process.cwd(), keyDir);
+        }
+        this.keyDir = keyDir;
     }
 
     /**

--- a/test/key_stores/unencrypted_file_system_keystore.test.js
+++ b/test/key_stores/unencrypted_file_system_keystore.test.js
@@ -6,6 +6,7 @@ const UnencryptedFileSystemKeyStore = nearApi.keyStores.UnencryptedFileSystemKey
 const KeyPair = nearApi.utils.KeyPairEd25519;
 const { ensureDir } = require('../test-utils');
 const fs = require('fs');
+const path = require('path');
 
 const KEYSTORE_PATH = '../test-keys';
 
@@ -19,6 +20,10 @@ describe('Unencrypted file system keystore', () => {
     });
 
     require('./keystore_common').shouldStoreAndRetriveKeys(ctx);
+
+    it('test path resolve', async() => {
+        expect(ctx.keyStore.keyDir).toEqual(path.join(process.cwd(), KEYSTORE_PATH));
+    });
 
     it('test public key exists', async () => {
         const key1 = KeyPair.fromRandom();


### PR DESCRIPTION
If application changes the path, keystore stops to work as it recorded a relative path.
This updates to record absolute path at the creation and leverage that during the app lifetime.