### PR TITLE
Add debug toString to signer and key stores

### DIFF
--- a/lib/account.js
+++ b/lib/account.js
@@ -80,7 +80,7 @@ class Account {
         const result = await exponential_backoff_1.default(TX_STATUS_RETRY_WAIT, TX_NONCE_RETRY_NUMBER, TX_STATUS_RETRY_WAIT_BACKOFF, async () => {
             const accessKeyInfo = await this.findAccessKey(receiverId, actions);
             if (!accessKeyInfo) {
-                throw new providers_1.TypedError(`Can not sign transactions for account ${this.accountId}, no matching key pair found in Signer.`, 'KeyNotFound');
+                throw new providers_1.TypedError(`Can not sign transactions for account ${this.accountId} on network ${this.connection.networkId}, no matching key pair found in ${this.connection.signer}.`, 'KeyNotFound');
             }
             const { publicKey, accessKey } = accessKeyInfo;
             const status = await this.connection.provider.status();

--- a/lib/key_stores/in_memory_key_store.d.ts
+++ b/lib/key_stores/in_memory_key_store.d.ts
@@ -41,4 +41,5 @@ export declare class InMemoryKeyStore extends KeyStore {
      * @returns{Promise<string[]>}
      */
     getAccounts(networkId: string): Promise<string[]>;
+    toString(): string;
 }

--- a/lib/key_stores/in_memory_key_store.js
+++ b/lib/key_stores/in_memory_key_store.js
@@ -74,5 +74,8 @@ class InMemoryKeyStore extends keystore_1.KeyStore {
         });
         return result;
     }
+    toString() {
+        return 'InMemoryKeyStore';
+    }
 }
 exports.InMemoryKeyStore = InMemoryKeyStore;

--- a/lib/key_stores/merge_key_store.d.ts
+++ b/lib/key_stores/merge_key_store.d.ts
@@ -44,4 +44,5 @@ export declare class MergeKeyStore extends KeyStore {
      * @returns{Promise<string[]>}
      */
     getAccounts(networkId: string): Promise<string[]>;
+    toString(): string;
 }

--- a/lib/key_stores/merge_key_store.js
+++ b/lib/key_stores/merge_key_store.js
@@ -82,5 +82,8 @@ class MergeKeyStore extends keystore_1.KeyStore {
         }
         return Array.from(result);
     }
+    toString() {
+        return `MergeKeyStore(${this.keyStores.join(', ')})`;
+    }
 }
 exports.MergeKeyStore = MergeKeyStore;

--- a/lib/key_stores/unencrypted_file_system_keystore.d.ts
+++ b/lib/key_stores/unencrypted_file_system_keystore.d.ts
@@ -41,4 +41,5 @@ export declare class UnencryptedFileSystemKeyStore extends KeyStore {
      * @returns{Promise<string[]>}
      */
     getAccounts(networkId: string): Promise<string[]>;
+    toString(): string;
 }

--- a/lib/key_stores/unencrypted_file_system_keystore.js
+++ b/lib/key_stores/unencrypted_file_system_keystore.js
@@ -127,5 +127,8 @@ class UnencryptedFileSystemKeyStore extends keystore_1.KeyStore {
             .filter(file => file.endsWith('.json'))
             .map(file => file.replace(/.json$/, ''));
     }
+    toString() {
+        return `UnencryptedFileSystemKeyStore(${this.keyDir})`;
+    }
 }
 exports.UnencryptedFileSystemKeyStore = UnencryptedFileSystemKeyStore;

--- a/lib/signer.d.ts
+++ b/lib/signer.d.ts
@@ -49,4 +49,5 @@ export declare class InMemorySigner extends Signer {
      * @returns {Promise<Signature>}
      */
     signMessage(message: Uint8Array, accountId?: string, networkId?: string): Promise<Signature>;
+    toString(): string;
 }

--- a/lib/signer.js
+++ b/lib/signer.js
@@ -61,5 +61,8 @@ class InMemorySigner extends Signer {
         }
         return keyPair.sign(hash);
     }
+    toString() {
+        return `InMemorySigner(${this.keyStore})`;
+    }
 }
 exports.InMemorySigner = InMemorySigner;

--- a/src/account.ts
+++ b/src/account.ts
@@ -117,7 +117,7 @@ export class Account {
         const result = await exponentialBackoff(TX_STATUS_RETRY_WAIT, TX_NONCE_RETRY_NUMBER, TX_STATUS_RETRY_WAIT_BACKOFF, async () => {
             const accessKeyInfo = await this.findAccessKey(receiverId, actions);
             if (!accessKeyInfo) {
-                throw new TypedError(`Can not sign transactions for account ${this.accountId}, no matching key pair found in Signer.`, 'KeyNotFound');
+                throw new TypedError(`Can not sign transactions for account ${this.accountId} on network ${this.connection.networkId}, no matching key pair found in ${this.connection.signer}.`, 'KeyNotFound');
             }
             const { publicKey, accessKey } = accessKeyInfo;
 

--- a/src/key_stores/in_memory_key_store.ts
+++ b/src/key_stores/in_memory_key_store.ts
@@ -80,4 +80,8 @@ export class InMemoryKeyStore extends KeyStore {
         });
         return result;
     }
+
+    toString(): string {
+        return 'InMemoryKeyStore';
+    }
 }

--- a/src/key_stores/merge_key_store.ts
+++ b/src/key_stores/merge_key_store.ts
@@ -89,4 +89,8 @@ export class MergeKeyStore extends KeyStore {
         }
         return Array.from(result);
     }
+
+    toString(): string {
+        return `MergeKeyStore(${this.keyStores.join(', ')})`;
+    }
 }

--- a/src/key_stores/unencrypted_file_system_keystore.ts
+++ b/src/key_stores/unencrypted_file_system_keystore.ts
@@ -141,4 +141,8 @@ export class UnencryptedFileSystemKeyStore extends KeyStore {
             .filter(file => file.endsWith('.json'))
             .map(file => file.replace(/.json$/, ''));
     }
+
+    toString(): string {
+        return `UnencryptedFileSystemKeyStore(${this.keyDir})`;
+    }
 }

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -82,4 +82,8 @@ export class InMemorySigner extends Signer {
         }
         return keyPair.sign(hash);
     }
+
+    toString(): string {
+        return `InMemorySigner(${this.keyStore})`;
+    }
 }

--- a/test/account.access_key.test.js
+++ b/test/account.access_key.test.js
@@ -40,7 +40,7 @@ test('remove access key no longer works', async() => {
         await contract.setValue({value: 'test'});
         fail('should throw an error');
     } catch (e) {
-        expect(e.message).toEqual(`Can not sign transactions for account ${workingAccount.accountId}, no matching key pair found in Signer.`);
+        expect(e.message).toEqual(`Can not sign transactions for account ${workingAccount.accountId} on network unittest, no matching key pair found in InMemorySigner(InMemoryKeyStore).`);
         expect(e.type).toEqual('KeyNotFound');
     }
 });


### PR DESCRIPTION
Makes error messages from Signer more useful:


> Can not sign transactions for account lockup.vg on network deDault, no matching key pair found in InMemorySigner(MergeKeyStore(UnencryptedFileSystemKeyStore(/Users/vg/.near-credentials), UnencryptedFileSystemKeyStore(/Users/vg/Documents/near-genesis/near-claims/neardev))).
