### PR TITLE
Fixing up addKey signature to support many method names

### DIFF
--- a/lib/account.d.ts
+++ b/lib/account.d.ts
@@ -90,12 +90,12 @@ export declare class Account {
     /**
      * @param publicKey A public key to be associated with the contract
      * @param contractId NEAR account where the contract is deployed
-     * @param methodName The method name on the contract as it is written in the contract code
+     * @param methodNames The method names on the contract that this key will have access to
      * @param amount Payment in yoctoⓃ that is sent to the contract during this function call
      * @returns {Promise<FinalExecutionOutcome>}
      * TODO: expand this API to support more options.
      */
-    addKey(publicKey: string | PublicKey, contractId?: string, methodName?: string, amount?: BN): Promise<FinalExecutionOutcome>;
+    addKey(publicKey: string | PublicKey, contractId?: string, methodNames?: string[], amount?: BN): Promise<FinalExecutionOutcome>;
     /**
      * @param publicKey The public key to be deleted
      * @returns {Promise<FinalExecutionOutcome>}

--- a/lib/account.js
+++ b/lib/account.js
@@ -231,18 +231,21 @@ class Account {
     /**
      * @param publicKey A public key to be associated with the contract
      * @param contractId NEAR account where the contract is deployed
-     * @param methodName The method name on the contract as it is written in the contract code
+     * @param methodNames The method names on the contract that this key will have access to
      * @param amount Payment in yoctoⓃ that is sent to the contract during this function call
      * @returns {Promise<FinalExecutionOutcome>}
      * TODO: expand this API to support more options.
      */
-    async addKey(publicKey, contractId, methodName, amount) {
+    async addKey(publicKey, contractId, methodNames, amount) {
         let accessKey;
         if (contractId === null || contractId === undefined || contractId === '') {
             accessKey = transaction_1.fullAccessKey();
         }
         else {
-            accessKey = transaction_1.functionCallAccessKey(contractId, !methodName ? [] : [methodName], amount);
+            if (!Array.isArray(methodNames)) {
+                methodNames = !methodNames ? [] : [methodNames];
+            }
+            accessKey = transaction_1.functionCallAccessKey(contractId, methodNames, amount);
         }
         return this.signAndSendTransaction(this.accountId, [transaction_1.addKey(key_pair_1.PublicKey.from(publicKey), accessKey)]);
     }

--- a/lib/account_multisig.d.ts
+++ b/lib/account_multisig.d.ts
@@ -22,7 +22,11 @@ export declare class AccountMultisig extends Account {
     contract: MultisigContract;
     storage: any;
     constructor(connection: Connection, accountId: string, storage: any);
-    addKey(publicKey: string | PublicKey, contractId?: string, methodName?: string, amount?: BN): Promise<FinalExecutionOutcome>;
+    /**
+     * If contractId matches given accountId, mutlisig only address another multisig access key.
+     * E.g. generally, one should not be adding full access keys to the multisig contract.
+     */
+    addKey(publicKey: string | PublicKey, contractId?: string, methodNames?: string[], amount?: BN): Promise<FinalExecutionOutcome>;
     signAndSendTransaction(receiverId: string, actions: Action[]): Promise<FinalExecutionOutcome>;
     signAndSendTransactions(transactions: any): Promise<void>;
     deployMultisig(contractBytes: Uint8Array): Promise<FinalExecutionOutcome>;

--- a/lib/account_multisig.js
+++ b/lib/account_multisig.js
@@ -31,11 +31,17 @@ class AccountMultisig extends account_1.Account {
         this.storage = storage;
         this.contract = getContract(this);
     }
-    async addKey(publicKey, contractId, methodName, amount) {
-        if (contractId) {
-            return super.addKey(publicKey, contractId, exports.MULTISIG_CHANGE_METHODS.join(), exports.MULTISIG_ALLOWANCE);
+    /**
+     * If contractId matches given accountId, mutlisig only address another multisig access key.
+     * E.g. generally, one should not be adding full access keys to the multisig contract.
+     */
+    async addKey(publicKey, contractId, methodNames, amount) {
+        if (contractId == this.accountId) {
+            return super.addKey(publicKey, this.accountId, exports.MULTISIG_CHANGE_METHODS, exports.MULTISIG_ALLOWANCE);
         }
-        return super.addKey(publicKey);
+        else {
+            throw new Error(`Multisig contract can not add keys for other accounts`);
+        }
     }
     async signAndSendTransaction(receiverId, actions) {
         const { accountId } = this;

--- a/lib/near.d.ts
+++ b/lib/near.d.ts
@@ -17,6 +17,7 @@ declare type NearConfig = {
     masterAccount?: string;
     networkId: string;
     nodeUrl: string;
+    walletUrl?: string;
 };
 export declare class Near {
     readonly config: any;

--- a/src/account.ts
+++ b/src/account.ts
@@ -305,17 +305,20 @@ export class Account {
     /**
      * @param publicKey A public key to be associated with the contract
      * @param contractId NEAR account where the contract is deployed
-     * @param methodName The method name on the contract as it is written in the contract code
+     * @param methodNames The method names on the contract that this key will have access to
      * @param amount Payment in yoctoⓃ that is sent to the contract during this function call
      * @returns {Promise<FinalExecutionOutcome>}
      * TODO: expand this API to support more options.
      */
-    async addKey(publicKey: string | PublicKey, contractId?: string, methodName?: string, amount?: BN): Promise<FinalExecutionOutcome> {
+    async addKey(publicKey: string | PublicKey, contractId?: string, methodNames?: string[], amount?: BN): Promise<FinalExecutionOutcome> {
         let accessKey;
         if (contractId === null || contractId === undefined || contractId === '') {
             accessKey = fullAccessKey();
         } else {
-            accessKey = functionCallAccessKey(contractId, !methodName ? [] : [methodName], amount);
+            if (!Array.isArray(methodNames)) {
+                methodNames = !methodNames ? [] : [methodNames];
+            }
+            accessKey = functionCallAccessKey(contractId, methodNames, amount);
         }
         return this.signAndSendTransaction(this.accountId, [addKey(PublicKey.from(publicKey), accessKey)]);
     }

--- a/src/account_multisig.ts
+++ b/src/account_multisig.ts
@@ -43,11 +43,16 @@ export class AccountMultisig extends Account {
         this.contract = <MultisigContract>getContract(this);
     }
 
-    async addKey(publicKey: string | PublicKey, contractId?: string, methodName?: string, amount?: BN): Promise<FinalExecutionOutcome> {
-        if (contractId) {
-            return super.addKey(publicKey, contractId, MULTISIG_CHANGE_METHODS.join(), MULTISIG_ALLOWANCE)
+    /** 
+     * If contractId matches given accountId, mutlisig only address another multisig access key.
+     * E.g. generally, one should not be adding full access keys to the multisig contract.
+     */
+    async addKey(publicKey: string | PublicKey, contractId?: string, methodNames?: string[], amount?: BN): Promise<FinalExecutionOutcome> {
+        if (contractId == this.accountId) {
+            return super.addKey(publicKey, this.accountId, MULTISIG_CHANGE_METHODS, MULTISIG_ALLOWANCE)
+        } else {
+            throw new Error(`Multisig contract can not add keys for other accounts`)
         }
-        return super.addKey(publicKey)
     }
 
     async signAndSendTransaction(receiverId: string, actions: Action[]): Promise<FinalExecutionOutcome> {


### PR DESCRIPTION
Additionally, fixing up logic in the MultisigAccount for AddKey.

This is fixing `add-key` command in near-shell