### PR TITLE
feat: allow borsh-serialized contract fn arguments

### DIFF
--- a/lib/browser-index.js
+++ b/lib/browser-index.js
@@ -14,13 +14,13 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
     __setModuleDefault(result, mod);
     return result;
 };
 var __exportStar = (this && this.__exportStar) || function(m, exports) {
     for (var p in m) if (p !== "default" && !exports.hasOwnProperty(p)) __createBinding(exports, m, p);
-};
+}
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.keyStores = __importStar(require("./key_stores/browser-index"));
 __exportStar(require("./common-index"), exports);

--- a/lib/common-index.js
+++ b/lib/common-index.js
@@ -14,7 +14,7 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
     __setModuleDefault(result, mod);
     return result;
 };

--- a/lib/contract.js
+++ b/lib/contract.js
@@ -15,6 +15,8 @@ function nameFunction(name, body) {
         }
     }[name];
 }
+const isUint8Array = (x) => x && x.byteLength !== undefined && x.byteLength === x.length;
+const isObject = (x) => Object.prototype.toString.call(x) === '[object Object]';
 /**
  * Defines a smart contract on NEAR including the mutable and non-mutable methods
  */
@@ -28,7 +30,7 @@ class Contract {
                 writable: false,
                 enumerable: true,
                 value: nameFunction(methodName, async (args = {}, ...ignored) => {
-                    if (ignored.length || Object.prototype.toString.call(args) !== '[object Object]') {
+                    if (ignored.length || !(isObject(args) || isUint8Array(args))) {
                         throw new errors_1.PositionalArgsError();
                     }
                     return this.account.viewFunction(this.contractId, methodName, args);
@@ -40,7 +42,7 @@ class Contract {
                 writable: false,
                 enumerable: true,
                 value: nameFunction(methodName, async (args = {}, gas, amount, ...ignored) => {
-                    if (ignored.length || Object.prototype.toString.call(args) !== '[object Object]') {
+                    if (ignored.length || !(isObject(args) || isUint8Array(args))) {
                         throw new errors_1.PositionalArgsError();
                     }
                     validateBNLike({ gas, amount });

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,13 +14,13 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
     __setModuleDefault(result, mod);
     return result;
 };
 var __exportStar = (this && this.__exportStar) || function(m, exports) {
     for (var p in m) if (p !== "default" && !exports.hasOwnProperty(p)) __createBinding(exports, m, p);
-};
+}
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.keyStores = __importStar(require("./key_stores/index"));
 __exportStar(require("./common-index"), exports);

--- a/lib/near.d.ts
+++ b/lib/near.d.ts
@@ -17,6 +17,7 @@ declare type NearConfig = {
     masterAccount?: string;
     networkId: string;
     nodeUrl: string;
+    walletUrl?: string;
 };
 export declare class Near {
     readonly config: any;

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -14,7 +14,7 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
     __setModuleDefault(result, mod);
     return result;
 };

--- a/lib/utils/rpc_errors.js
+++ b/lib/utils/rpc_errors.js
@@ -14,13 +14,13 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
     __setModuleDefault(result, mod);
     return result;
 };
 var __exportStar = (this && this.__exportStar) || function(m, exports) {
     for (var p in m) if (p !== "default" && !exports.hasOwnProperty(p)) __createBinding(exports, m, p);
-};
+}
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };

--- a/lib/utils/serialize.js
+++ b/lib/utils/serialize.js
@@ -20,7 +20,7 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
     __setModuleDefault(result, mod);
     return result;
 };
@@ -133,81 +133,84 @@ function handlingRangeError(target, propertyKey, propertyDescriptor) {
         }
     };
 }
-class BinaryReader {
-    constructor(buf) {
-        this.buf = buf;
-        this.offset = 0;
-    }
-    read_u8() {
-        const value = this.buf.readUInt8(this.offset);
-        this.offset += 1;
-        return value;
-    }
-    read_u32() {
-        const value = this.buf.readUInt32LE(this.offset);
-        this.offset += 4;
-        return value;
-    }
-    read_u64() {
-        const buf = this.read_buffer(8);
-        return new bn_js_1.default(buf, 'le');
-    }
-    read_u128() {
-        const buf = this.read_buffer(16);
-        return new bn_js_1.default(buf, 'le');
-    }
-    read_buffer(len) {
-        if ((this.offset + len) > this.buf.length) {
-            throw new BorshError(`Expected buffer length ${len} isn't within bounds`);
+let BinaryReader = /** @class */ (() => {
+    class BinaryReader {
+        constructor(buf) {
+            this.buf = buf;
+            this.offset = 0;
         }
-        const result = this.buf.slice(this.offset, this.offset + len);
-        this.offset += len;
-        return result;
-    }
-    read_string() {
-        const len = this.read_u32();
-        const buf = this.read_buffer(len);
-        try {
-            // NOTE: Using TextDecoder to fail on invalid UTF-8
-            return textDecoder.decode(buf);
+        read_u8() {
+            const value = this.buf.readUInt8(this.offset);
+            this.offset += 1;
+            return value;
         }
-        catch (e) {
-            throw new BorshError(`Error decoding UTF-8 string: ${e}`);
+        read_u32() {
+            const value = this.buf.readUInt32LE(this.offset);
+            this.offset += 4;
+            return value;
+        }
+        read_u64() {
+            const buf = this.read_buffer(8);
+            return new bn_js_1.default(buf, 'le');
+        }
+        read_u128() {
+            const buf = this.read_buffer(16);
+            return new bn_js_1.default(buf, 'le');
+        }
+        read_buffer(len) {
+            if ((this.offset + len) > this.buf.length) {
+                throw new BorshError(`Expected buffer length ${len} isn't within bounds`);
+            }
+            const result = this.buf.slice(this.offset, this.offset + len);
+            this.offset += len;
+            return result;
+        }
+        read_string() {
+            const len = this.read_u32();
+            const buf = this.read_buffer(len);
+            try {
+                // NOTE: Using TextDecoder to fail on invalid UTF-8
+                return textDecoder.decode(buf);
+            }
+            catch (e) {
+                throw new BorshError(`Error decoding UTF-8 string: ${e}`);
+            }
+        }
+        read_fixed_array(len) {
+            return new Uint8Array(this.read_buffer(len));
+        }
+        read_array(fn) {
+            const len = this.read_u32();
+            const result = Array();
+            for (let i = 0; i < len; ++i) {
+                result.push(fn());
+            }
+            return result;
         }
     }
-    read_fixed_array(len) {
-        return new Uint8Array(this.read_buffer(len));
-    }
-    read_array(fn) {
-        const len = this.read_u32();
-        const result = Array();
-        for (let i = 0; i < len; ++i) {
-            result.push(fn());
-        }
-        return result;
-    }
-}
-__decorate([
-    handlingRangeError
-], BinaryReader.prototype, "read_u8", null);
-__decorate([
-    handlingRangeError
-], BinaryReader.prototype, "read_u32", null);
-__decorate([
-    handlingRangeError
-], BinaryReader.prototype, "read_u64", null);
-__decorate([
-    handlingRangeError
-], BinaryReader.prototype, "read_u128", null);
-__decorate([
-    handlingRangeError
-], BinaryReader.prototype, "read_string", null);
-__decorate([
-    handlingRangeError
-], BinaryReader.prototype, "read_fixed_array", null);
-__decorate([
-    handlingRangeError
-], BinaryReader.prototype, "read_array", null);
+    __decorate([
+        handlingRangeError
+    ], BinaryReader.prototype, "read_u8", null);
+    __decorate([
+        handlingRangeError
+    ], BinaryReader.prototype, "read_u32", null);
+    __decorate([
+        handlingRangeError
+    ], BinaryReader.prototype, "read_u64", null);
+    __decorate([
+        handlingRangeError
+    ], BinaryReader.prototype, "read_u128", null);
+    __decorate([
+        handlingRangeError
+    ], BinaryReader.prototype, "read_string", null);
+    __decorate([
+        handlingRangeError
+    ], BinaryReader.prototype, "read_fixed_array", null);
+    __decorate([
+        handlingRangeError
+    ], BinaryReader.prototype, "read_array", null);
+    return BinaryReader;
+})();
 exports.BinaryReader = BinaryReader;
 function serializeField(schema, fieldName, value, fieldType, writer) {
     try {

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -12,6 +12,12 @@ function nameFunction(name, body) {
     }[name];
 }
 
+const isUint8Array = (x: any) =>
+    x && x.byteLength !== undefined && x.byteLength === x.length;
+
+const isObject = (x: any) =>
+    Object.prototype.toString.call(x) === '[object Object]';
+
 /**
  * Defines a smart contract on NEAR including the mutable and non-mutable methods
  */
@@ -19,7 +25,7 @@ export class Contract {
     readonly account: Account;
     readonly contractId: string;
 
-    constructor(account: Account, contractId: string, options: { viewMethods: string[], changeMethods: string[] }) {
+    constructor(account: Account, contractId: string, options: { viewMethods: string[]; changeMethods: string[] }) {
         this.account = account;
         this.contractId = contractId;
         const { viewMethods = [], changeMethods = [] } = options;
@@ -28,7 +34,7 @@ export class Contract {
                 writable: false,
                 enumerable: true,
                 value: nameFunction(methodName, async (args: object = {}, ...ignored) => {
-                    if (ignored.length || Object.prototype.toString.call(args) !== '[object Object]') {
+                    if (ignored.length || !(isObject(args) || isUint8Array(args))) {
                         throw new PositionalArgsError();
                     }
                     return this.account.viewFunction(this.contractId, methodName, args);
@@ -40,7 +46,7 @@ export class Contract {
                 writable: false,
                 enumerable: true,
                 value: nameFunction(methodName, async (args: object = {}, gas?: BN, amount?: BN, ...ignored) => {
-                    if (ignored.length || Object.prototype.toString.call(args) !== '[object Object]') {
+                    if (ignored.length || !(isObject(args) || isUint8Array(args))) {
                         throw new PositionalArgsError();
                     }
                     validateBNLike({ gas, amount });

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -4,9 +4,9 @@ import { getTransactionLastResult } from './providers';
 import { PositionalArgsError, ArgumentTypeError } from './utils/errors';
 
 // Makes `function.name` return given name
-function nameFunction(name, body) {
+function nameFunction(name: string, body: (args?: any[]) => {}) {
     return {
-        [name](...args) {
+        [name](...args: any[]) {
             return body(...args);
         }
     }[name];

--- a/test/contract.test.js
+++ b/test/contract.test.js
@@ -49,6 +49,10 @@ const contract = new Contract(account, null, {
         test('throws PositionalArgsError if given too many arguments', () => {
             return expect(contract[method]({}, 1, 0, 'oops')).rejects.toBeInstanceOf(PositionalArgsError);
         });
+
+        test('allows args encoded as Uint8Array (for borsh)', async () => {
+            expect(await contract[method](new Uint8Array()));
+        });
     });
 });
 


### PR DESCRIPTION
Let's say you have a `contract` object instantiated in your code, and the contract it wraps has an `add_person` function which receives a borsh-serialized struct. The following code now works:

    import { serialize } from 'near-api-js/lib/utils/serialize'

    class Person {
      constructor (proof) {
        Object.assign(this, proof)
      }
    }

    const personSchema = new Map([
      [Person, {
        kind: 'struct',
        fields: [
          ['age', 'u64'],
          ['name', 'String'],
        ]
      }]
    ])

    const person = new Person({ age: 33, name: 'Jesus' })

    contract.add_person(serialize(personSchema, person))