### PR TITLE
feat: enable view calls to deserialize with borsh

### DIFF
--- a/lib/account.d.ts
+++ b/lib/account.d.ts
@@ -15,6 +15,7 @@ export interface AccountBalance {
     staked: string;
     available: string;
 }
+declare function parseJsonFromRawResponse(response: Uint8Array): any;
 /**
  * More information on [the Account spec](https://nomicon.io/DataStructures/Account.html)
  */
@@ -114,7 +115,9 @@ export declare class Account {
      * @param args Any arguments to the view contract method, wrapped in JSON
      * @returns {Promise<any>}
      */
-    viewFunction(contractId: string, methodName: string, args: any): Promise<any>;
+    viewFunction(contractId: string, methodName: string, args: any, { parse }?: {
+        parse?: typeof parseJsonFromRawResponse;
+    }): Promise<any>;
     /**
      * @returns array of {access_key: AccessKey, public_key: PublicKey} items.
      */
@@ -130,3 +133,4 @@ export declare class Account {
      */
     getAccountBalance(): Promise<AccountBalance>;
 }
+export {};

--- a/lib/account.js
+++ b/lib/account.js
@@ -27,6 +27,9 @@ const TX_STATUS_RETRY_NUMBER = 12;
 const TX_STATUS_RETRY_WAIT = 500;
 // Exponential back off for waiting to retry.
 const TX_STATUS_RETRY_WAIT_BACKOFF = 1.5;
+function parseJsonFromRawResponse(response) {
+    return JSON.parse(response.toString());
+}
 /**
  * More information on [the Account spec](https://nomicon.io/DataStructures/Account.html)
  */
@@ -121,7 +124,7 @@ class Account {
             }
         });
         if (!result) {
-            throw new providers_1.TypedError(`nonce retries exceeded for transaction. This usually means there are too many parallel requests with the same access key.`, 'RetriesExceeded');
+            throw new providers_1.TypedError('nonce retries exceeded for transaction. This usually means there are too many parallel requests with the same access key.', 'RetriesExceeded');
         }
         const flatLogs = [result.transaction_outcome, ...result.receipts_outcome].reduce((acc, it) => {
             if (it.outcome.logs.length ||
@@ -276,14 +279,14 @@ class Account {
      * @param args Any arguments to the view contract method, wrapped in JSON
      * @returns {Promise<any>}
      */
-    async viewFunction(contractId, methodName, args) {
+    async viewFunction(contractId, methodName, args, { parse = parseJsonFromRawResponse } = {}) {
         args = args || {};
         this.validateArgs(args);
         const result = await this.connection.provider.query(`call/${contractId}/${methodName}`, serialize_1.base_encode(JSON.stringify(args)));
         if (result.logs) {
             this.printLogs(contractId, result.logs);
         }
-        return result.result && result.result.length > 0 && JSON.parse(Buffer.from(result.result).toString());
+        return result.result && result.result.length > 0 && parse(Buffer.from(result.result));
     }
     /**
      * @returns array of {access_key: AccessKey, public_key: PublicKey} items.

--- a/lib/account.js
+++ b/lib/account.js
@@ -333,7 +333,7 @@ class Account {
         const stateStaked = new bn_js_1.default(state.storage_usage).mul(costPerByte);
         const staked = new bn_js_1.default(state.locked);
         const totalBalance = new bn_js_1.default(state.amount).add(staked);
-        const availableBalance = totalBalance.sub(staked).sub(stateStaked);
+        const availableBalance = totalBalance.sub(bn_js_1.default.max(staked, stateStaked));
         return {
             total: totalBalance.toString(),
             stateStaked: stateStaked.toString(),

--- a/lib/account.js
+++ b/lib/account.js
@@ -28,7 +28,7 @@ const TX_STATUS_RETRY_WAIT = 500;
 // Exponential back off for waiting to retry.
 const TX_STATUS_RETRY_WAIT_BACKOFF = 1.5;
 function parseJsonFromRawResponse(response) {
-    return JSON.parse(response.toString());
+    return JSON.parse(Buffer.from(response).toString());
 }
 /**
  * More information on [the Account spec](https://nomicon.io/DataStructures/Account.html)

--- a/lib/browser-index.js
+++ b/lib/browser-index.js
@@ -14,13 +14,13 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
     __setModuleDefault(result, mod);
     return result;
 };
 var __exportStar = (this && this.__exportStar) || function(m, exports) {
     for (var p in m) if (p !== "default" && !exports.hasOwnProperty(p)) __createBinding(exports, m, p);
-};
+}
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.keyStores = __importStar(require("./key_stores/browser-index"));
 __exportStar(require("./common-index"), exports);

--- a/lib/common-index.js
+++ b/lib/common-index.js
@@ -14,7 +14,7 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
     __setModuleDefault(result, mod);
     return result;
 };

--- a/lib/contract.js
+++ b/lib/contract.js
@@ -29,11 +29,11 @@ class Contract {
             Object.defineProperty(this, methodName, {
                 writable: false,
                 enumerable: true,
-                value: nameFunction(methodName, async (args = {}, ...ignored) => {
-                    if (ignored.length || !(isObject(args) || isUint8Array(args))) {
+                value: nameFunction(methodName, async (args = {}, options = {}, ...ignored) => {
+                    if (ignored.length || !(isObject(args) || isUint8Array(args)) || !isObject(options)) {
                         throw new errors_1.PositionalArgsError();
                     }
-                    return this.account.viewFunction(this.contractId, methodName, args);
+                    return this.account.viewFunction(this.contractId, methodName, args, options);
                 })
             });
         });

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,13 +14,13 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
     __setModuleDefault(result, mod);
     return result;
 };
 var __exportStar = (this && this.__exportStar) || function(m, exports) {
     for (var p in m) if (p !== "default" && !exports.hasOwnProperty(p)) __createBinding(exports, m, p);
-};
+}
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.keyStores = __importStar(require("./key_stores/index"));
 __exportStar(require("./common-index"), exports);

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -14,7 +14,7 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
     __setModuleDefault(result, mod);
     return result;
 };

--- a/lib/utils/rpc_errors.js
+++ b/lib/utils/rpc_errors.js
@@ -14,13 +14,13 @@ var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
     __setModuleDefault(result, mod);
     return result;
 };
 var __exportStar = (this && this.__exportStar) || function(m, exports) {
     for (var p in m) if (p !== "default" && !exports.hasOwnProperty(p)) __createBinding(exports, m, p);
-};
+}
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };

--- a/lib/utils/serialize.js
+++ b/lib/utils/serialize.js
@@ -20,7 +20,7 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
 var __importStar = (this && this.__importStar) || function (mod) {
     if (mod && mod.__esModule) return mod;
     var result = {};
-    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    if (mod != null) for (var k in mod) if (Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
     __setModuleDefault(result, mod);
     return result;
 };
@@ -133,81 +133,84 @@ function handlingRangeError(target, propertyKey, propertyDescriptor) {
         }
     };
 }
-class BinaryReader {
-    constructor(buf) {
-        this.buf = buf;
-        this.offset = 0;
-    }
-    read_u8() {
-        const value = this.buf.readUInt8(this.offset);
-        this.offset += 1;
-        return value;
-    }
-    read_u32() {
-        const value = this.buf.readUInt32LE(this.offset);
-        this.offset += 4;
-        return value;
-    }
-    read_u64() {
-        const buf = this.read_buffer(8);
-        return new bn_js_1.default(buf, 'le');
-    }
-    read_u128() {
-        const buf = this.read_buffer(16);
-        return new bn_js_1.default(buf, 'le');
-    }
-    read_buffer(len) {
-        if ((this.offset + len) > this.buf.length) {
-            throw new BorshError(`Expected buffer length ${len} isn't within bounds`);
+let BinaryReader = /** @class */ (() => {
+    class BinaryReader {
+        constructor(buf) {
+            this.buf = buf;
+            this.offset = 0;
         }
-        const result = this.buf.slice(this.offset, this.offset + len);
-        this.offset += len;
-        return result;
-    }
-    read_string() {
-        const len = this.read_u32();
-        const buf = this.read_buffer(len);
-        try {
-            // NOTE: Using TextDecoder to fail on invalid UTF-8
-            return textDecoder.decode(buf);
+        read_u8() {
+            const value = this.buf.readUInt8(this.offset);
+            this.offset += 1;
+            return value;
         }
-        catch (e) {
-            throw new BorshError(`Error decoding UTF-8 string: ${e}`);
+        read_u32() {
+            const value = this.buf.readUInt32LE(this.offset);
+            this.offset += 4;
+            return value;
+        }
+        read_u64() {
+            const buf = this.read_buffer(8);
+            return new bn_js_1.default(buf, 'le');
+        }
+        read_u128() {
+            const buf = this.read_buffer(16);
+            return new bn_js_1.default(buf, 'le');
+        }
+        read_buffer(len) {
+            if ((this.offset + len) > this.buf.length) {
+                throw new BorshError(`Expected buffer length ${len} isn't within bounds`);
+            }
+            const result = this.buf.slice(this.offset, this.offset + len);
+            this.offset += len;
+            return result;
+        }
+        read_string() {
+            const len = this.read_u32();
+            const buf = this.read_buffer(len);
+            try {
+                // NOTE: Using TextDecoder to fail on invalid UTF-8
+                return textDecoder.decode(buf);
+            }
+            catch (e) {
+                throw new BorshError(`Error decoding UTF-8 string: ${e}`);
+            }
+        }
+        read_fixed_array(len) {
+            return new Uint8Array(this.read_buffer(len));
+        }
+        read_array(fn) {
+            const len = this.read_u32();
+            const result = Array();
+            for (let i = 0; i < len; ++i) {
+                result.push(fn());
+            }
+            return result;
         }
     }
-    read_fixed_array(len) {
-        return new Uint8Array(this.read_buffer(len));
-    }
-    read_array(fn) {
-        const len = this.read_u32();
-        const result = Array();
-        for (let i = 0; i < len; ++i) {
-            result.push(fn());
-        }
-        return result;
-    }
-}
-__decorate([
-    handlingRangeError
-], BinaryReader.prototype, "read_u8", null);
-__decorate([
-    handlingRangeError
-], BinaryReader.prototype, "read_u32", null);
-__decorate([
-    handlingRangeError
-], BinaryReader.prototype, "read_u64", null);
-__decorate([
-    handlingRangeError
-], BinaryReader.prototype, "read_u128", null);
-__decorate([
-    handlingRangeError
-], BinaryReader.prototype, "read_string", null);
-__decorate([
-    handlingRangeError
-], BinaryReader.prototype, "read_fixed_array", null);
-__decorate([
-    handlingRangeError
-], BinaryReader.prototype, "read_array", null);
+    __decorate([
+        handlingRangeError
+    ], BinaryReader.prototype, "read_u8", null);
+    __decorate([
+        handlingRangeError
+    ], BinaryReader.prototype, "read_u32", null);
+    __decorate([
+        handlingRangeError
+    ], BinaryReader.prototype, "read_u64", null);
+    __decorate([
+        handlingRangeError
+    ], BinaryReader.prototype, "read_u128", null);
+    __decorate([
+        handlingRangeError
+    ], BinaryReader.prototype, "read_string", null);
+    __decorate([
+        handlingRangeError
+    ], BinaryReader.prototype, "read_fixed_array", null);
+    __decorate([
+        handlingRangeError
+    ], BinaryReader.prototype, "read_array", null);
+    return BinaryReader;
+})();
 exports.BinaryReader = BinaryReader;
 function serializeField(schema, fieldName, value, fieldType, writer) {
     try {

--- a/src/account.ts
+++ b/src/account.ts
@@ -68,7 +68,7 @@ interface ReceiptLogWithFailure {
 }
 
 function parseJsonFromRawResponse (response: Uint8Array): any {
-    return JSON.parse(response.toString());
+    return JSON.parse(Buffer.from(response).toString());
 }
 
 /**

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -33,11 +33,11 @@ export class Contract {
             Object.defineProperty(this, methodName, {
                 writable: false,
                 enumerable: true,
-                value: nameFunction(methodName, async (args: object = {}, ...ignored) => {
-                    if (ignored.length || !(isObject(args) || isUint8Array(args))) {
+                value: nameFunction(methodName, async (args: object = {}, options = {}, ...ignored) => {
+                    if (ignored.length || !(isObject(args) || isUint8Array(args)) || !isObject(options)) {
                         throw new PositionalArgsError();
                     }
-                    return this.account.viewFunction(this.contractId, methodName, args);
+                    return this.account.viewFunction(this.contractId, methodName, args, options);
                 })
             });
         });

--- a/test/account.test.js
+++ b/test/account.test.js
@@ -142,6 +142,16 @@ describe('with deploy contract', () => {
         expect(await workingAccount.viewFunction(contractId, 'getValue', {})).toEqual(setCallValue);
     });
 
+    test('make function calls via account with custom parser', async() => {
+        const result = await workingAccount.viewFunction(
+            contractId,
+            'hello', // this is the function defined in hello.wasm file that we are calling
+            {name: 'trex'},
+            { parse: x => JSON.parse(x.toString()).replace('trex', 'friend') }
+        );
+        expect(result).toEqual('hello friend');
+    });
+
     test('make function calls via contract', async() => {
         const result = await contract.hello({ name: 'trex' });
         expect(result).toEqual('hello trex');

--- a/test/contract.test.js
+++ b/test/contract.test.js
@@ -63,22 +63,22 @@ describe('viewMethod', () => {
         expect(stubbedReturnValue.options.parse).toBe(customParser);
     });
 
-    test('throws PositionalArgsError if second argument is not an object', () => {
-        return Promise.all([
-            1,
-            'lol',
-            [],
-            new Date(),
-            null,
-            new Set(),
-        ].map(async badArgs => {
+    describe.each([
+        1,
+        'lol',
+        [],
+        new Date(),
+        null,
+        new Set(),
+    ])('throws PositionalArgsError if 2nd arg is not an object', badArg => {
+        test(String(badArg), async () => {
             try {
-                await contract.viewMethod({ a: 1 }, badArgs);
-                throw new Error(`Calling \`contract.viewMethod({ a: 1 }, ${badArgs})\` worked. It shouldn't have worked.`);
+                await contract.viewMethod({ a: 1 }, badArg);
+                throw new Error(`Calling \`contract.viewMethod({ a: 1 }, ${badArg})\` worked. It shouldn't have worked.`);
             } catch (e) {
                 if (!(e instanceof PositionalArgsError)) throw e;
             }
-        }));
+        });
     });
 });
 


### PR DESCRIPTION
Say you have a `contract` object instantiated in your code, and this contract has a `get_age` endpoint which returns a borsh-serialized number. The following code now works:

    import {
      deserialize as deserializeBorsh
    } from 'near-api-js/lib/utils/serialize'

    class BorshPerson {
      constructor (args) {
        Object.assign(this, args)
      }
    }

    const schema = new Map([
      [BorshPerson, {
        kind: 'struct',
        fields: [
          ['get_age', 'u64']
        ]
      }]
    ])

    function deserializePerson (raw) {
      return deserializeBorsh(schema, Person, raw)
    }

    // a small helper class to wrap a near-api-js Contract instance
    export default class Person {
      constructor (contract) {
        this.contract = contract
      }

      async getAge () {
        const deserialized = await this.contract.get_age(
          {},
          { parse: deserializePerson }
        )
        return deserialized.get_age.toNumber()
      }
    }