### PR TITLE
fix: fixed the available balance computation when stake is involved

### DIFF
--- a/src/account.ts
+++ b/src/account.ts
@@ -412,7 +412,7 @@ export class Account {
         const stateStaked = new BN(state.storage_usage).mul(costPerByte);
         const staked = new BN(state.locked);
         const totalBalance = new BN(state.amount).add(staked);
-        const availableBalance = totalBalance.sub(staked).sub(stateStaked);
+        const availableBalance = totalBalance.sub(BN.max(staked, stateStaked));
 
         return {
             total: totalBalance.toString(),


### PR DESCRIPTION
Currently, we did not hit the corner case since there are only a few accounts that do real stake.

See https://nomicon.io/Economics/README.html#state-stake

```python
def check_storage_cost(account):
    # Compute requiredAmount given size of the account.
    requiredAmount = sizeOf(account) * storageAmountPerByte
    return Ok() if account.amount + account.locked >= requiredAmount else Error(requiredAmount)
```

and also the matching implementation in nearcore: https://github.com/near/nearcore/blob/a480d6eb3d9c6542100efdc6364eb89daac69383/core/runtime-configs/src/lib.rs#L75-L95

/cc @icerove 