### PR TITLE
add support for multiple methodNames to Account.addKey

### DIFF
--- a/lib/account.d.ts
+++ b/lib/account.d.ts
@@ -95,7 +95,7 @@ export declare class Account {
      * @returns {Promise<FinalExecutionOutcome>}
      * TODO: expand this API to support more options.
      */
-    addKey(publicKey: string | PublicKey, contractId?: string, methodName?: string, amount?: BN): Promise<FinalExecutionOutcome>;
+    addKey(publicKey: string | PublicKey, contractId?: string, methodNames?: string | string[], amount?: BN): Promise<FinalExecutionOutcome>;
     /**
      * @param publicKey The public key to be deleted
      * @returns {Promise<FinalExecutionOutcome>}

--- a/lib/account.d.ts
+++ b/lib/account.d.ts
@@ -90,7 +90,7 @@ export declare class Account {
     /**
      * @param publicKey A public key to be associated with the contract
      * @param contractId NEAR account where the contract is deployed
-     * @param methodName The method name on the contract as it is written in the contract code
+     * @param methodNames The method names on the contract that should be allowed to be called. Pass null for no method names and '' or [] for any method names.
      * @param amount Payment in yoctoⓃ that is sent to the contract during this function call
      * @returns {Promise<FinalExecutionOutcome>}
      * TODO: expand this API to support more options.

--- a/lib/account.js
+++ b/lib/account.js
@@ -231,14 +231,17 @@ class Account {
     /**
      * @param publicKey A public key to be associated with the contract
      * @param contractId NEAR account where the contract is deployed
-     * @param methodName The method name on the contract as it is written in the contract code
+     * @param methodNames The method names on the contract that should be allowed to be called. Pass null for no method names and '' or [] for any method names.
      * @param amount Payment in yoctoⓃ that is sent to the contract during this function call
      * @returns {Promise<FinalExecutionOutcome>}
      * TODO: expand this API to support more options.
      */
     async addKey(publicKey, contractId, methodNames, amount) {
-        if (!methodNames) {
+        if (methodNames === '') {
             methodNames = [];
+        }
+        if (!methodNames) {
+            methodNames = [''];
         }
         if (!Array.isArray(methodNames)) {
             methodNames = [methodNames];

--- a/lib/account.js
+++ b/lib/account.js
@@ -236,13 +236,19 @@ class Account {
      * @returns {Promise<FinalExecutionOutcome>}
      * TODO: expand this API to support more options.
      */
-    async addKey(publicKey, contractId, methodName, amount) {
+    async addKey(publicKey, contractId, methodNames, amount) {
+        if (!methodNames) {
+            methodNames = [];
+        }
+        if (!Array.isArray(methodNames)) {
+            methodNames = [methodNames];
+        }
         let accessKey;
         if (contractId === null || contractId === undefined || contractId === '') {
             accessKey = transaction_1.fullAccessKey();
         }
         else {
-            accessKey = transaction_1.functionCallAccessKey(contractId, !methodName ? [] : [methodName], amount);
+            accessKey = transaction_1.functionCallAccessKey(contractId, methodNames, amount);
         }
         return this.signAndSendTransaction(this.accountId, [transaction_1.addKey(key_pair_1.PublicKey.from(publicKey), accessKey)]);
     }

--- a/src/account.ts
+++ b/src/account.ts
@@ -305,14 +305,14 @@ export class Account {
     /**
      * @param publicKey A public key to be associated with the contract
      * @param contractId NEAR account where the contract is deployed
-     * @param methodName The method name on the contract as it is written in the contract code
+     * @param methodNames The method names on the contract that should be allowed to be called. Pass null or '' for no method names and [] for any method names.
      * @param amount Payment in yoctoⓃ that is sent to the contract during this function call
      * @returns {Promise<FinalExecutionOutcome>}
      * TODO: expand this API to support more options.
      */
     async addKey(publicKey: string | PublicKey, contractId?: string, methodNames?: string|string[], amount?: BN): Promise<FinalExecutionOutcome> {
         if (!methodNames) {
-            methodNames = []
+            methodNames = ['']
         }
         if (!Array.isArray(methodNames)) {
             methodNames = [methodNames]

--- a/src/account.ts
+++ b/src/account.ts
@@ -312,13 +312,13 @@ export class Account {
      */
     async addKey(publicKey: string | PublicKey, contractId?: string, methodNames?: string|string[], amount?: BN): Promise<FinalExecutionOutcome> {
         if (methodNames === '') {
-            methodNames = []
+            methodNames = [];
         }
         if (!methodNames) {
-            methodNames = ['']
+            methodNames = [''];
         }
         if (!Array.isArray(methodNames)) {
-            methodNames = [methodNames]
+            methodNames = [methodNames];
         }
         let accessKey;
         if (contractId === null || contractId === undefined || contractId === '') {

--- a/src/account.ts
+++ b/src/account.ts
@@ -310,12 +310,18 @@ export class Account {
      * @returns {Promise<FinalExecutionOutcome>}
      * TODO: expand this API to support more options.
      */
-    async addKey(publicKey: string | PublicKey, contractId?: string, methodName?: string, amount?: BN): Promise<FinalExecutionOutcome> {
+    async addKey(publicKey: string | PublicKey, contractId?: string, methodNames?: string|string[], amount?: BN): Promise<FinalExecutionOutcome> {
+        if (!methodNames) {
+            methodNames = []
+        }
+        if (!Array.isArray(methodNames)) {
+            methodNames = [methodNames]
+        }
         let accessKey;
         if (contractId === null || contractId === undefined || contractId === '') {
             accessKey = fullAccessKey();
         } else {
-            accessKey = functionCallAccessKey(contractId, !methodName ? [] : [methodName], amount);
+            accessKey = functionCallAccessKey(contractId, methodNames, amount);
         }
         return this.signAndSendTransaction(this.accountId, [addKey(PublicKey.from(publicKey), accessKey)]);
     }

--- a/src/account.ts
+++ b/src/account.ts
@@ -305,12 +305,15 @@ export class Account {
     /**
      * @param publicKey A public key to be associated with the contract
      * @param contractId NEAR account where the contract is deployed
-     * @param methodNames The method names on the contract that should be allowed to be called. Pass null or '' for no method names and [] for any method names.
+     * @param methodNames The method names on the contract that should be allowed to be called. Pass null for no method names and '' or [] for any method names.
      * @param amount Payment in yoctoⓃ that is sent to the contract during this function call
      * @returns {Promise<FinalExecutionOutcome>}
      * TODO: expand this API to support more options.
      */
     async addKey(publicKey: string | PublicKey, contractId?: string, methodNames?: string|string[], amount?: BN): Promise<FinalExecutionOutcome> {
+        if (methodNames === '') {
+            methodNames = []
+        }
         if (!methodNames) {
             methodNames = ['']
         }


### PR DESCRIPTION
This PR adds support for `Account.addKey` that _also_ accepts an array of methodNames vs. just a string of 1 methodName. Matches more closely to how `functionCallAccessKey` works.