### PR TITLE
hotfix: missing await in getRequestNonce and getRequestIds

### DIFF
--- a/lib/account_multisig.js
+++ b/lib/account_multisig.js
@@ -44,6 +44,7 @@ class AccountMultisig extends account_1.Account {
         }
         await this.deleteUnconfirmedRequests();
         const requestId = await this.getRequestNonce();
+        console.log('getRequestNonce', requestId);
         this.setRequest({ accountId, requestId, actions });
         const args = new Uint8Array(new TextEncoder().encode(JSON.stringify({
             request: {
@@ -94,10 +95,10 @@ class AccountMultisig extends account_1.Account {
     }
     // helpers
     async getRequestNonce() {
-        return this.contract.get_request_nonce();
+        return await this.contract.get_request_nonce();
     }
     async getRequestIds() {
-        return this.contract.list_request_ids();
+        return await this.contract.list_request_ids();
     }
     isDeleteAction(actions) {
         return actions && actions[0] && actions[0].functionCall && actions[0].functionCall.methodName === 'delete_request';

--- a/src/account_multisig.ts
+++ b/src/account_multisig.ts
@@ -21,7 +21,6 @@ export const MULTISIG_CHANGE_METHODS = ['add_request', 'add_request_and_confirm'
 export const MULTISIG_VIEW_METHODS = ['get_request_nonce', 'list_request_ids'];
 export const MULTISIG_CONFIRM_METHODS = ['confirm'];
 
-
 interface MultisigContract {
     get_request_nonce(): any,
     list_request_ids(): any,
@@ -59,6 +58,9 @@ export class AccountMultisig extends Account {
         await this.deleteUnconfirmedRequests()
 
         const requestId = await this.getRequestNonce()
+
+        console.log('getRequestNonce', requestId)
+
         this.setRequest({ accountId, requestId, actions });
 
         const args = new Uint8Array(new TextEncoder().encode(JSON.stringify({
@@ -115,11 +117,11 @@ export class AccountMultisig extends Account {
     // helpers
 
     async getRequestNonce(): Promise<Number> {
-        return this.contract.get_request_nonce();
+        return await this.contract.get_request_nonce();
     }
 
     async getRequestIds(): Promise<string> {
-        return this.contract.list_request_ids();
+        return await this.contract.list_request_ids();
     }
 
     isDeleteAction(actions): Boolean {

--- a/src/account_multisig.ts
+++ b/src/account_multisig.ts
@@ -59,8 +59,6 @@ export class AccountMultisig extends Account {
 
         const requestId = await this.getRequestNonce()
 
-        console.log('getRequestNonce', requestId)
-
         this.setRequest({ accountId, requestId, actions });
 
         const args = new Uint8Array(new TextEncoder().encode(JSON.stringify({

--- a/src/account_multisig.ts
+++ b/src/account_multisig.ts
@@ -114,12 +114,12 @@ export class AccountMultisig extends Account {
 
     // helpers
 
-    async getRequestNonce(): Promise<Number> {
-        return await this.contract.get_request_nonce();
+    getRequestNonce(): Promise<Number> {
+        return this.contract.get_request_nonce();
     }
 
-    async getRequestIds(): Promise<string> {
-        return await this.contract.list_request_ids();
+    getRequestIds(): Promise<string> {
+        return this.contract.list_request_ids();
     }
 
     isDeleteAction(actions): Boolean {


### PR DESCRIPTION
missing await so not often requestId is not set properly because it's still receiving promise from contract call vs. value

Fixes so requestId will always be value:

https://github.com/near/near-api-js/blob/93e8a6025cb278cbdfaf97983aea514ccfa1a016/src/account_multisig.ts#L61-L62

