### PR TITLE
hotfix: 2FA key rotations, Account.addKey, InMemorySigner.fromKeyPair

### DIFF
--- a/lib/account.js
+++ b/lib/account.js
@@ -240,17 +240,14 @@ class Account {
      * TODO: expand this API to support more options.
      */
     async addKey(publicKey, contractId, methodNames, amount) {
-        if (methodNames === '') {
-            methodNames = [];
-        }
         if (!methodNames) {
-            methodNames = [''];
+            methodNames = [];
         }
         if (!Array.isArray(methodNames)) {
             methodNames = [methodNames];
         }
         let accessKey;
-        if (contractId === null || contractId === undefined || contractId === '') {
+        if (!contractId) {
             accessKey = transaction_1.fullAccessKey();
         }
         else {

--- a/lib/account_multisig.d.ts
+++ b/lib/account_multisig.d.ts
@@ -49,7 +49,7 @@ export declare class Account2FA extends AccountMultisig {
     helperUrl: string;
     constructor(connection: Connection, accountId: string, options: any);
     signAndSendTransaction(receiverId: string, actions: Action[]): Promise<FinalExecutionOutcome>;
-    deployMultisig(contractBytes: Uint8Array): Promise<FinalExecutionOutcome>;
+    deployMultisig(contractBytes: Uint8Array): Promise<void>;
     disable(contractBytes: Uint8Array): Promise<FinalExecutionOutcome>;
     sendCodeDefault(): Promise<any>;
     getCodeDefault(method: any): Promise<string>;

--- a/lib/account_multisig.d.ts
+++ b/lib/account_multisig.d.ts
@@ -49,7 +49,7 @@ export declare class Account2FA extends AccountMultisig {
     helperUrl: string;
     constructor(connection: Connection, accountId: string, options: any);
     signAndSendTransaction(receiverId: string, actions: Action[]): Promise<FinalExecutionOutcome>;
-    deployMultisig(contractBytes: Uint8Array): Promise<void>;
+    deployMultisig(contractBytes: Uint8Array): Promise<FinalExecutionOutcome>;
     disable(contractBytes: Uint8Array): Promise<FinalExecutionOutcome>;
     sendCodeDefault(): Promise<any>;
     getCodeDefault(method: any): Promise<string>;

--- a/lib/account_multisig.js
+++ b/lib/account_multisig.js
@@ -123,12 +123,10 @@ class Account2FA extends AccountMultisig {
         const seedOrLedgerKey = (await this.getRecoveryMethods()).data
             .filter(({ kind, publicKey }) => (kind === 'phrase' || kind === 'ledger') && publicKey !== null)
             .map((rm) => rm.publicKey);
-        console.log('seedOrLedgerKey', seedOrLedgerKey);
         const fak2lak = (await this.getAccessKeys())
             .filter(({ public_key, access_key: { permission } }) => permission === 'FullAccess' && !seedOrLedgerKey.includes(public_key))
-            .map((ak) => ak.public_key);
-        // .map(toPK)
-        console.log('fak2lak', fak2lak);
+            .map((ak) => ak.public_key)
+            .map(toPK);
         const confirmOnlyKey = toPK((await this.postSignedJson('/2fa/getAccessKey', { accountId })).publicKey);
         const newArgs = Buffer.from(JSON.stringify({ 'num_confirmations': 2 }));
         const actions = [

--- a/lib/account_multisig.js
+++ b/lib/account_multisig.js
@@ -139,7 +139,7 @@ class Account2FA extends AccountMultisig {
             actions.push(transaction_1.functionCall('new', newArgs, exports.MULTISIG_GAS, exports.MULTISIG_DEPOSIT));
         }
         console.log('deploying multisig contract for', accountId);
-        // return await super.signAndSendTransactionWithAccount(accountId, actions);
+        return await super.signAndSendTransactionWithAccount(accountId, actions);
     }
     async disable(contractBytes) {
         const { accountId } = this;

--- a/lib/account_multisig.js
+++ b/lib/account_multisig.js
@@ -120,12 +120,15 @@ class Account2FA extends AccountMultisig {
     // default helpers for CH deployments of multisig
     async deployMultisig(contractBytes) {
         const { accountId } = this;
-        // replace account keys & recovery keys with limited access keys; DO NOT replace seed phrase keys
-        const accountKeys = (await this.getAccessKeys()).map((ak) => ak.public_key);
-        const seedOrLedgerKeys = (await this.getRecoveryMethods()).data
-            .filter(({ kind, publicKey }) => (kind === 'phrase' || kind === 'ledger') && publicKey !== null && accountKeys.includes(publicKey))
+        const seedOrLedgerKey = (await this.getRecoveryMethods()).data
+            .filter(({ kind, publicKey }) => (kind === 'phrase' || kind === 'ledger') && publicKey !== null)
             .map((rm) => rm.publicKey);
-        const fak2lak = accountKeys.filter((k) => !seedOrLedgerKeys.includes(k)).map(toPK);
+        console.log('seedOrLedgerKey', seedOrLedgerKey);
+        const fak2lak = (await this.getAccessKeys())
+            .filter(({ public_key, access_key: { permission } }) => permission === 'FullAccess' && !seedOrLedgerKey.includes(public_key))
+            .map((ak) => ak.public_key);
+        // .map(toPK)
+        console.log('fak2lak', fak2lak);
         const confirmOnlyKey = toPK((await this.postSignedJson('/2fa/getAccessKey', { accountId })).publicKey);
         const newArgs = Buffer.from(JSON.stringify({ 'num_confirmations': 2 }));
         const actions = [
@@ -138,7 +141,7 @@ class Account2FA extends AccountMultisig {
             actions.push(transaction_1.functionCall('new', newArgs, exports.MULTISIG_GAS, exports.MULTISIG_DEPOSIT));
         }
         console.log('deploying multisig contract for', accountId);
-        return await super.signAndSendTransactionWithAccount(accountId, actions);
+        // return await super.signAndSendTransactionWithAccount(accountId, actions);
     }
     async disable(contractBytes) {
         const { accountId } = this;

--- a/lib/signer.d.ts
+++ b/lib/signer.d.ts
@@ -29,11 +29,13 @@ export declare class InMemorySigner extends Signer {
     readonly keyStore: KeyStore;
     constructor(keyStore: KeyStore);
     /**
-     * Creates a tempSigner (intended to be one time use) with account, network and keyPair provided
+     * Creates a single account Signer instance with account, network and keyPair provided.
+     *
+     * Intended to be useful for temporary keys (e.g. claiming a Linkdrop).
+     *
      * @param networkId The targeted network. (ex. default, betanet, etc…)
-     * @param accountId The NEAR account to assign a public key to
+     * @param accountId The NEAR account to assign the key pair to
      * @param keyPair The keyPair to use for signing
-     * @returns {Promise<PublicKey>}
      */
     static fromKeyPair(networkId: string, accountId: string, keyPair: KeyPair): Promise<Signer>;
     /**

--- a/lib/signer.js
+++ b/lib/signer.js
@@ -22,11 +22,13 @@ class InMemorySigner extends Signer {
         this.keyStore = keyStore;
     }
     /**
-     * Creates a tempSigner (intended to be one time use) with account, network and keyPair provided
+     * Creates a single account Signer instance with account, network and keyPair provided.
+     *
+     * Intended to be useful for temporary keys (e.g. claiming a Linkdrop).
+     *
      * @param networkId The targeted network. (ex. default, betanet, etc…)
-     * @param accountId The NEAR account to assign a public key to
+     * @param accountId The NEAR account to assign the key pair to
      * @param keyPair The keyPair to use for signing
-     * @returns {Promise<PublicKey>}
      */
     static async fromKeyPair(networkId, accountId, keyPair) {
         const keyStore = new key_stores_1.InMemoryKeyStore();

--- a/src/account.ts
+++ b/src/account.ts
@@ -315,17 +315,14 @@ export class Account {
      * TODO: expand this API to support more options.
      */
     async addKey(publicKey: string | PublicKey, contractId?: string, methodNames?: string|string[], amount?: BN): Promise<FinalExecutionOutcome> {
-        if (methodNames === '') {
-            methodNames = [];
-        }
         if (!methodNames) {
-            methodNames = [''];
+            methodNames = [];
         }
         if (!Array.isArray(methodNames)) {
             methodNames = [methodNames];
         }
         let accessKey;
-        if (contractId === null || contractId === undefined || contractId === '') {
+        if (!contractId) {
             accessKey = fullAccessKey();
         } else {
             accessKey = functionCallAccessKey(contractId, methodNames, amount);

--- a/src/account_multisig.ts
+++ b/src/account_multisig.ts
@@ -161,12 +161,19 @@ export class Account2FA extends AccountMultisig {
 
     async deployMultisig(contractBytes: Uint8Array) {
         const { accountId } = this
-        // replace account keys & recovery keys with limited access keys; DO NOT replace seed phrase keys
-        const accountKeys = (await this.getAccessKeys()).map((ak) => ak.public_key)
-        const seedOrLedgerKeys = (await this.getRecoveryMethods()).data
-            .filter(({ kind, publicKey }) => (kind === 'phrase' || kind === 'ledger') && publicKey !== null && accountKeys.includes(publicKey))
+
+        const seedOrLedgerKey = (await this.getRecoveryMethods()).data
+            .filter(({ kind, publicKey }) => (kind === 'phrase' || kind === 'ledger') && publicKey !== null)
             .map((rm) => rm.publicKey)
-        const fak2lak = accountKeys.filter((k) => !seedOrLedgerKeys.includes(k)).map(toPK)
+        console.log('seedOrLedgerKey', seedOrLedgerKey)
+
+        const fak2lak = (await this.getAccessKeys())
+            .filter(({ public_key, access_key: { permission } }) => permission === 'FullAccess' && !seedOrLedgerKey.includes(public_key))
+            .map((ak) => ak.public_key)
+            // .map(toPK)
+        console.log('fak2lak', fak2lak)
+
+        
         const confirmOnlyKey = toPK((await this.postSignedJson('/2fa/getAccessKey', { accountId })).publicKey)
         const newArgs = Buffer.from(JSON.stringify({ 'num_confirmations': 2 }));
         const actions = [
@@ -179,7 +186,7 @@ export class Account2FA extends AccountMultisig {
             actions.push(functionCall('new', newArgs, MULTISIG_GAS, MULTISIG_DEPOSIT),)
         }
         console.log('deploying multisig contract for', accountId)
-        return await super.signAndSendTransactionWithAccount(accountId, actions);
+        // return await super.signAndSendTransactionWithAccount(accountId, actions);
     }
 
     async disable(contractBytes: Uint8Array) {

--- a/src/account_multisig.ts
+++ b/src/account_multisig.ts
@@ -174,7 +174,7 @@ export class Account2FA extends AccountMultisig {
         const confirmOnlyKey = toPK((await this.postSignedJson('/2fa/getAccessKey', { accountId })).publicKey)
 
         const newArgs = Buffer.from(JSON.stringify({ 'num_confirmations': 2 }));
-        
+
         const actions = [
             ...fak2lak.map((pk) => deleteKey(pk)),
             ...fak2lak.map((pk) => addKey(pk, functionCallAccessKey(accountId, MULTISIG_CHANGE_METHODS, null))),
@@ -185,7 +185,7 @@ export class Account2FA extends AccountMultisig {
             actions.push(functionCall('new', newArgs, MULTISIG_GAS, MULTISIG_DEPOSIT),)
         }
         console.log('deploying multisig contract for', accountId)
-        // return await super.signAndSendTransactionWithAccount(accountId, actions);
+        return await super.signAndSendTransactionWithAccount(accountId, actions);
     }
 
     async disable(contractBytes: Uint8Array) {

--- a/src/account_multisig.ts
+++ b/src/account_multisig.ts
@@ -165,17 +165,16 @@ export class Account2FA extends AccountMultisig {
         const seedOrLedgerKey = (await this.getRecoveryMethods()).data
             .filter(({ kind, publicKey }) => (kind === 'phrase' || kind === 'ledger') && publicKey !== null)
             .map((rm) => rm.publicKey)
-        console.log('seedOrLedgerKey', seedOrLedgerKey)
 
         const fak2lak = (await this.getAccessKeys())
             .filter(({ public_key, access_key: { permission } }) => permission === 'FullAccess' && !seedOrLedgerKey.includes(public_key))
             .map((ak) => ak.public_key)
-            // .map(toPK)
-        console.log('fak2lak', fak2lak)
+            .map(toPK)
 
-        
         const confirmOnlyKey = toPK((await this.postSignedJson('/2fa/getAccessKey', { accountId })).publicKey)
+
         const newArgs = Buffer.from(JSON.stringify({ 'num_confirmations': 2 }));
+        
         const actions = [
             ...fak2lak.map((pk) => deleteKey(pk)),
             ...fak2lak.map((pk) => addKey(pk, functionCallAccessKey(accountId, MULTISIG_CHANGE_METHODS, null))),

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -38,13 +38,15 @@ export class InMemorySigner extends Signer {
         super();
         this.keyStore = keyStore;
     }
-    
+
     /**
-     * Creates a tempSigner (intended to be one time use) with account, network and keyPair provided
+     * Creates a single account Signer instance with account, network and keyPair provided.
+     *
+     * Intended to be useful for temporary keys (e.g. claiming a Linkdrop).
+     *
      * @param networkId The targeted network. (ex. default, betanet, etc…)
-     * @param accountId The NEAR account to assign a public key to
+     * @param accountId The NEAR account to assign the key pair to
      * @param keyPair The keyPair to use for signing
-     * @returns {Promise<PublicKey>}
      */
     static async fromKeyPair(networkId: string, accountId: string, keyPair: KeyPair): Promise<Signer> {
         const keyStore = new InMemoryKeyStore()

--- a/test/account_multisig.test.js
+++ b/test/account_multisig.test.js
@@ -82,6 +82,17 @@ describe('deployMultisig key rotations', () => {
 
 describe('account2fa transactions', () => {
 
+    test('add app key before deployMultisig', async() => {
+        let account = await testUtils.createAccount(nearjs);
+        const appPublicKey = KeyPair.fromRandom('ed25519').getPublicKey();
+        const appMethodNames = ['some_app_stuff','some_more_app_stuff'];
+        await account.addKey(appPublicKey.toString(), 'foobar', appMethodNames.join(), new BN(parseNearAmount('0.25')));
+        account = await getAccount2FA(account);
+        const keys = await account.getAccessKeys();
+        expect(keys.find(({ public_key }) => appPublicKey.toString() === public_key)
+            .access_key.permission.FunctionCall.method_names.toString()).toEqual(appMethodNames.toString());
+    });
+
     test('add app key', async() => {
         let account = await testUtils.createAccount(nearjs);
         account = await getAccount2FA(account);

--- a/test/account_multisig.test.js
+++ b/test/account_multisig.test.js
@@ -81,7 +81,7 @@ describe('account2fa transactions', () => {
     test('add app key before deployMultisig', async() => {
         let account = await testUtils.createAccount(nearjs);
         const appPublicKey = KeyPair.fromRandom('ed25519').getPublicKey();
-        const appAccountId = 'foobar'
+        const appAccountId = 'foobar';
         const appMethodNames = ['some_app_stuff','some_more_app_stuff'];
         await account.addKey(appPublicKey.toString(), appAccountId, appMethodNames, new BN(parseNearAmount('0.25')));
         account = await getAccount2FA(account);
@@ -96,7 +96,7 @@ describe('account2fa transactions', () => {
         let account = await testUtils.createAccount(nearjs);
         account = await getAccount2FA(account);
         const appPublicKey = KeyPair.fromRandom('ed25519').getPublicKey();
-        const appAccountId = 'foobar'
+        const appAccountId = 'foobar';
         const appMethodNames = ['some_app_stuff', 'some_more_app_stuff'];
         await account.addKey(appPublicKey.toString(), appAccountId, appMethodNames, new BN(parseNearAmount('0.25')));
         const keys = await account.getAccessKeys();

--- a/test/account_multisig.test.js
+++ b/test/account_multisig.test.js
@@ -25,7 +25,6 @@ const getAccount2FA = async (account, keyMapping = ({ public_key: publicKey }) =
     const keys = await account.getAccessKeys();
     const account2fa = new Account2FA(nearjs.connection, accountId, {
         // skip this (not using CH)
-        // skip this (not using CH)
         getCode: () => {},
         sendCode: () => {},
         // auto accept "code"
@@ -85,13 +84,13 @@ describe('account2fa transactions', () => {
     test('add app key before deployMultisig', async() => {
         let account = await testUtils.createAccount(nearjs);
         const appPublicKey = KeyPair.fromRandom('ed25519').getPublicKey();
-        const appAccountId = 'foobar';
+        const appAccountId = 'foobar'
         const appMethodNames = ['some_app_stuff','some_more_app_stuff'];
-        await account.addKey(appPublicKey.toString(), appAccountId, appMethodNames.join(), new BN(parseNearAmount('0.25')));
+        await account.addKey(appPublicKey.toString(), appAccountId, appMethodNames, new BN(parseNearAmount('0.25')));
         account = await getAccount2FA(account);
         const keys = await account.getAccessKeys();
         expect(keys.find(({ public_key }) => appPublicKey.toString() === public_key)
-            .access_key.permission.FunctionCall.method_names.join()).toEqual(appMethodNames.join());
+            .access_key.permission.FunctionCall.method_names).toEqual(appMethodNames);
         expect(keys.find(({ public_key }) => appPublicKey.toString() === public_key)
             .access_key.permission.FunctionCall.receiver_id).toEqual(appAccountId);
     });
@@ -100,12 +99,12 @@ describe('account2fa transactions', () => {
         let account = await testUtils.createAccount(nearjs);
         account = await getAccount2FA(account);
         const appPublicKey = KeyPair.fromRandom('ed25519').getPublicKey();
-        const appAccountId = 'foobar';
+        const appAccountId = 'foobar'
         const appMethodNames = ['some_app_stuff', 'some_more_app_stuff'];
-        await account.addKey(appPublicKey.toString(), appAccountId, appMethodNames.join(), new BN(parseNearAmount('0.25')));
+        await account.addKey(appPublicKey.toString(), appAccountId, appMethodNames, new BN(parseNearAmount('0.25')));
         const keys = await account.getAccessKeys();
         expect(keys.find(({ public_key }) => appPublicKey.toString() === public_key)
-            .access_key.permission.FunctionCall.method_names.join()).toEqual(appMethodNames.join());
+            .access_key.permission.FunctionCall.method_names).toEqual(appMethodNames);
         expect(keys.find(({ public_key }) => appPublicKey.toString() === public_key)
             .access_key.permission.FunctionCall.receiver_id).toEqual(appAccountId);
     });

--- a/test/account_multisig.test.js
+++ b/test/account_multisig.test.js
@@ -85,23 +85,29 @@ describe('account2fa transactions', () => {
     test('add app key before deployMultisig', async() => {
         let account = await testUtils.createAccount(nearjs);
         const appPublicKey = KeyPair.fromRandom('ed25519').getPublicKey();
+        const appAccountId = 'foobar';
         const appMethodNames = ['some_app_stuff','some_more_app_stuff'];
-        await account.addKey(appPublicKey.toString(), 'foobar', appMethodNames.join(), new BN(parseNearAmount('0.25')));
+        await account.addKey(appPublicKey.toString(), appAccountId, appMethodNames.join(), new BN(parseNearAmount('0.25')));
         account = await getAccount2FA(account);
         const keys = await account.getAccessKeys();
         expect(keys.find(({ public_key }) => appPublicKey.toString() === public_key)
-            .access_key.permission.FunctionCall.method_names.toString()).toEqual(appMethodNames.toString());
+            .access_key.permission.FunctionCall.method_names.join()).toEqual(appMethodNames.join());
+        expect(keys.find(({ public_key }) => appPublicKey.toString() === public_key)
+            .access_key.permission.FunctionCall.receiver_id).toEqual(appAccountId);
     });
 
     test('add app key', async() => {
         let account = await testUtils.createAccount(nearjs);
         account = await getAccount2FA(account);
         const appPublicKey = KeyPair.fromRandom('ed25519').getPublicKey();
+        const appAccountId = 'foobar';
         const appMethodNames = ['some_app_stuff', 'some_more_app_stuff'];
-        await account.addKey(appPublicKey.toString(), 'foobar', appMethodNames.join(), new BN(parseNearAmount('0.25')));
+        await account.addKey(appPublicKey.toString(), appAccountId, appMethodNames.join(), new BN(parseNearAmount('0.25')));
         const keys = await account.getAccessKeys();
         expect(keys.find(({ public_key }) => appPublicKey.toString() === public_key)
-            .access_key.permission.FunctionCall.method_names).toEqual(appMethodNames);
+            .access_key.permission.FunctionCall.method_names.join()).toEqual(appMethodNames.join());
+        expect(keys.find(({ public_key }) => appPublicKey.toString() === public_key)
+            .access_key.permission.FunctionCall.receiver_id).toEqual(appAccountId);
     });
 
     test('send money', async() => {


### PR DESCRIPTION
- fix deployMultisig to only convert full access keys to multisig limited access keys
- fix to Account.addKey where you can add multiple methodNames
- fix to add one off signer from keyPair