### PR TITLE
fix(utils/web): Fix typo in Content-Type header

### DIFF
--- a/src/utils/web.ts
+++ b/src/utils/web.ts
@@ -56,7 +56,7 @@ export async function fetchJson(connection: string | ConnectionInfo, json?: stri
             const response = await fetch(url, {
                 method: json ? 'POST' : 'GET',
                 body: json ? json : undefined,
-                headers: { 'Content-type': 'application/json; charset=utf-8' }
+                headers: { 'Content-Type': 'application/json; charset=utf-8' }
             });
             if (!response.ok) {
                 if (response.status === 503) {


### PR DESCRIPTION
Reasons:
- RFC says it's Content-Type, not Content-type
- node-fetch package is checking for the `Content-Type` header in a case sensitive manner and overwrites it when cannot find it https://github.com/node-fetch/node-fetch/blob/master/src/request.js#L71
- because of the node-fetch Content-Type check, the header is sometimes overwritten and near-api-js call is not always recognized as application/json request