### PR TITLE
feat: add `completedTransactions` cache

### DIFF
--- a/lib/account.d.ts
+++ b/lib/account.d.ts
@@ -5,14 +5,8 @@ import { FinalExecutionOutcome } from './providers';
 import { Finality, BlockId } from './providers/provider';
 import { Connection } from './connection';
 import { PublicKey } from './utils/key_pair';
-declare type TxMetadata = {
-    [key: string]: string | number;
-};
-export declare type ChangeMethodOptions = {
-    gas?: BN;
-    deposit?: BN;
-    meta?: TxMetadata;
-};
+import { ChangeMethodOptions } from './wallet-account';
+import { BasicCachedTransaction, TxMetadata } from './cached-transactions';
 export interface AccountState {
     amount: string;
     code_hash: string;
@@ -52,12 +46,15 @@ export declare class Account {
     /**
      * @param receiverId NEAR account receiving the transaction
      * @param actions The transaction [Action as described in the spec](https://nomicon.io/RuntimeSpec/Actions.html).
-     * @param meta Free-form {@link TxMetadata}. If provided, whether it
-     *   requires a redirect through NEAR Wallet or not, the transaction's
-     *   outcome will be available in the {@link WalletAccount.completedTransactions} collection.
+     * @param meta do not provide; interface only available for ConnectedWalletAccount subclass
+     * @param onInit for internal library use from ConnectedWalletAccount
+     * @param onSuccess for internal library use from ConnectedWalletAccount
      * @returns {Promise<FinalExecutionOutcome>}
      */
-    protected signAndSendTransaction(receiverId: string, actions: Action[], meta?: TxMetadata): Promise<FinalExecutionOutcome>;
+    protected signAndSendTransaction(receiverId: string, actions: Action[], meta?: TxMetadata, { onInit, onSuccess }?: {
+        onInit?: (tx: BasicCachedTransaction) => void;
+        onSuccess?: (txHash: string, result: FinalExecutionOutcome) => void;
+    }): Promise<FinalExecutionOutcome>;
     accessKeyByPublicKeyCache: {
         [key: string]: AccessKey;
     };

--- a/lib/account.d.ts
+++ b/lib/account.d.ts
@@ -5,6 +5,14 @@ import { FinalExecutionOutcome } from './providers';
 import { Finality, BlockId } from './providers/provider';
 import { Connection } from './connection';
 import { PublicKey } from './utils/key_pair';
+declare type TxMetadata = {
+    [key: string]: string | number;
+};
+export declare type ChangeMethodOptions = {
+    gas?: BN;
+    deposit?: BN;
+    meta?: TxMetadata;
+};
 export interface AccountState {
     amount: string;
     code_hash: string;
@@ -44,9 +52,12 @@ export declare class Account {
     /**
      * @param receiverId NEAR account receiving the transaction
      * @param actions The transaction [Action as described in the spec](https://nomicon.io/RuntimeSpec/Actions.html).
+     * @param meta Free-form {@link TxMetadata}. If provided, whether it
+     *   requires a redirect through NEAR Wallet or not, the transaction's
+     *   outcome will be available in the {@link WalletAccount.completedTransactions} collection.
      * @returns {Promise<FinalExecutionOutcome>}
      */
-    protected signAndSendTransaction(receiverId: string, actions: Action[]): Promise<FinalExecutionOutcome>;
+    protected signAndSendTransaction(receiverId: string, actions: Action[], meta?: TxMetadata): Promise<FinalExecutionOutcome>;
     accessKeyByPublicKeyCache: {
         [key: string]: AccessKey;
     };
@@ -84,12 +95,16 @@ export declare class Account {
      * @param contractId NEAR account where the contract is deployed
      * @param methodName The method name on the contract as it is written in the contract code
      * @param args arguments to pass to method. Can be either plain JS object which gets serialized as JSON automatically
-     *  or `Uint8Array` instance which represents bytes passed as is.
-     * @param gas max amount of gas that method call can use
-      * @param deposit amount of NEAR (in yoctoNEAR) to send together with the call
+     *   or `Uint8Array` instance which represents bytes passed as is.
+     * @param options object containing options for this function call. Available options:
+     *   gas: max amount of gas (in gas units) that method call can use
+     *   deposit: amount of NEAR (in yoctoNEAR) to attach to the call
+     *   meta: a user-specified shallow object (string keys with string or number values). If provided,
+     *         the outcome of this transaction, along with provided `meta` data, will be available in
+     *         {@link WalletAccount.completedTransactions}
      * @returns {Promise<FinalExecutionOutcome>}
      */
-    functionCall(contractId: string, methodName: string, args: any, gas?: BN, amount?: BN): Promise<FinalExecutionOutcome>;
+    functionCall(contractId: string, methodName: string, args: any, optionsOrGas?: ChangeMethodOptions | BN, deposit?: BN): Promise<FinalExecutionOutcome>;
     /**
      * @param publicKey A public key to be associated with the contract
      * @param contractId NEAR account where the contract is deployed

--- a/lib/account.js
+++ b/lib/account.js
@@ -1,16 +1,18 @@
-'use strict';
+"use strict";
 var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.Account = void 0;
 const bn_js_1 = __importDefault(require("bn.js"));
+const depd_1 = __importDefault(require("depd"));
 const transaction_1 = require("./transaction");
 const providers_1 = require("./providers");
 const borsh_1 = require("borsh");
 const key_pair_1 = require("./utils/key_pair");
 const errors_1 = require("./utils/errors");
 const rpc_errors_1 = require("./utils/rpc_errors");
+const cached_transactions_1 = require("./cached-transactions");
 const exponential_backoff_1 = __importDefault(require("./utils/exponential-backoff"));
 // Default amount of gas to be sent with the function calls. Used to pay for the fees
 // incurred while running the contract execution. The unused amount will be refunded back to
@@ -86,18 +88,31 @@ class Account {
     /**
      * @param receiverId NEAR account receiving the transaction
      * @param actions The transaction [Action as described in the spec](https://nomicon.io/RuntimeSpec/Actions.html).
+     * @param meta Free-form {@link TxMetadata}. If provided, whether it
+     *   requires a redirect through NEAR Wallet or not, the transaction's
+     *   outcome will be available in the {@link WalletAccount.completedTransactions} collection.
      * @returns {Promise<FinalExecutionOutcome>}
      */
-    async signAndSendTransaction(receiverId, actions) {
+    async signAndSendTransaction(receiverId, actions, meta = null) {
         await this.ready;
         let txHash, signedTx;
         // TODO: TX_NONCE (different constants for different uses of exponentialBackoff?)
         const result = await exponential_backoff_1.default(TX_STATUS_RETRY_WAIT, TX_NONCE_RETRY_NUMBER, TX_STATUS_RETRY_WAIT_BACKOFF, async () => {
             [txHash, signedTx] = await this.signTransaction(receiverId, actions);
             const publicKey = signedTx.transaction.publicKey;
+            if (meta) {
+                cached_transactions_1.cacheTransaction({
+                    hash: Buffer.from(txHash).toString('hex'),
+                    meta,
+                    publicKey: publicKey.toString(),
+                    receiverId,
+                    signedTx: Buffer.from(signedTx.encode()).toString('hex'),
+                });
+            }
             try {
                 const result = await exponential_backoff_1.default(TX_STATUS_RETRY_WAIT, TX_STATUS_RETRY_NUMBER, TX_STATUS_RETRY_WAIT_BACKOFF, async () => {
                     try {
+                        // TODO: Where does redirect to NEAR Wallet happen?
                         return await this.connection.provider.sendTransaction(signedTx);
                     }
                     catch (error) {
@@ -143,14 +158,20 @@ class Account {
         }, []);
         this.printLogsAndFailures(signedTx.transaction.receiverId, flatLogs);
         if (typeof result.status === 'object' && typeof result.status.Failure === 'object') {
+            let error;
             // if error data has error_message and error_type properties, we consider that node returned an error in the old format
             if (result.status.Failure.error_message && result.status.Failure.error_type) {
-                throw new providers_1.TypedError(`Transaction ${result.transaction_outcome.id} failed. ${result.status.Failure.error_message}`, result.status.Failure.error_type);
+                error = new providers_1.TypedError(`Transaction ${result.transaction_outcome.id} failed. ${result.status.Failure.error_message}`, result.status.Failure.error_type);
             }
             else {
-                throw rpc_errors_1.parseResultError(result);
+                error = rpc_errors_1.parseResultError(result);
             }
+            if (meta)
+                cached_transactions_1.markTransactionFailed(txHash.toString(), result, error.message);
+            throw error;
         }
+        if (meta)
+            cached_transactions_1.markTransactionSucceeded(txHash.toString(), result);
         // TODO: if Tx is Unknown or Started.
         return result;
     }
@@ -224,15 +245,32 @@ class Account {
      * @param contractId NEAR account where the contract is deployed
      * @param methodName The method name on the contract as it is written in the contract code
      * @param args arguments to pass to method. Can be either plain JS object which gets serialized as JSON automatically
-     *  or `Uint8Array` instance which represents bytes passed as is.
-     * @param gas max amount of gas that method call can use
-      * @param deposit amount of NEAR (in yoctoNEAR) to send together with the call
+     *   or `Uint8Array` instance which represents bytes passed as is.
+     * @param options object containing options for this function call. Available options:
+     *   gas: max amount of gas (in gas units) that method call can use
+     *   deposit: amount of NEAR (in yoctoNEAR) to attach to the call
+     *   meta: a user-specified shallow object (string keys with string or number values). If provided,
+     *         the outcome of this transaction, along with provided `meta` data, will be available in
+     *         {@link WalletAccount.completedTransactions}
      * @returns {Promise<FinalExecutionOutcome>}
      */
-    async functionCall(contractId, methodName, args, gas, amount) {
+    async functionCall(contractId, methodName, args, optionsOrGas, deposit) {
+        let options = optionsOrGas;
+        if (!options && !deposit) {
+            options = {};
+        }
+        else if (!options || !(options.gas || options.deposit || options.meta)) {
+            // passed positional gas or deposit
+            const deprecate = depd_1.default('positional gas & deposit amount');
+            deprecate('pass { gas: inUnits, deposit: inYoctoNEAR } instead');
+            options = {
+                gas: optionsOrGas,
+                deposit
+            };
+        }
         args = args || {};
         this.validateArgs(args);
-        return this.signAndSendTransaction(contractId, [transaction_1.functionCall(methodName, args, gas || DEFAULT_FUNC_CALL_GAS, amount)]);
+        return this.signAndSendTransaction(contractId, [transaction_1.functionCall(methodName, args, options.gas || DEFAULT_FUNC_CALL_GAS, options.deposit)], options.meta);
     }
     /**
      * @param publicKey A public key to be associated with the contract

--- a/lib/account.js
+++ b/lib/account.js
@@ -12,7 +12,6 @@ const borsh_1 = require("borsh");
 const key_pair_1 = require("./utils/key_pair");
 const errors_1 = require("./utils/errors");
 const rpc_errors_1 = require("./utils/rpc_errors");
-const cached_transactions_1 = require("./cached-transactions");
 const exponential_backoff_1 = __importDefault(require("./utils/exponential-backoff"));
 // Default amount of gas to be sent with the function calls. Used to pay for the fees
 // incurred while running the contract execution. The unused amount will be refunded back to
@@ -88,22 +87,25 @@ class Account {
     /**
      * @param receiverId NEAR account receiving the transaction
      * @param actions The transaction [Action as described in the spec](https://nomicon.io/RuntimeSpec/Actions.html).
-     * @param meta Free-form {@link TxMetadata}. If provided, whether it
-     *   requires a redirect through NEAR Wallet or not, the transaction's
-     *   outcome will be available in the {@link WalletAccount.completedTransactions} collection.
+     * @param meta do not provide; interface only available for ConnectedWalletAccount subclass
+     * @param onInit for internal library use from ConnectedWalletAccount
+     * @param onSuccess for internal library use from ConnectedWalletAccount
      * @returns {Promise<FinalExecutionOutcome>}
      */
-    async signAndSendTransaction(receiverId, actions, meta = null) {
+    async signAndSendTransaction(receiverId, actions, meta, { onInit, onSuccess } = {}) {
+        if (meta) {
+            throw new Error('to cache transactions by passing `meta`, you must initialize a connection to NEAR with WalletConnection');
+        }
         await this.ready;
-        let txHash, signedTx;
+        let txHash, txHashString, signedTx;
         // TODO: TX_NONCE (different constants for different uses of exponentialBackoff?)
         const result = await exponential_backoff_1.default(TX_STATUS_RETRY_WAIT, TX_NONCE_RETRY_NUMBER, TX_STATUS_RETRY_WAIT_BACKOFF, async () => {
             [txHash, signedTx] = await this.signTransaction(receiverId, actions);
             const publicKey = signedTx.transaction.publicKey;
-            if (meta) {
-                cached_transactions_1.cacheTransaction({
-                    hash: Buffer.from(txHash).toString('hex'),
-                    meta,
+            const txHashString = Buffer.from(txHash).toString('hex');
+            if (onInit) {
+                onInit({
+                    hash: txHashString,
                     publicKey: publicKey.toString(),
                     receiverId,
                     signedTx: Buffer.from(signedTx.encode()).toString('hex'),
@@ -112,7 +114,6 @@ class Account {
             try {
                 const result = await exponential_backoff_1.default(TX_STATUS_RETRY_WAIT, TX_STATUS_RETRY_NUMBER, TX_STATUS_RETRY_WAIT_BACKOFF, async () => {
                     try {
-                        // TODO: Where does redirect to NEAR Wallet happen?
                         return await this.connection.provider.sendTransaction(signedTx);
                     }
                     catch (error) {
@@ -166,12 +167,13 @@ class Account {
             else {
                 error = rpc_errors_1.parseResultError(result);
             }
-            if (meta)
-                cached_transactions_1.markTransactionFailed(txHash.toString(), result, error.message);
+            // attaching extra info to the error OMG 😳
+            error.txHash = txHashString;
+            error.result = result;
             throw error;
         }
-        if (meta)
-            cached_transactions_1.markTransactionSucceeded(txHash.toString(), result);
+        if (onSuccess)
+            onSuccess(txHash.toString(), result);
         // TODO: if Tx is Unknown or Started.
         return result;
     }

--- a/lib/account.js
+++ b/lib/account.js
@@ -108,7 +108,7 @@ class Account {
                     hash: txHashString,
                     publicKey: publicKey.toString(),
                     receiverId,
-                    signedTx: Buffer.from(signedTx.encode()).toString('hex'),
+                    senderId: this.accountId
                 });
             }
             try {

--- a/lib/cached-transactions.d.ts
+++ b/lib/cached-transactions.d.ts
@@ -1,13 +1,18 @@
 import { FinalExecutionOutcome } from './providers';
-declare type TxMetadata = {
+export declare type TxMetadata = {
     [key: string]: string | number;
 };
-declare type Tx = {
+export declare type BasicCachedTransaction = {
     hash: string;
-    meta: TxMetadata;
     publicKey: string;
     receiverId: string;
     signedTx: string;
+};
+declare type Tx = BasicCachedTransaction & {
+    meta: TxMetadata;
+};
+declare type InitiatedTransaction = Tx & {
+    complete: false;
 };
 declare type SuccessfulTransaction = Tx & FinalExecutionOutcome & {
     complete: true;
@@ -19,6 +24,7 @@ declare type FailedTransaction = Tx & FinalExecutionOutcome & {
     error: string;
 };
 declare type CompletedTransaction = FailedTransaction | SuccessfulTransaction;
+declare type CachedTransaction = InitiatedTransaction | CompletedTransaction;
 /**
  * Add a transaction to the underlying cache. This is a low-level API called
  * internally when transactions are initiated via a changeMethod on a {@link Contract}
@@ -46,6 +52,13 @@ export declare function markTransactionFailed(hash: string, result: FinalExecuti
  * @param result FinalExecutionOutcome from RPC call
  */
 export declare function markTransactionSucceeded(hash: string, result: FinalExecutionOutcome): void;
+/**
+ * Transactions are stored as an object for easy updates & removal,
+ * but returned as an array for easier filtering. WARNING: this function
+ * returns raw data from the cache; it is up to the consumer to ensure that the
+ * cache stays accurate after operating on this data.
+ */
+export declare function getCachedTransactions(filter?: (tx: CachedTransaction) => boolean): CachedTransaction[];
 /**
  * A wrapper for the collection of completed, cached transactions which
  * provides safe interfaces for inspecting and removing them from the

--- a/lib/cached-transactions.d.ts
+++ b/lib/cached-transactions.d.ts
@@ -1,0 +1,84 @@
+import { FinalExecutionOutcome } from './providers';
+declare type TxMetadata = {
+    [key: string]: string | number;
+};
+declare type Tx = {
+    hash: string;
+    meta: TxMetadata;
+    publicKey: string;
+    receiverId: string;
+    signedTx: string;
+};
+declare type SuccessfulTransaction = Tx & FinalExecutionOutcome & {
+    complete: true;
+    failed: false;
+};
+declare type FailedTransaction = Tx & FinalExecutionOutcome & {
+    complete: true;
+    failed: true;
+    error: string;
+};
+declare type CompletedTransaction = FailedTransaction | SuccessfulTransaction;
+/**
+ * Add a transaction to the underlying cache. This is a low-level API called
+ * internally when transactions are initiated via a changeMethod on a {@link Contract}
+ * or via {@link Account.functionCall} and provided `meta` data
+ *
+ * @param tx the transaction to cache, requires all fields in {@link Tx}
+ */
+export declare function cacheTransaction(tx: Tx): void;
+/**
+ * Mark a cached transaction as having failed. This is a low-level API called
+ * internally when transactions are initiated via a changeMethod on a {@link Contract}
+ * or via {@link Account.functionCall} and provided `meta` data
+ *
+ * @param hash transaction hash of transaction to update
+ * @param result FinalExecutionOutcome from RPC call
+ * @param errorMessage a string with failure reason
+ */
+export declare function markTransactionFailed(hash: string, result: FinalExecutionOutcome, errorMessage: string): void;
+/**
+ * Mark a cached transaction as having succeeded. This is a low-level API called
+ * internally when transactions are initiated via a changeMethod on a {@link Contract}
+ * or via {@link Account.functionCall} and provided `meta` data
+ *
+ * @param hash transaction hash of transaction to update
+ * @param result FinalExecutionOutcome from RPC call
+ */
+export declare function markTransactionSucceeded(hash: string, result: FinalExecutionOutcome): void;
+/**
+ * A wrapper for the collection of completed, cached transactions which
+ * provides safe interfaces for inspecting and removing them from the
+ * underlying cache.
+ */
+export declare class CompletedTransactions {
+    /**
+     * Find and remove an item from the cache. Works like `Array.prototype.find`,
+     * but removes the item from the underlying cache if found.
+     *
+     * If you pass `meta` data to a `changeMethod` on a {@link Contract} or to
+     * {@link Account.functionCall}, the transaction will be automatically
+     * added to a cache. Whether or not the function call results in a redirect
+     * to NEAR Wallet, your app can then call {@link CompletedTransactions.remove},
+     * and find the transaction using the provided `meta` data, to determine
+     * the outcome of the transaction and update app state accordingly.
+     *
+     * Example:
+     *
+     * ```js
+     * const id = 1; // this is specific to and tracked by your app
+     * const completedTx = new CompletedTransactions().remove(tx => tx.meta.id === id)
+     * if (completedTx) {
+     *   // do app stuff, dealing with completed transaction
+     * } else {
+     *   const contract = new Contract(someAccount, 'some-address', { changeMethods: ['doThing'] })
+     *   contract.doThing(
+     *     { arg1: 'whatever' }, // arguments passed to `doThing` method
+     *     { meta: { id } } // options for near-api-js
+     *   )
+     * }
+     * ```
+     */
+    remove(finder: (tx: CompletedTransaction) => CompletedTransaction | null): CompletedTransaction | null;
+}
+export {};

--- a/lib/cached-transactions.d.ts
+++ b/lib/cached-transactions.d.ts
@@ -6,7 +6,7 @@ export declare type BasicCachedTransaction = {
     hash: string;
     publicKey: string;
     receiverId: string;
-    signedTx: string;
+    senderId: string;
 };
 declare type Tx = BasicCachedTransaction & {
     meta: TxMetadata;

--- a/lib/cached-transactions.js
+++ b/lib/cached-transactions.js
@@ -106,6 +106,8 @@ function removeCachedTransaction(hash) {
  */
 function getCachedTransactions(filter) {
     const txs = storage.get(STORAGE_KEY);
+    if (!txs)
+        return [];
     let arr = Object.keys(txs).reduce((arr, hash) => {
         arr.push(txs[hash]);
         return arr;
@@ -122,8 +124,7 @@ exports.getCachedTransactions = getCachedTransactions;
  * completed transactions again
  */
 function getCompletedTransactions() {
-    return getCachedTransactions()
-        .filter(t => t.complete === true);
+    return getCachedTransactions(t => t.complete === true);
 }
 /**
  * A wrapper for the collection of completed, cached transactions which

--- a/lib/cached-transactions.js
+++ b/lib/cached-transactions.js
@@ -19,7 +19,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.CompletedTransactions = exports.markTransactionSucceeded = exports.markTransactionFailed = exports.cacheTransaction = void 0;
+exports.CompletedTransactions = exports.getCachedTransactions = exports.markTransactionSucceeded = exports.markTransactionFailed = exports.cacheTransaction = void 0;
 const storage = __importStar(require("./storage"));
 const STORAGE_KEY = 'cachedTransactions';
 /**
@@ -100,18 +100,21 @@ function removeCachedTransaction(hash) {
 }
 /**
  * Transactions are stored as an object for easy updates & removal,
- * but returned as an array for easier filtering. This function is not exported
- * to prevent people from acting on completed transactions but forgetting to
- * remove them from the cache, causing bugs in their app when they try to act
- * on the same transactions again
+ * but returned as an array for easier filtering. WARNING: this function
+ * returns raw data from the cache; it is up to the consumer to ensure that the
+ * cache stays accurate after operating on this data.
  */
-function getCachedTransactions() {
+function getCachedTransactions(filter) {
     const txs = storage.get(STORAGE_KEY);
-    return Object.keys(txs).reduce((arr, hash) => {
+    let arr = Object.keys(txs).reduce((arr, hash) => {
         arr.push(txs[hash]);
         return arr;
     }, []);
+    if (filter)
+        arr = arr.filter(filter);
+    return arr;
 }
+exports.getCachedTransactions = getCachedTransactions;
 /**
  * Get only completed transactions. This function is not exported to prevent
  * people from acting on completed transactions but forgetting to remove them

--- a/lib/cached-transactions.js
+++ b/lib/cached-transactions.js
@@ -1,0 +1,167 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || function (mod) {
+    if (mod && mod.__esModule) return mod;
+    var result = {};
+    if (mod != null) for (var k in mod) if (k !== "default" && Object.hasOwnProperty.call(mod, k)) __createBinding(result, mod, k);
+    __setModuleDefault(result, mod);
+    return result;
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.CompletedTransactions = exports.markTransactionSucceeded = exports.markTransactionFailed = exports.cacheTransaction = void 0;
+const storage = __importStar(require("./storage"));
+const STORAGE_KEY = 'cachedTransactions';
+/**
+ * Add a transaction to the underlying cache. This is a low-level API called
+ * internally when transactions are initiated via a changeMethod on a {@link Contract}
+ * or via {@link Account.functionCall} and provided `meta` data
+ *
+ * @param tx the transaction to cache, requires all fields in {@link Tx}
+ */
+function cacheTransaction(tx) {
+    storage.set(STORAGE_KEY, {
+        ...getCachedTransactions(),
+        [tx.hash]: { ...tx, complete: false }
+    });
+}
+exports.cacheTransaction = cacheTransaction;
+/**
+ * Mark a cached transaction as having failed. This is a low-level API called
+ * internally when transactions are initiated via a changeMethod on a {@link Contract}
+ * or via {@link Account.functionCall} and provided `meta` data
+ *
+ * @param hash transaction hash of transaction to update
+ * @param result FinalExecutionOutcome from RPC call
+ * @param errorMessage a string with failure reason
+ */
+function markTransactionFailed(hash, result, errorMessage) {
+    const txs = storage.get(STORAGE_KEY);
+    const tx = txs[hash];
+    if (!tx) {
+        throw new Error(`No cached transaction with hash=${hash}`);
+    }
+    const updatedTx = {
+        ...tx,
+        ...result,
+        complete: true,
+        failed: true,
+        error: errorMessage
+    };
+    storage.set(STORAGE_KEY, { ...txs, [hash]: updatedTx });
+}
+exports.markTransactionFailed = markTransactionFailed;
+/**
+ * Mark a cached transaction as having succeeded. This is a low-level API called
+ * internally when transactions are initiated via a changeMethod on a {@link Contract}
+ * or via {@link Account.functionCall} and provided `meta` data
+ *
+ * @param hash transaction hash of transaction to update
+ * @param result FinalExecutionOutcome from RPC call
+ */
+function markTransactionSucceeded(hash, result) {
+    const txs = storage.get(STORAGE_KEY);
+    const tx = txs[hash];
+    if (!tx) {
+        throw new Error(`No cached transaction with hash=${hash}`);
+    }
+    const updatedTx = {
+        ...tx,
+        ...result,
+        complete: true,
+        failed: false
+    };
+    storage.set(STORAGE_KEY, { ...txs, [hash]: updatedTx });
+}
+exports.markTransactionSucceeded = markTransactionSucceeded;
+/**
+ * Remove an item from the underlying cache. Not for direct use, so not
+ * exported. Prefer to use {@link CompletedTransactions} instead
+ */
+function removeCachedTransaction(hash) {
+    const txs = getCachedTransactions();
+    if (txs[hash]) {
+        delete txs[hash];
+        storage.set(STORAGE_KEY, txs);
+    }
+    else {
+        console.error(new Error(`No cached transaction with hash=${hash}`));
+    }
+}
+/**
+ * Transactions are stored as an object for easy updates & removal,
+ * but returned as an array for easier filtering. This function is not exported
+ * to prevent people from acting on completed transactions but forgetting to
+ * remove them from the cache, causing bugs in their app when they try to act
+ * on the same transactions again
+ */
+function getCachedTransactions() {
+    const txs = storage.get(STORAGE_KEY);
+    return Object.keys(txs).reduce((arr, hash) => {
+        arr.push(txs[hash]);
+        return arr;
+    }, []);
+}
+/**
+ * Get only completed transactions. This function is not exported to prevent
+ * people from acting on completed transactions but forgetting to remove them
+ * from the cache, causing bugs in their app when they try to act on the same
+ * completed transactions again
+ */
+function getCompletedTransactions() {
+    return getCachedTransactions()
+        .filter(t => t.complete === true);
+}
+/**
+ * A wrapper for the collection of completed, cached transactions which
+ * provides safe interfaces for inspecting and removing them from the
+ * underlying cache.
+ */
+class CompletedTransactions {
+    /**
+     * Find and remove an item from the cache. Works like `Array.prototype.find`,
+     * but removes the item from the underlying cache if found.
+     *
+     * If you pass `meta` data to a `changeMethod` on a {@link Contract} or to
+     * {@link Account.functionCall}, the transaction will be automatically
+     * added to a cache. Whether or not the function call results in a redirect
+     * to NEAR Wallet, your app can then call {@link CompletedTransactions.remove},
+     * and find the transaction using the provided `meta` data, to determine
+     * the outcome of the transaction and update app state accordingly.
+     *
+     * Example:
+     *
+     * ```js
+     * const id = 1; // this is specific to and tracked by your app
+     * const completedTx = new CompletedTransactions().remove(tx => tx.meta.id === id)
+     * if (completedTx) {
+     *   // do app stuff, dealing with completed transaction
+     * } else {
+     *   const contract = new Contract(someAccount, 'some-address', { changeMethods: ['doThing'] })
+     *   contract.doThing(
+     *     { arg1: 'whatever' }, // arguments passed to `doThing` method
+     *     { meta: { id } } // options for near-api-js
+     *   )
+     * }
+     * ```
+     */
+    remove(finder) {
+        const found = getCompletedTransactions().find(finder);
+        if (found) {
+            removeCachedTransaction(found.hash);
+            return found;
+        }
+        return null;
+    }
+}
+exports.CompletedTransactions = CompletedTransactions;

--- a/lib/contract.d.ts
+++ b/lib/contract.d.ts
@@ -1,9 +1,10 @@
 import { Account } from './account';
+import { ConnectedWalletAccount } from './wallet-account';
 /**
  * Defines a smart contract on NEAR including the mutable and non-mutable methods
  */
 export declare class Contract {
-    readonly account: Account;
+    readonly account: Account | ConnectedWalletAccount;
     readonly contractId: string;
     constructor(account: Account, contractId: string, options: {
         viewMethods: string[];

--- a/lib/contract.js
+++ b/lib/contract.js
@@ -5,6 +5,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.Contract = void 0;
 const bn_js_1 = __importDefault(require("bn.js"));
+const depd_1 = __importDefault(require("depd"));
 const providers_1 = require("./providers");
 const errors_1 = require("./utils/errors");
 // Makes `function.name` return given name
@@ -41,12 +42,25 @@ class Contract {
             Object.defineProperty(this, methodName, {
                 writable: false,
                 enumerable: true,
-                value: nameFunction(methodName, async (args = {}, gas, amount, ...ignored) => {
+                value: nameFunction(methodName, async (args = {}, optionsOrGas, deposit, ...ignored) => {
+                    let options = optionsOrGas;
+                    if (!options && !deposit) {
+                        options = {};
+                    }
+                    else if (!options || !(options.gas || options.deposit || options.meta)) {
+                        // passed positional gas or deposit
+                        const deprecate = depd_1.default('positional gas & deposit amount');
+                        deprecate('pass { gas: inUnits, deposit: inYoctoNEAR } instead');
+                        options = {
+                            gas: optionsOrGas,
+                            deposit
+                        };
+                    }
                     if (ignored.length || !(isObject(args) || isUint8Array(args))) {
                         throw new errors_1.PositionalArgsError();
                     }
-                    validateBNLike({ gas, amount });
-                    const rawResult = await this.account.functionCall(this.contractId, methodName, args, gas, amount);
+                    validateBNLike({ gas: options.gas, deposit: options.deposit });
+                    const rawResult = await this.account.functionCall(this.contractId, methodName, args, options);
                     return providers_1.getTransactionLastResult(rawResult);
                 })
             });

--- a/lib/providers/index.d.ts
+++ b/lib/providers/index.d.ts
@@ -1,3 +1,3 @@
-import { Provider, FinalExecutionOutcome, ExecutionOutcomeWithId, getTransactionLastResult, FinalExecutionStatusBasic } from './provider';
-import { JsonRpcProvider, TypedError, ErrorContext } from './json-rpc-provider';
-export { Provider, FinalExecutionOutcome, JsonRpcProvider, ExecutionOutcomeWithId, FinalExecutionStatusBasic, getTransactionLastResult, TypedError, ErrorContext };
+import { ExecutionOutcomeWithId, FinalExecutionOutcome, FinalExecutionStatus, FinalExecutionStatusBasic, Provider, getTransactionLastResult } from './provider';
+import { ErrorContext, JsonRpcProvider, TypedError } from './json-rpc-provider';
+export { ErrorContext, ExecutionOutcomeWithId, FinalExecutionOutcome, FinalExecutionStatus, FinalExecutionStatusBasic, JsonRpcProvider, Provider, TypedError, getTransactionLastResult };

--- a/lib/providers/index.js
+++ b/lib/providers/index.js
@@ -1,11 +1,11 @@
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.ErrorContext = exports.TypedError = exports.getTransactionLastResult = exports.FinalExecutionStatusBasic = exports.JsonRpcProvider = exports.Provider = void 0;
+exports.getTransactionLastResult = exports.TypedError = exports.Provider = exports.JsonRpcProvider = exports.FinalExecutionStatusBasic = exports.ErrorContext = void 0;
 const provider_1 = require("./provider");
+Object.defineProperty(exports, "FinalExecutionStatusBasic", { enumerable: true, get: function () { return provider_1.FinalExecutionStatusBasic; } });
 Object.defineProperty(exports, "Provider", { enumerable: true, get: function () { return provider_1.Provider; } });
 Object.defineProperty(exports, "getTransactionLastResult", { enumerable: true, get: function () { return provider_1.getTransactionLastResult; } });
-Object.defineProperty(exports, "FinalExecutionStatusBasic", { enumerable: true, get: function () { return provider_1.FinalExecutionStatusBasic; } });
 const json_rpc_provider_1 = require("./json-rpc-provider");
+Object.defineProperty(exports, "ErrorContext", { enumerable: true, get: function () { return json_rpc_provider_1.ErrorContext; } });
 Object.defineProperty(exports, "JsonRpcProvider", { enumerable: true, get: function () { return json_rpc_provider_1.JsonRpcProvider; } });
 Object.defineProperty(exports, "TypedError", { enumerable: true, get: function () { return json_rpc_provider_1.TypedError; } });
-Object.defineProperty(exports, "ErrorContext", { enumerable: true, get: function () { return json_rpc_provider_1.ErrorContext; } });

--- a/lib/storage.d.ts
+++ b/lib/storage.d.ts
@@ -1,0 +1,12 @@
+/**
+ * A low-level wrapper around localStorage.getItem (using node-localstorage
+ * library for Node). Prefer using one of these higher-level libraries instead:
+ *   - {@link CompletedTransactions}
+ */
+export declare function get(key: string): any;
+/**
+ * A low-level wrapper around localStorage.setItem (using node-localstorage
+ * library for Node). Prefer using one of these higher-level libraries instead:
+ *   - {@link CompletedTransactions}
+ */
+export declare function set(key: string, state: any): void;

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -1,0 +1,40 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.set = exports.get = void 0;
+if (typeof localStorage === 'undefined' || localStorage === null) {
+    const { LocalStorage } = require('node-localstorage'); // eslint-disable-line @typescript-eslint/no-var-requires
+    localStorage = new LocalStorage(process.env.NEAR_CACHE_DIR || '~/.near-api-js');
+}
+const BASE_KEY = 'near-api-js.internal-cache';
+/**
+ * A low-level wrapper around localStorage.getItem (using node-localstorage
+ * library for Node). Prefer using one of these higher-level libraries instead:
+ *   - {@link CompletedTransactions}
+ */
+function get(key) {
+    try {
+        const serializedState = localStorage.getItem(key);
+        if (serializedState === null) {
+            return undefined;
+        }
+        return JSON.parse(serializedState);
+    }
+    catch (err) {
+        console.error(`Something went wrong getting key:${key} from localStorage in near-api-js`);
+        throw err;
+    }
+}
+exports.get = get;
+/**
+ * A low-level wrapper around localStorage.setItem (using node-localstorage
+ * library for Node). Prefer using one of these higher-level libraries instead:
+ *   - {@link CompletedTransactions}
+ */
+function set(key, state) {
+    if (!key || !state) {
+        throw new Error('expected two arguments, only got one');
+    }
+    const serializedState = JSON.stringify(state);
+    localStorage.setItem(`${BASE_KEY}.${key}`, serializedState);
+}
+exports.set = set;

--- a/lib/transaction.d.ts
+++ b/lib/transaction.d.ts
@@ -6,7 +6,7 @@ import { Signer } from './signer';
 export declare class FunctionCallPermission extends Assignable {
     allowance?: BN;
     receiverId: string;
-    methodNames: String[];
+    methodNames: string[];
 }
 export declare class FullAccessPermission extends Assignable {
 }
@@ -19,7 +19,7 @@ export declare class AccessKey extends Assignable {
     permission: AccessKeyPermission;
 }
 export declare function fullAccessKey(): AccessKey;
-export declare function functionCallAccessKey(receiverId: string, methodNames: String[], allowance?: BN): AccessKey;
+export declare function functionCallAccessKey(receiverId: string, methodNames: string[], allowance?: BN): AccessKey;
 export declare class IAction extends Assignable {
 }
 export declare class CreateAccount extends IAction {
@@ -78,6 +78,10 @@ export declare class Transaction extends Assignable {
     receiverId: string;
     actions: Action[];
     blockHash: Uint8Array;
+    _hash: Uint8Array;
+    _message: Uint8Array;
+    getMessage(): Uint8Array;
+    getHash(): Uint8Array;
     encode(): Uint8Array;
     static decode(bytes: Buffer): Transaction;
 }

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -103,6 +103,14 @@ class Signature extends enums_1.Assignable {
 }
 exports.Signature = Signature;
 class Transaction extends enums_1.Assignable {
+    getMessage() {
+        this._message = this._message || borsh_1.serialize(exports.SCHEMA, this);
+        return this._message;
+    }
+    getHash() {
+        this._hash = this._hash || new Uint8Array(js_sha256_1.default.sha256.array(this.getMessage()));
+        return this._hash;
+    }
     encode() {
         return borsh_1.serialize(exports.SCHEMA, this);
     }
@@ -211,14 +219,12 @@ exports.createTransaction = createTransaction;
  * @param networkId The targeted network. (ex. default, betanet, etc…)
  */
 async function signTransactionObject(transaction, signer, accountId, networkId) {
-    const message = borsh_1.serialize(exports.SCHEMA, transaction);
-    const hash = new Uint8Array(js_sha256_1.default.sha256.array(message));
-    const signature = await signer.signMessage(message, accountId, networkId);
+    const signature = await signer.signMessage(transaction.getMessage(), accountId, networkId);
     const signedTx = new SignedTransaction({
         transaction,
         signature: new Signature({ keyType: transaction.publicKey.keyType, data: signature.signature })
     });
-    return [hash, signedTx];
+    return [transaction.getHash(), signedTx];
 }
 async function signTransaction(...args) {
     if (args[0].constructor === Transaction) {

--- a/lib/utils/isObject.d.ts
+++ b/lib/utils/isObject.d.ts
@@ -1,0 +1,2 @@
+declare const _default: (x: any) => boolean;
+export default _default;

--- a/lib/utils/isObject.js
+++ b/lib/utils/isObject.js
@@ -1,0 +1,3 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.default = (x) => Object.prototype.toString.call(x) === '[object Object]';

--- a/lib/wallet-account.d.ts
+++ b/lib/wallet-account.d.ts
@@ -5,7 +5,9 @@ import { FinalExecutionOutcome } from './providers';
 import { Transaction, Action } from './transaction';
 import { PublicKey } from './utils';
 import { Connection } from './connection';
+import { CompletedTransactions } from './cached-transactions';
 export declare class WalletConnection {
+    _completedTransactions: CompletedTransactions;
     _walletBaseUrl: string;
     _authDataKey: string;
     _keyStore: KeyStore;
@@ -14,6 +16,38 @@ export declare class WalletConnection {
     _near: Near;
     _connectedAccount: ConnectedWalletAccount;
     constructor(near: Near, appKeyPrefix: string | null);
+    /**
+     * A wrapper for the collection of completed, cached transactions which
+     * provides safe interfaces for inspecting and removing them from the
+     * underlying cache.
+     *
+     * If you pass `meta` data to a `changeMethod` on a {@link Contract} or to
+     * {@link Account.functionCall}, the transaction will be automatically
+     * added to a cache. Whether or not the function call results in a redirect
+     * to NEAR Wallet, your app can then use this `completedTransactions`
+     * interface to determine the outcome of the transaction and update your
+     * app's state.
+     *
+     * Example:
+     *
+     * ```js
+     * const id = 1; // this is specific to and tracked by your app
+     * const completedTx = walletConnection.completedTransactions.remove(tx => tx.meta.id === id)
+     * if (completedTx) {
+     *   // do app stuff, dealing with completed transaction
+     * } else {
+     *   const contract = new Contract(someAccount, 'some-address', { changeMethods: ['doThing'] })
+     *   contract.doThing(
+     *     // arguments passed to contract's `doThing` method:
+     *     { arg1: 'whatever' },
+     *
+     *     // options for near-api-js:
+     *     { meta: { id: id } }
+     *   )
+     * }
+     * ```
+     */
+    completedTransactions(): CompletedTransactions;
     /**
      * Returns true, if this WalletAccount is authorized with the wallet.
      * @example

--- a/lib/wallet-account.d.ts
+++ b/lib/wallet-account.d.ts
@@ -1,3 +1,4 @@
+import BN from 'bn.js';
 import { Account } from './account';
 import { Near } from './near';
 import { KeyStore } from './key_stores';
@@ -5,7 +6,12 @@ import { FinalExecutionOutcome } from './providers';
 import { Transaction, Action } from './transaction';
 import { PublicKey } from './utils';
 import { Connection } from './connection';
-import { CompletedTransactions } from './cached-transactions';
+import { TxMetadata, CompletedTransactions } from './cached-transactions';
+export declare type ChangeMethodOptions = {
+    gas?: BN;
+    deposit?: BN;
+    meta?: TxMetadata;
+};
 export declare class WalletConnection {
     _completedTransactions: CompletedTransactions;
     _walletBaseUrl: string;
@@ -106,10 +112,19 @@ export declare const WalletAccount: typeof WalletConnection;
 /**
  * {@link Account} implementation which redirects to wallet using (@link WalletConnection) when no local key is available.
  */
-declare class ConnectedWalletAccount extends Account {
+export declare class ConnectedWalletAccount extends Account {
     walletConnection: WalletConnection;
     constructor(walletConnection: WalletConnection, connection: Connection, accountId: string);
-    protected signAndSendTransaction(receiverId: string, actions: Action[]): Promise<FinalExecutionOutcome>;
+    /**
+     * Overrides Account.signAndSendTransaction, adds caching ability with `meta` param
+     *
+     * @param receiverId NEAR account receiving the transaction
+     * @param actions The transaction [Action as described in the spec](https://nomicon.io/RuntimeSpec/Actions.html).
+     * @param meta Free-form {@link TxMetadata}. If provided, whether it
+     *   requires a redirect through NEAR Wallet or not, the transaction's
+     *   outcome will be available in the {@link WalletAccount.completedTransactions} collection.
+     */
+    protected signAndSendTransaction(receiverId: string, actions: Action[], meta?: TxMetadata): Promise<FinalExecutionOutcome>;
     /**
      * Check if given access key allows the function call or method attempted in transaction
      * @param accessKey Array of {access_key: AccessKey, public_key: PublicKey} items
@@ -126,4 +141,3 @@ declare class ConnectedWalletAccount extends Account {
      */
     accessKeyForTransaction(receiverId: string, actions: Action[], localKey?: PublicKey): Promise<any>;
 }
-export {};

--- a/lib/wallet-account.d.ts
+++ b/lib/wallet-account.d.ts
@@ -53,7 +53,7 @@ export declare class WalletConnection {
      * }
      * ```
      */
-    completedTransactions(): CompletedTransactions;
+    get completedTransactions(): CompletedTransactions;
     /**
      * Returns true, if this WalletAccount is authorized with the wallet.
      * @example

--- a/lib/wallet-account.js
+++ b/lib/wallet-account.js
@@ -62,7 +62,7 @@ class WalletConnection {
      * }
      * ```
      */
-    completedTransactions() {
+    get completedTransactions() {
         return this._completedTransactions;
     }
     /**
@@ -186,13 +186,15 @@ class ConnectedWalletAccount extends account_1.Account {
     constructor(walletConnection, connection, accountId) {
         super(connection, accountId);
         this.walletConnection = walletConnection;
+        const initializedTransactions = cached_transactions_1.getCachedTransactions(tx => !tx.complete);
+        console.log('in ConnectedWalletAccount#constructor, checking initialized transactions: ', { initializedTransactions });
         // Check if a redirect to NEAR Wallet for tx signing was just completed.
         // If so, check tx outcome, call markTransactionSucceeded or markTransactionFailed.
         //
         // NOTE: a constructor cannot be `async`, so this will process in the
         // background after caller already receives an initialized
         // `ConnectedWalletAccount`. It uses `Promise.all` to check all in parallel.
-        Promise.all(cached_transactions_1.getCachedTransactions(tx => !tx.complete).map(({ hash }) => (connection.provider.txStatus(bs58_1.default.decode(hash), accountId).then(result => {
+        Promise.all(initializedTransactions.map(({ hash }) => (connection.provider.txStatus(bs58_1.default.decode(hash), accountId).then(result => {
             console.log('in ConnectedWalletAccount#constructor, checking status of cached transaction: ', { hash, result });
             const status = result.status;
             if (status.SuccessValue) {
@@ -219,14 +221,17 @@ class ConnectedWalletAccount extends account_1.Account {
         if (!accessKey) {
             throw new Error(`Cannot find matching key for transaction sent to ${receiverId}`);
         }
+        let initializedCache = false;
         if (localKey && localKey.toString() === accessKey.public_key) {
             try {
                 // this call will cache and mark cached as successful in happy case, will not mark as failed if error thrown
                 return await super.signAndSendTransaction(receiverId, actions, null, {
                     onInit: (tx) => {
                         console.log('in ConnectedWalletAccount#signAndSendTransaction, caching tx: ', { ...tx, meta });
-                        if (meta)
+                        if (meta) {
                             cached_transactions_1.cacheTransaction({ ...tx, meta });
+                            initializedCache = true;
+                        }
                     },
                     onSuccess: (txHash, result) => {
                         console.log('in ConnectedWalletAccount#signAndSendTransaction, marking successful tx: ', { txHash, result });
@@ -254,6 +259,17 @@ class ConnectedWalletAccount extends account_1.Account {
         const status = await this.connection.provider.status();
         const blockHash = borsh_1.baseDecode(status.sync_info.latest_block_hash);
         const transaction = transaction_1.createTransaction(this.accountId, publicKey, receiverId, nonce, actions, blockHash);
+        if (!initializedCache && meta) {
+            const tx = {
+                hash: Buffer.from(transaction.getHash()).toString('hex'),
+                meta,
+                publicKey: transaction.publicKey.toString(),
+                receiverId: transaction.receiverId,
+                senderId: this.accountId
+            };
+            console.log('in ConnectedWalletAccount#signAndSendTransaction, caching tx:', { tx });
+            cached_transactions_1.cacheTransaction(tx);
+        }
         await this.walletConnection.requestSignTransactions([transaction], window.location.href);
         return new Promise((resolve, reject) => {
             setTimeout(() => {

--- a/lib/wallet-account.js
+++ b/lib/wallet-account.js
@@ -1,6 +1,10 @@
 "use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.WalletAccount = exports.WalletConnection = void 0;
+exports.ConnectedWalletAccount = exports.WalletAccount = exports.WalletConnection = void 0;
+const bs58_1 = __importDefault(require("bs58"));
 const account_1 = require("./account");
 const transaction_1 = require("./transaction");
 const utils_1 = require("./utils");
@@ -182,9 +186,33 @@ class ConnectedWalletAccount extends account_1.Account {
     constructor(walletConnection, connection, accountId) {
         super(connection, accountId);
         this.walletConnection = walletConnection;
+        // Check if a redirect to NEAR Wallet for tx signing was just completed.
+        // If so, check tx outcome, call markTransactionSucceeded or markTransactionFailed.
+        //
+        // NOTE: a constructor cannot be `async`, so this will process in the
+        // background after caller already receives an initialized
+        // `ConnectedWalletAccount`. It uses `Promise.all` to check all in parallel.
+        Promise.all(cached_transactions_1.getCachedTransactions(tx => !tx.complete).map(({ hash }) => (connection.provider.txStatus(bs58_1.default.decode(hash), accountId).then(result => {
+            console.log('in ConnectedWalletAccount#constructor, checking status of cached transaction: ', { hash, result });
+            const status = result.status;
+            if (status.SuccessValue) {
+                cached_transactions_1.markTransactionSucceeded(hash, result);
+            }
+            else if (status.Failure) {
+                cached_transactions_1.markTransactionFailed(hash, result, status.Failure.error_message || 'Something went wrong');
+            }
+        }))));
     }
-    // Overriding Account methods
-    async signAndSendTransaction(receiverId, actions) {
+    /**
+     * Overrides Account.signAndSendTransaction, adds caching ability with `meta` param
+     *
+     * @param receiverId NEAR account receiving the transaction
+     * @param actions The transaction [Action as described in the spec](https://nomicon.io/RuntimeSpec/Actions.html).
+     * @param meta Free-form {@link TxMetadata}. If provided, whether it
+     *   requires a redirect through NEAR Wallet or not, the transaction's
+     *   outcome will be available in the {@link WalletAccount.completedTransactions} collection.
+     */
+    async signAndSendTransaction(receiverId, actions, meta) {
         await this.ready;
         const localKey = await this.connection.signer.getPublicKey(this.accountId, this.connection.networkId);
         let accessKey = await this.accessKeyForTransaction(receiverId, actions, localKey);
@@ -193,7 +221,19 @@ class ConnectedWalletAccount extends account_1.Account {
         }
         if (localKey && localKey.toString() === accessKey.public_key) {
             try {
-                return await super.signAndSendTransaction(receiverId, actions);
+                // this call will cache and mark cached as successful in happy case, will not mark as failed if error thrown
+                return await super.signAndSendTransaction(receiverId, actions, null, {
+                    onInit: (tx) => {
+                        console.log('in ConnectedWalletAccount#signAndSendTransaction, caching tx: ', { ...tx, meta });
+                        if (meta)
+                            cached_transactions_1.cacheTransaction({ ...tx, meta });
+                    },
+                    onSuccess: (txHash, result) => {
+                        console.log('in ConnectedWalletAccount#signAndSendTransaction, marking successful tx: ', { txHash, result });
+                        if (meta)
+                            cached_transactions_1.markTransactionSucceeded(txHash, result);
+                    }
+                });
             }
             catch (e) {
                 // TODO: Use TypedError when available
@@ -201,6 +241,9 @@ class ConnectedWalletAccount extends account_1.Account {
                     accessKey = await this.accessKeyForTransaction(receiverId, actions);
                 }
                 else {
+                    // error includes txHash & result for some reason??
+                    // what's a better way to get this info here?? 😩
+                    cached_transactions_1.markTransactionFailed(e.txHash, e.result, e.message);
                     throw e;
                 }
             }
@@ -278,3 +321,4 @@ class ConnectedWalletAccount extends account_1.Account {
         return null;
     }
 }
+exports.ConnectedWalletAccount = ConnectedWalletAccount;

--- a/lib/wallet-account.js
+++ b/lib/wallet-account.js
@@ -6,6 +6,7 @@ const transaction_1 = require("./transaction");
 const utils_1 = require("./utils");
 const borsh_1 = require("borsh");
 const borsh_2 = require("borsh");
+const cached_transactions_1 = require("./cached-transactions");
 const LOGIN_WALLET_URL_SUFFIX = '/login/';
 const MULTISIG_HAS_METHOD = 'add_request_and_confirm';
 const LOCAL_STORAGE_KEY_SUFFIX = '_wallet_auth_key';
@@ -15,6 +16,7 @@ class WalletConnection {
         this._near = near;
         const authDataKey = appKeyPrefix + LOCAL_STORAGE_KEY_SUFFIX;
         const authData = JSON.parse(window.localStorage.getItem(authDataKey));
+        this._completedTransactions = new cached_transactions_1.CompletedTransactions();
         this._networkId = near.config.networkId;
         this._walletBaseUrl = near.config.walletUrl;
         appKeyPrefix = appKeyPrefix || near.config.contractName || 'default';
@@ -24,6 +26,40 @@ class WalletConnection {
         if (!this.isSignedIn()) {
             this._completeSignInWithAccessKey();
         }
+    }
+    /**
+     * A wrapper for the collection of completed, cached transactions which
+     * provides safe interfaces for inspecting and removing them from the
+     * underlying cache.
+     *
+     * If you pass `meta` data to a `changeMethod` on a {@link Contract} or to
+     * {@link Account.functionCall}, the transaction will be automatically
+     * added to a cache. Whether or not the function call results in a redirect
+     * to NEAR Wallet, your app can then use this `completedTransactions`
+     * interface to determine the outcome of the transaction and update your
+     * app's state.
+     *
+     * Example:
+     *
+     * ```js
+     * const id = 1; // this is specific to and tracked by your app
+     * const completedTx = walletConnection.completedTransactions.remove(tx => tx.meta.id === id)
+     * if (completedTx) {
+     *   // do app stuff, dealing with completed transaction
+     * } else {
+     *   const contract = new Contract(someAccount, 'some-address', { changeMethods: ['doThing'] })
+     *   contract.doThing(
+     *     // arguments passed to contract's `doThing` method:
+     *     { arg1: 'whatever' },
+     *
+     *     // options for near-api-js:
+     *     { meta: { id: id } }
+     *   )
+     * }
+     * ```
+     */
+    completedTransactions() {
+        return this._completedTransactions;
     }
     /**
      * Returns true, if this WalletAccount is authorized with the wallet.
@@ -210,7 +246,7 @@ class ConnectedWalletAccount extends account_1.Account {
                 }
                 const [{ functionCall }] = actions;
                 return functionCall &&
-                    (!functionCall.deposit || functionCall.deposit.toString() === "0") && // TODO: Should support charging amount smaller than allowance?
+                    (!functionCall.deposit || functionCall.deposit.toString() === '0') && // TODO: Should support charging amount smaller than allowance?
                     (allowedMethods.length === 0 || allowedMethods.includes(functionCall.methodName));
                 // TODO: Handle cases when allowance doesn't have enough to pay for gas
             }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "tweetnacl": "^1.0.1"
   },
   "devDependencies": {
+    "@types/bs58": "^4.0.1",
     "@types/depd": "^1.1.32",
     "@types/http-errors": "^1.6.1",
     "@typescript-eslint/eslint-plugin": "^2.18.0",

--- a/package.json
+++ b/package.json
@@ -21,10 +21,12 @@
     "js-sha256": "^0.9.0",
     "mustache": "^4.0.0",
     "node-fetch": "^2.6.1",
+    "node-localstorage": "^2.1.6",
     "text-encoding-utf-8": "^1.0.2",
     "tweetnacl": "^1.0.1"
   },
   "devDependencies": {
+    "@types/depd": "^1.1.32",
     "@types/http-errors": "^1.6.1",
     "@typescript-eslint/eslint-plugin": "^2.18.0",
     "@typescript-eslint/parser": "^2.18.0",

--- a/src/account.ts
+++ b/src/account.ts
@@ -179,7 +179,7 @@ export class Account {
                     hash: txHashString,
                     publicKey: publicKey.toString(),
                     receiverId,
-                    signedTx: Buffer.from(signedTx.encode()).toString('hex'),
+                    senderId: this.accountId
                 });
             }
 

--- a/src/cached-transactions.ts
+++ b/src/cached-transactions.ts
@@ -7,7 +7,7 @@ export type BasicCachedTransaction = {
     hash: string;
     publicKey: string;
     receiverId: string;
-    signedTx: string;
+    senderId: string;
 };
 
 type Tx = BasicCachedTransaction & {
@@ -126,6 +126,8 @@ export function getCachedTransactions (
 ): CachedTransaction[] {
     const txs = storage.get(STORAGE_KEY);
 
+    if (!txs) return [];
+
     let arr = Object.keys(txs).reduce(
         (arr: CachedTransaction[], hash: string) => {
             arr.push(txs[hash]);
@@ -146,8 +148,7 @@ export function getCachedTransactions (
  * completed transactions again
  */
 function getCompletedTransactions(): CompletedTransaction[] {
-    return getCachedTransactions()
-        .filter(t => t.complete === true) as CompletedTransaction[];
+    return getCachedTransactions(t => t.complete === true) as CompletedTransaction[];
 }
 
 /**

--- a/src/cached-transactions.ts
+++ b/src/cached-transactions.ts
@@ -1,0 +1,187 @@
+import { FinalExecutionOutcome } from './providers';
+import * as storage from './storage';
+
+type TxMetadata = { [key: string]: string | number };
+
+type Tx = {
+    hash: string;
+    meta: TxMetadata;
+    publicKey: string;
+    receiverId: string;
+    signedTx: string;
+};
+
+type InitiatedTransaction = Tx & {
+    complete: false;
+};
+
+type SuccessfulTransaction = Tx & FinalExecutionOutcome & {
+    complete: true;
+    failed: false;
+};
+
+type FailedTransaction = Tx & FinalExecutionOutcome & {
+    complete: true;
+    failed: true;
+    error: string;
+};
+
+type CompletedTransaction = FailedTransaction | SuccessfulTransaction;
+
+type CachedTransaction = InitiatedTransaction | CompletedTransaction;
+
+const STORAGE_KEY = 'cachedTransactions';
+
+/**
+ * Add a transaction to the underlying cache. This is a low-level API called
+ * internally when transactions are initiated via a changeMethod on a {@link Contract}
+ * or via {@link Account.functionCall} and provided `meta` data
+ *
+ * @param tx the transaction to cache, requires all fields in {@link Tx}
+ */
+export function cacheTransaction (tx: Tx) {
+    storage.set(STORAGE_KEY, {
+        ...getCachedTransactions(),
+        [tx.hash]: { ...tx, complete: false } as InitiatedTransaction
+    });
+}
+
+/**
+ * Mark a cached transaction as having failed. This is a low-level API called
+ * internally when transactions are initiated via a changeMethod on a {@link Contract}
+ * or via {@link Account.functionCall} and provided `meta` data
+ *
+ * @param hash transaction hash of transaction to update
+ * @param result FinalExecutionOutcome from RPC call
+ * @param errorMessage a string with failure reason
+ */
+export function markTransactionFailed (
+    hash: string,
+    result: FinalExecutionOutcome,
+    errorMessage: string
+) {
+    const txs = storage.get(STORAGE_KEY);
+    const tx = txs[hash] as InitiatedTransaction;
+    if (!tx) {
+        throw new Error(`No cached transaction with hash=${hash}`);
+    }
+    const updatedTx: FailedTransaction = {
+        ...tx,
+        ...result,
+        complete: true,
+        failed: true,
+        error: errorMessage
+    };
+    storage.set(STORAGE_KEY, { ...txs, [hash]: updatedTx });
+}
+
+/**
+ * Mark a cached transaction as having succeeded. This is a low-level API called
+ * internally when transactions are initiated via a changeMethod on a {@link Contract}
+ * or via {@link Account.functionCall} and provided `meta` data
+ *
+ * @param hash transaction hash of transaction to update
+ * @param result FinalExecutionOutcome from RPC call
+ */
+export function markTransactionSucceeded (hash: string, result: FinalExecutionOutcome) {
+    const txs = storage.get(STORAGE_KEY);
+    const tx = txs[hash] as InitiatedTransaction;
+    if (!tx) {
+        throw new Error(`No cached transaction with hash=${hash}`);
+    }
+    const updatedTx: CompletedTransaction = {
+        ...tx,
+        ...result,
+        complete: true,
+        failed: false
+    };
+    storage.set(STORAGE_KEY, { ...txs, [hash]: updatedTx });
+}
+
+/**
+ * Remove an item from the underlying cache. Not for direct use, so not
+ * exported. Prefer to use {@link CompletedTransactions} instead
+ */
+function removeCachedTransaction (hash: string) {
+    const txs = getCachedTransactions();
+    if (txs[hash]) {
+        delete txs[hash];
+        storage.set(STORAGE_KEY, txs);
+    } else {
+        console.error(new Error(`No cached transaction with hash=${hash}`));
+    }
+}
+
+/**
+ * Transactions are stored as an object for easy updates & removal,
+ * but returned as an array for easier filtering. This function is not exported
+ * to prevent people from acting on completed transactions but forgetting to
+ * remove them from the cache, causing bugs in their app when they try to act
+ * on the same transactions again
+ */
+function getCachedTransactions (): CachedTransaction[] {
+    const txs = storage.get(STORAGE_KEY);
+    return Object.keys(txs).reduce(
+        (arr: CachedTransaction[], hash: string) => {
+            arr.push(txs[hash]);
+            return arr;
+        },
+        []
+    );
+}
+
+/**
+ * Get only completed transactions. This function is not exported to prevent
+ * people from acting on completed transactions but forgetting to remove them
+ * from the cache, causing bugs in their app when they try to act on the same
+ * completed transactions again
+ */
+function getCompletedTransactions(): CompletedTransaction[] {
+    return getCachedTransactions()
+        .filter(t => t.complete === true) as CompletedTransaction[];
+}
+
+/**
+ * A wrapper for the collection of completed, cached transactions which
+ * provides safe interfaces for inspecting and removing them from the
+ * underlying cache.
+ */
+export class CompletedTransactions {
+    /**
+     * Find and remove an item from the cache. Works like `Array.prototype.find`,
+     * but removes the item from the underlying cache if found.
+     *
+     * If you pass `meta` data to a `changeMethod` on a {@link Contract} or to
+     * {@link Account.functionCall}, the transaction will be automatically
+     * added to a cache. Whether or not the function call results in a redirect
+     * to NEAR Wallet, your app can then call {@link CompletedTransactions.remove},
+     * and find the transaction using the provided `meta` data, to determine
+     * the outcome of the transaction and update app state accordingly.
+     *
+     * Example:
+     *
+     * ```js
+     * const id = 1; // this is specific to and tracked by your app
+     * const completedTx = new CompletedTransactions().remove(tx => tx.meta.id === id)
+     * if (completedTx) {
+     *   // do app stuff, dealing with completed transaction
+     * } else {
+     *   const contract = new Contract(someAccount, 'some-address', { changeMethods: ['doThing'] })
+     *   contract.doThing(
+     *     { arg1: 'whatever' }, // arguments passed to `doThing` method
+     *     { meta: { id } } // options for near-api-js
+     *   )
+     * }
+     * ```
+     */
+    remove(finder: (tx: CompletedTransaction) => CompletedTransaction | null): CompletedTransaction | null {
+        const found = getCompletedTransactions().find(finder);
+
+        if (found) {
+            removeCachedTransaction(found.hash);
+            return found;
+        }
+
+        return null;
+    }
+}

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -1,8 +1,9 @@
 import BN from 'bn.js';
 import depd from 'depd';
-import { Account, ChangeMethodOptions } from './account';
+import { Account } from './account';
 import { getTransactionLastResult } from './providers';
 import { PositionalArgsError, ArgumentTypeError } from './utils/errors';
+import { ChangeMethodOptions, ConnectedWalletAccount } from './wallet-account';
 
 // Makes `function.name` return given name
 function nameFunction(name: string, body: (args?: any[]) => {}) {
@@ -22,7 +23,7 @@ const isObject = (x: any) =>
  * Defines a smart contract on NEAR including the mutable and non-mutable methods
  */
 export class Contract {
-    readonly account: Account;
+    readonly account: Account | ConnectedWalletAccount;
     readonly contractId: string;
 
     constructor(account: Account, contractId: string, options: { viewMethods: string[]; changeMethods: string[] }) {

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,14 +1,25 @@
-
-import { Provider, FinalExecutionOutcome, ExecutionOutcomeWithId, getTransactionLastResult, FinalExecutionStatusBasic } from './provider';
-import { JsonRpcProvider, TypedError, ErrorContext } from './json-rpc-provider';
+import {
+    ExecutionOutcomeWithId,
+    FinalExecutionOutcome,
+    FinalExecutionStatus,
+    FinalExecutionStatusBasic,
+    Provider,
+    getTransactionLastResult
+} from './provider';
+import {
+    ErrorContext,
+    JsonRpcProvider,
+    TypedError
+} from './json-rpc-provider';
 
 export {
-    Provider,
-    FinalExecutionOutcome,
-    JsonRpcProvider,
+    ErrorContext,
     ExecutionOutcomeWithId,
+    FinalExecutionOutcome,
+    FinalExecutionStatus,
     FinalExecutionStatusBasic,
-    getTransactionLastResult,
+    JsonRpcProvider,
+    Provider,
     TypedError,
-    ErrorContext
+    getTransactionLastResult
 };

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,0 +1,37 @@
+if (typeof localStorage === 'undefined' || localStorage === null) {
+    const { LocalStorage } = require('node-localstorage'); // eslint-disable-line @typescript-eslint/no-var-requires
+    localStorage = new LocalStorage(process.env.NEAR_CACHE_DIR || '~/.near-api-js');
+}
+
+const BASE_KEY = 'near-api-js.internal-cache';
+
+/**
+ * A low-level wrapper around localStorage.getItem (using node-localstorage
+ * library for Node). Prefer using one of these higher-level libraries instead:
+ *   - {@link CompletedTransactions}
+ */
+export function get (key: string) {
+    try {
+        const serializedState = localStorage.getItem(key);
+        if (serializedState === null) {
+            return undefined;
+        }
+        return JSON.parse(serializedState);
+    } catch (err) {
+        console.error(`Something went wrong getting key:${key} from localStorage in near-api-js`);
+        throw err;
+    }
+}
+
+/**
+ * A low-level wrapper around localStorage.setItem (using node-localstorage
+ * library for Node). Prefer using one of these higher-level libraries instead:
+ *   - {@link CompletedTransactions}
+ */
+export function set (key: string, state: any) {
+    if (!key || !state) {
+        throw new Error('expected two arguments, only got one');
+    }
+    const serializedState = JSON.stringify(state);
+    localStorage.setItem(`${BASE_KEY}.${key}`, serializedState);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -561,6 +561,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/bs58@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@types/bs58/-/bs58-4.0.1.tgz#3d51222aab067786d3bc3740a84a7f5a0effaa37"
+  integrity sha512-yfAgiWgVLjFCmRv8zAcOIHywYATEwiTVccTLnRp6UxTNavT55M9d/uhK3T03St/+8/z/wW+CRjGKUNmEqoHHCA==
+  dependencies:
+    base-x "^3.0.6"
+
 "@types/depd@^1.1.32":
   version "1.1.32"
   resolved "https://registry.yarnpkg.com/@types/depd/-/depd-1.1.32.tgz#7937f66870d0cd7a9881152e4eb02c8c43298f11"
@@ -971,7 +978,7 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
   integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
 
-base-x@^3.0.2:
+base-x@^3.0.2, base-x@^3.0.6:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/base-x/-/base-x-3.0.8.tgz#1e1106c2537f0162e8b52474a557ebb09000018d"
   integrity sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -561,6 +561,13 @@
   dependencies:
     "@types/node" "*"
 
+"@types/depd@^1.1.32":
+  version "1.1.32"
+  resolved "https://registry.yarnpkg.com/@types/depd/-/depd-1.1.32.tgz#7937f66870d0cd7a9881152e4eb02c8c43298f11"
+  integrity sha512-kB2cpXs3A0TGWl4a4h74yIwvclYZUTW6Irpee/3Dc1s4Cr5rGPHtpGPpBBpEV1MaKH5z/oul+57oDkEkeRXRnw==
+  dependencies:
+    "@types/node" "*"
+
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
@@ -2341,7 +2348,7 @@ globals@^12.1.0:
   dependencies:
     type-fest "^0.8.1"
 
-graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4:
+graceful-fs@^4.1.11, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4:
   version "4.2.4"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
@@ -3741,6 +3748,13 @@ node-int64@^0.4.0:
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
   integrity sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=
 
+node-localstorage@^2.1.6:
+  version "2.1.6"
+  resolved "https://registry.yarnpkg.com/node-localstorage/-/node-localstorage-2.1.6.tgz#7c62120beff8abbf960c858da70fddcfc336898a"
+  integrity sha512-yE7AycE5G2hU55d+F7Ona9nx97C+enJzWWx6jrsji7fuPZFJOvuW3X/LKKAcXRBcEIJPDOKt8ZiFWFmShR/irg==
+  dependencies:
+    write-file-atomic "^1.1.4"
+
 node-modules-regexp@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/node-modules-regexp/-/node-modules-regexp-1.0.0.tgz#8d9dbe28964a4ac5712e9131642107c71e90ec40"
@@ -4555,6 +4569,11 @@ slice-ansi@^2.1.0:
     astral-regex "^1.0.0"
     is-fullwidth-code-point "^2.0.0"
 
+slide@^1.1.5:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/slide/-/slide-1.1.6.tgz#56eb027d65b4d2dce6cb2e2d32c4d4afc9e1d707"
+  integrity sha1-VusCfWW00tzmyy4tMsTUr8nh1wc=
+
 snapdragon-node@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"
@@ -5368,6 +5387,15 @@ wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
   integrity sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
+
+write-file-atomic@^1.1.4:
+  version "1.3.4"
+  resolved "https://registry.yarnpkg.com/write-file-atomic/-/write-file-atomic-1.3.4.tgz#f807a4f0b1d9e913ae7a48112e6cc3af1991b45f"
+  integrity sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=
+  dependencies:
+    graceful-fs "^4.1.11"
+    imurmurhash "^0.1.4"
+    slide "^1.1.5"
 
 write-file-atomic@^3.0.0:
   version "3.0.3"


### PR DESCRIPTION
For an example of how this would be used, see https://github.com/near/rainbow-bridge-frontend/pull/48

Sometimes a transaction requires confirmation in NEAR Wallet.

1. `Person` takes action in `App`
2. `App` calls `Function` in `Contract` on behalf of `Person`
3. `Function` requires confirmation from `Person`. This could happen if:
   * `Function` has an attached deposit
   * `Person` signed into `App` using a contract other than `Contract` (`walletConnection.requestSignIn(contractName)` was given a `contractName` other than the name of `Contract`)
   * `Person` signed into `App` using `Contract`, which grantend a FunctionCall access key to `App`, but this access key ran out of allowance
4. near-api-js redirects to NEAR Wallet
5. `Person` clicks Approve or Deny
6. NEAR Wallet redirects back to `App`
7. `App` needs to figure out if the call to `Function` succeeded or failed

near-api-js provides two main ways for `App` to call `Function`:

* `Account.functionCall`
* A `changeMethod` on a `Contract` – under the hood, this calls `Account.functionCall`

Both of these previously accepted positional arguments for `gas` and `deposit`. Instead, now they accept an `options` object, with `gas` and `deposit` keys. In addition, you can provide a `meta` key, with its value a free-form object. If `meta` is provided, this transaction will be saved to a cache, along with your `meta` data. Whether or not the transaction results in a redirect to NEAR Wallet, once complete you can check the outcome in `walletConnection.completedTransactions`.

For now, `completedTransactions` only provides one way to look up a specific completed transaction: the `remove` method. Your app will only want to process a completed transaction once, so this method automatically removes a found transaction from the underlying cache.

Where is the cache? If in a browser, near-api-js will use localStorage. If used from Node, near-api-js imports the `node-localstorage` module, which writes the data to a file. By default, this file will live in `~/.near-api-js`, but you can pick a different folder by setting the `NEAR_CACHE_DIR` environment variable.