### PR TITLE
Adding keyPath uses that keystore first

### DIFF
--- a/src/near.ts
+++ b/src/near.ts
@@ -112,7 +112,7 @@ export async function connect(config: ConnectConfig): Promise<Near> {
                 if (!config.masterAccount) {
                     config.masterAccount = accountKeyFile[0];
                 }
-                config.deps.keyStore = new MergeKeyStore([config.deps.keyStore, keyPathStore]);
+                config.deps.keyStore = new MergeKeyStore([keyPathStore, config.deps.keyStore]);
                 console.log(`Loaded master account ${accountKeyFile[0]} key from ${config.keyPath} with public key = ${keyPair.getPublicKey()}`);
             }
         } catch (error) {


### PR DESCRIPTION
I've noticed this on and off and finally figured out it's a one-liner.
When I create a function-call access key for an account and then specify it as the `keyPath`, the full access key was being used.
When a person specifies the keyPath, I believe that means, "Please use this keystore first, as I'm specifying to use it." Instead it's added to the end of the MergeKeyStore, so it's the last keystore to be checked.
This simply flips that so the first keystore used is the one specified by keyPath.