### PR TITLE
Don't fetch account state pre-emptively

### DIFF
--- a/lib/account.d.ts
+++ b/lib/account.d.ts
@@ -24,14 +24,8 @@ declare function parseJsonFromRawResponse(response: Uint8Array): any;
 export declare class Account {
     readonly connection: Connection;
     readonly accountId: string;
-    private _state;
-    private _ready;
     protected get ready(): Promise<void>;
     constructor(connection: Connection, accountId: string);
-    /**
-     * Helper function when getting the state of a NEAR account
-     * @returns Promise<void>
-     */
     fetchState(): Promise<void>;
     /**
      * Returns the state of a NEAR account

--- a/lib/account.js
+++ b/lib/account.js
@@ -5,6 +5,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.Account = void 0;
 const bn_js_1 = __importDefault(require("bn.js"));
+const depd_1 = __importDefault(require("depd"));
 const transaction_1 = require("./transaction");
 const providers_1 = require("./providers");
 const borsh_1 = require("borsh");
@@ -38,22 +39,20 @@ class Account {
         this.accountId = accountId;
     }
     get ready() {
-        return this._ready || (this._ready = Promise.resolve(this.fetchState()));
+        const deprecate = depd_1.default('Account.ready()');
+        deprecate('not needed anymore, cannot be in not ready state');
+        return Promise.resolve();
     }
-    /**
-     * Helper function when getting the state of a NEAR account
-     * @returns Promise<void>
-     */
     async fetchState() {
-        this._state = await this.connection.provider.query(`account/${this.accountId}`, '');
+        const deprecate = depd_1.default('Account.fetchState()');
+        deprecate('use `Account.state()` instead');
     }
     /**
      * Returns the state of a NEAR account
      * @returns {Promise<AccountState>}
      */
     async state() {
-        await this.ready;
-        return this._state;
+        return await this.connection.provider.query(`account/${this.accountId}`, '');
     }
     printLogsAndFailures(contractId, results) {
         for (const result of results) {
@@ -70,7 +69,6 @@ class Account {
         }
     }
     async signTransaction(receiverId, actions) {
-        await this.ready;
         const accessKeyInfo = await this.findAccessKey(receiverId, actions);
         if (!accessKeyInfo) {
             throw new providers_1.TypedError(`Can not sign transactions for account ${this.accountId} on network ${this.connection.networkId}, no matching key pair found in ${this.connection.signer}.`, 'KeyNotFound');
@@ -87,7 +85,6 @@ class Account {
      * @returns {Promise<FinalExecutionOutcome>}
      */
     async signAndSendTransaction(receiverId, actions) {
-        await this.ready;
         let txHash, signedTx;
         // TODO: TX_NONCE (different constants for different uses of exponentialBackoff?)
         const result = await exponential_backoff_1.default(TX_NONCE_RETRY_WAIT, TX_NONCE_RETRY_NUMBER, TX_NONCE_RETRY_WAIT_BACKOFF, async () => {

--- a/lib/near.js
+++ b/lib/near.js
@@ -36,7 +36,6 @@ class Near {
      */
     async account(accountId) {
         const account = new account_1.Account(this.connection, accountId);
-        await account.state();
         return account;
     }
     /**

--- a/lib/wallet-account.js
+++ b/lib/wallet-account.js
@@ -149,7 +149,6 @@ class ConnectedWalletAccount extends account_1.Account {
     }
     // Overriding Account methods
     async signAndSendTransaction(receiverId, actions) {
-        await this.ready;
         const localKey = await this.connection.signer.getPublicKey(this.accountId, this.connection.networkId);
         let accessKey = await this.accessKeyForTransaction(receiverId, actions, localKey);
         if (!accessKey) {

--- a/src/account.ts
+++ b/src/account.ts
@@ -1,6 +1,7 @@
 'use strict';
 
 import BN from 'bn.js';
+import depd from 'depd';
 import {
     transfer,
     createAccount,
@@ -76,9 +77,20 @@ export class Account {
     readonly connection: Connection;
     readonly accountId: string;
 
+    protected get ready(): Promise<void> {
+        const deprecate = depd('Account.ready()');
+        deprecate('not needed anymore, always ready');
+        return Promise.resolve();
+    }
+
     constructor(connection: Connection, accountId: string) {
         this.connection = connection;
         this.accountId = accountId;
+    }
+
+    async fetchState(): Promise<void> {
+        const deprecate = depd('Account.fetchState()');
+        deprecate('use `Account.state()` instead');
     }
 
     /**

--- a/src/near.ts
+++ b/src/near.ts
@@ -49,7 +49,6 @@ export class Near {
      */
     async account(accountId: string): Promise<Account> {
         const account = new Account(this.connection, accountId);
-        await account.state();
         return account;
     }
 

--- a/src/wallet-account.ts
+++ b/src/wallet-account.ts
@@ -178,8 +178,6 @@ class ConnectedWalletAccount extends Account {
     // Overriding Account methods
 
     protected async signAndSendTransaction(receiverId: string, actions: Action[]): Promise<FinalExecutionOutcome> {
-        await this.ready;
-
         const localKey = await this.connection.signer.getPublicKey(this.accountId, this.connection.networkId);
         let accessKey = await this.accessKeyForTransaction(receiverId, actions, localKey);
         if (!accessKey) {

--- a/test/account.test.js
+++ b/test/account.test.js
@@ -45,8 +45,6 @@ test('send money', async() => {
     const receiver = await testUtils.createAccount(nearjs);
     const { amount: receiverAmount } = await receiver.state();
     await sender.sendMoney(receiver.accountId, new BN(10000));
-    await receiver.fetchState();
-    // TODO: Why `.state()` is not fetching state?
     const state = await receiver.state();
     expect(state.amount).toEqual(new BN(receiverAmount).add(new BN(10000)).toString());
 });

--- a/test/account_multisig.test.js
+++ b/test/account_multisig.test.js
@@ -113,7 +113,6 @@ describe('account2fa transactions', () => {
         receiver = await getAccount2FA(receiver);
         const { amount: receiverAmount } = await receiver.state();
         await sender.sendMoney(receiver.accountId, new BN(parseNearAmount('1')));
-        await receiver.fetchState();
         const state = await receiver.state();
         expect(BigInt(state.amount)).toBeGreaterThanOrEqual(BigInt(new BN(receiverAmount).add(new BN(parseNearAmount('0.9'))).toString()));
     });


### PR DESCRIPTION
This creates extra RPC requests and seems to be there only for historic reasons.