### PR TITLE
Types added to some JSON RPC errors

### DIFF
--- a/lib/account.js
+++ b/lib/account.js
@@ -116,7 +116,7 @@ class Account {
                 return result;
             }
             catch (error) {
-                if (error.message.match(/Transaction nonce \d+ must be larger than nonce of the used access key \d+/)) {
+                if (error.type === 'InvalidNonce') {
                     console.warn(`Retrying transaction ${receiverId}:${borsh_1.baseEncode(txHash)} with new nonce.`);
                     delete this.accessKeyByPublicKeyCache[publicKey.toString()];
                     return null;

--- a/lib/providers/json-rpc-provider.js
+++ b/lib/providers/json-rpc-provider.js
@@ -70,7 +70,7 @@ class JsonRpcProvider extends provider_1.Provider {
             result = await this.sendJsonRpc('query', [path, data]);
         }
         if (result && result.error) {
-            throw new Error(`Querying ${args} failed: ${result.error}.\n${JSON.stringify(result, null, 2)}`);
+            throw new errors_1.TypedError(`Querying ${args} failed: ${result.error}.\n${JSON.stringify(result, null, 2)}`, rpc_errors_1.getErrorTypeFromErrorMessage(result.error));
         }
         return result;
     }
@@ -160,7 +160,7 @@ class JsonRpcProvider extends provider_1.Provider {
                     throw new errors_1.TypedError('send_tx_commit has timed out.', 'TimeoutError');
                 }
                 else {
-                    throw new errors_1.TypedError(errorMessage);
+                    throw new errors_1.TypedError(errorMessage, rpc_errors_1.getErrorTypeFromErrorMessage(response.error.data));
                 }
             }
         }

--- a/lib/utils/rpc_errors.d.ts
+++ b/lib/utils/rpc_errors.d.ts
@@ -6,3 +6,4 @@ declare class ServerTransactionError extends ServerError {
 export declare function parseRpcError(errorObj: Record<string, any>): ServerError;
 export declare function parseResultError(result: any): ServerTransactionError;
 export declare function formatError(errorClassName: string, errorData: any): string;
+export declare function getErrorTypeFromErrorMessage(errorMessage: any): "UntypedError" | "CodeDoesNotExist" | "AccountDoesNotExist" | "AccessKeyDoesNotExist";

--- a/lib/utils/rpc_errors.js
+++ b/lib/utils/rpc_errors.js
@@ -103,6 +103,7 @@ function walkSubtype(errorObj, schema, result, typeName) {
     }
 }
 function getErrorTypeFromErrorMessage(errorMessage) {
+    // This function should be removed when JSON RPC starts returning typed errors.
     switch (true) {
         case /^account .*? does not exist while viewing$/.test(errorMessage):
             return 'AccountDoesNotExist';

--- a/lib/utils/rpc_errors.js
+++ b/lib/utils/rpc_errors.js
@@ -25,7 +25,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.formatError = exports.parseResultError = exports.parseRpcError = void 0;
+exports.getErrorTypeFromErrorMessage = exports.formatError = exports.parseResultError = exports.parseRpcError = void 0;
 const mustache_1 = __importDefault(require("mustache"));
 const rpc_error_schema_json_1 = __importDefault(require("../generated/rpc_error_schema.json"));
 const error_messages_json_1 = __importDefault(require("../res/error_messages.json"));
@@ -102,6 +102,21 @@ function walkSubtype(errorObj, schema, result, typeName) {
         return typeName;
     }
 }
+function getErrorTypeFromErrorMessage(errorMessage) {
+    switch (true) {
+        case /^account .*? does not exist while viewing$/.test(errorMessage):
+            return 'AccountDoesNotExist';
+        case /^Account .*? doesn't exist$/.test(errorMessage):
+            return 'AccountDoesNotExist';
+        case /^access key .*? does not exist while viewing$/.test(errorMessage):
+            return 'AccessKeyDoesNotExist';
+        case /wasm execution failed with error: FunctionCallError\(CompilationError\(CodeDoesNotExist/.test(errorMessage):
+            return 'CodeDoesNotExist';
+        default:
+            return 'UntypedError';
+    }
+}
+exports.getErrorTypeFromErrorMessage = getErrorTypeFromErrorMessage;
 /**
  * Helper function determining if the argument is an object
  * @param n Value to check

--- a/lib/wallet-account.js
+++ b/lib/wallet-account.js
@@ -160,8 +160,7 @@ class ConnectedWalletAccount extends account_1.Account {
                 return await super.signAndSendTransaction(receiverId, actions);
             }
             catch (e) {
-                // TODO: Use TypedError when available
-                if (e.message.includes('does not have enough balance')) {
+                if (e.type === 'NotEnoughBalance') {
                     accessKey = await this.accessKeyForTransaction(receiverId, actions);
                 }
                 else {

--- a/src/account.ts
+++ b/src/account.ts
@@ -178,7 +178,7 @@ export class Account {
                 }
                 return result;
             } catch (error) {
-                if (error.message.match(/Transaction nonce \d+ must be larger than nonce of the used access key \d+/)) {
+                if (error.type === 'InvalidNonce') {
                     console.warn(`Retrying transaction ${receiverId}:${baseEncode(txHash)} with new nonce.`);
                     delete this.accessKeyByPublicKeyCache[publicKey.toString()];
                     return null;

--- a/src/providers/json-rpc-provider.ts
+++ b/src/providers/json-rpc-provider.ts
@@ -8,7 +8,7 @@ import { Network } from '../utils/network';
 import { ConnectionInfo, fetchJson } from '../utils/web';
 import { TypedError, ErrorContext } from '../utils/errors';
 import { baseEncode } from 'borsh';
-import { parseRpcError } from '../utils/rpc_errors';
+import { parseRpcError, getErrorTypeFromErrorMessage } from '../utils/rpc_errors';
 import { SignedTransaction } from '../transaction';
 
 export { TypedError, ErrorContext };
@@ -78,7 +78,9 @@ export class JsonRpcProvider extends Provider {
             result = await this.sendJsonRpc('query', [path, data]);
         }
         if (result && result.error) {
-            throw new Error(`Querying ${args} failed: ${result.error}.\n${JSON.stringify(result, null, 2)}`);
+            throw new TypedError(
+                `Querying ${args} failed: ${result.error}.\n${JSON.stringify(result, null, 2)}`,
+                getErrorTypeFromErrorMessage(result.error));
         }
         return result;
     }
@@ -174,7 +176,7 @@ export class JsonRpcProvider extends Provider {
                 if (response.error.data === 'Timeout' || errorMessage.includes('Timeout error')) {
                     throw new TypedError('send_tx_commit has timed out.', 'TimeoutError');
                 } else {
-                    throw new TypedError(errorMessage);
+                    throw new TypedError(errorMessage, getErrorTypeFromErrorMessage(response.error.data));
                 }
             }
         }

--- a/src/utils/rpc_errors.ts
+++ b/src/utils/rpc_errors.ts
@@ -78,6 +78,7 @@ function walkSubtype(errorObj, schema, result, typeName) {
 }
 
 export function getErrorTypeFromErrorMessage(errorMessage) {
+    // This function should be removed when JSON RPC starts returning typed errors.
     switch (true) {
         case /^account .*? does not exist while viewing$/.test(errorMessage):
             return 'AccountDoesNotExist';

--- a/src/utils/rpc_errors.ts
+++ b/src/utils/rpc_errors.ts
@@ -77,6 +77,21 @@ function walkSubtype(errorObj, schema, result, typeName) {
     }
 }
 
+export function getErrorTypeFromErrorMessage(errorMessage) {
+    switch (true) {
+        case /^account .*? does not exist while viewing$/.test(errorMessage):
+            return 'AccountDoesNotExist';
+        case /^Account .*? doesn't exist$/.test(errorMessage):
+            return 'AccountDoesNotExist';
+        case /^access key .*? does not exist while viewing$/.test(errorMessage):
+            return 'AccessKeyDoesNotExist';
+        case /wasm execution failed with error: FunctionCallError\(CompilationError\(CodeDoesNotExist/.test(errorMessage):
+            return 'CodeDoesNotExist';
+        default:
+            return 'UntypedError';
+    }
+}
+
 /**
  * Helper function determining if the argument is an object
  * @param n Value to check

--- a/src/utils/rpc_errors.ts
+++ b/src/utils/rpc_errors.ts
@@ -80,16 +80,16 @@ function walkSubtype(errorObj, schema, result, typeName) {
 export function getErrorTypeFromErrorMessage(errorMessage) {
     // This function should be removed when JSON RPC starts returning typed errors.
     switch (true) {
-        case /^account .*? does not exist while viewing$/.test(errorMessage):
-            return 'AccountDoesNotExist';
-        case /^Account .*? doesn't exist$/.test(errorMessage):
-            return 'AccountDoesNotExist';
-        case /^access key .*? does not exist while viewing$/.test(errorMessage):
-            return 'AccessKeyDoesNotExist';
-        case /wasm execution failed with error: FunctionCallError\(CompilationError\(CodeDoesNotExist/.test(errorMessage):
-            return 'CodeDoesNotExist';
-        default:
-            return 'UntypedError';
+    case /^account .*? does not exist while viewing$/.test(errorMessage):
+        return 'AccountDoesNotExist';
+    case /^Account .*? doesn't exist$/.test(errorMessage):
+        return 'AccountDoesNotExist';
+    case /^access key .*? does not exist while viewing$/.test(errorMessage):
+        return 'AccessKeyDoesNotExist';
+    case /wasm execution failed with error: FunctionCallError\(CompilationError\(CodeDoesNotExist/.test(errorMessage):
+        return 'CodeDoesNotExist';
+    default:
+        return 'UntypedError';
     }
 }
 

--- a/src/wallet-account.ts
+++ b/src/wallet-account.ts
@@ -190,8 +190,7 @@ class ConnectedWalletAccount extends Account {
             try {
                 return await super.signAndSendTransaction(receiverId, actions);
             } catch (e) {
-                // TODO: Use TypedError when available
-                if (e.message.includes('does not have enough balance')) {
+                if (e.type === 'NotEnoughBalance') {
                     accessKey = await this.accessKeyForTransaction(receiverId, actions);
                 } else {
                     throw e;

--- a/test/utils/rpc-errors.test.js
+++ b/test/utils/rpc-errors.test.js
@@ -110,9 +110,9 @@ describe('rpc-errors', () => {
 
     test('test getErrorTypeFromErrorMessage', () => {
         const err1 = 'account random.near does not exist while viewing';
-        const err2 = "Account random2.testnet doesn't exist";
+        const err2 = 'Account random2.testnet doesn\'t exist';
         const err3 = 'access key ed25519:DvXowCpBHKdbD2qutgfhG6jvBMaXyUh7DxrDSjkLxMHp does not exist while viewing';
-        const err4 = 'wasm execution failed with error: FunctionCallError(CompilationError(CodeDoesNotExist { account_id: \"random.testnet\" }))';
+        const err4 = 'wasm execution failed with error: FunctionCallError(CompilationError(CodeDoesNotExist { account_id: "random.testnet" }))';
         expect(getErrorTypeFromErrorMessage(err1)).toEqual('AccountDoesNotExist');
         expect(getErrorTypeFromErrorMessage(err2)).toEqual('AccountDoesNotExist');
         expect(getErrorTypeFromErrorMessage(err3)).toEqual('AccessKeyDoesNotExist');

--- a/test/utils/rpc-errors.test.js
+++ b/test/utils/rpc-errors.test.js
@@ -11,7 +11,8 @@ const {
     HostError,
     InvalidIteratorIndex,
     GasLimitExceeded,
-    formatError
+    formatError,
+    getErrorTypeFromErrorMessage,
 } = nearApi.utils.rpc_errors;
 describe('rpc-errors', () => {
     test('test AccountAlreadyExists error', async () => {
@@ -107,4 +108,17 @@ describe('rpc-errors', () => {
         expect(error).toEqual(new FunctionCallError('{"index":0,"kind":{"EvmError":"ArgumentParseError"}}'));
     });
 
+    test('test getErrorTypeFromErrorMessage', () => {
+        const err1 = 'account random.near does not exist while viewing';
+        const err2 = "Account random2.testnet doesn't exist";
+        const err3 = 'access key ed25519:DvXowCpBHKdbD2qutgfhG6jvBMaXyUh7DxrDSjkLxMHp does not exist while viewing';
+        const err4 = 'wasm execution failed with error: FunctionCallError(CompilationError(CodeDoesNotExist { account_id: \"random.testnet\" }))';
+        expect(getErrorTypeFromErrorMessage(err1)).toEqual('AccountDoesNotExist');
+        expect(getErrorTypeFromErrorMessage(err2)).toEqual('AccountDoesNotExist');
+        expect(getErrorTypeFromErrorMessage(err3)).toEqual('AccessKeyDoesNotExist');
+        expect(getErrorTypeFromErrorMessage(err4)).toEqual('CodeDoesNotExist');
+        expect(getErrorTypeFromErrorMessage('random string')).toEqual('UntypedError');
+        expect(getErrorTypeFromErrorMessage(undefined)).toEqual('UntypedError');
+        expect(getErrorTypeFromErrorMessage('')).toEqual('UntypedError');
+    });
 });


### PR DESCRIPTION
To avoid the situations where we are matching string errors with the use of `match`, `indexOf`, or `includes` we can do this only once in JSON RPC provider.
This logic can be deleted when `nearcore` will start returning typed errors.