### PR TITLE
Implement timeout handling at sendJsonRpc level

### DIFF
--- a/lib/account.js
+++ b/lib/account.js
@@ -21,12 +21,10 @@ const exponential_backoff_1 = __importDefault(require("./utils/exponential-backo
 const DEFAULT_FUNC_CALL_GAS = new bn_js_1.default('30000000000000');
 // Default number of retries with different nonce before giving up on a transaction.
 const TX_NONCE_RETRY_NUMBER = 12;
-// Default number of retries before giving up on a transaction.
-const TX_STATUS_RETRY_NUMBER = 12;
 // Default wait until next retry in millis.
-const TX_STATUS_RETRY_WAIT = 500;
+const TX_NONCE_RETRY_WAIT = 500;
 // Exponential back off for waiting to retry.
-const TX_STATUS_RETRY_WAIT_BACKOFF = 1.5;
+const TX_NONCE_RETRY_WAIT_BACKOFF = 1.5;
 function parseJsonFromRawResponse(response) {
     return JSON.parse(Buffer.from(response).toString());
 }
@@ -92,28 +90,11 @@ class Account {
         await this.ready;
         let txHash, signedTx;
         // TODO: TX_NONCE (different constants for different uses of exponentialBackoff?)
-        const result = await exponential_backoff_1.default(TX_STATUS_RETRY_WAIT, TX_NONCE_RETRY_NUMBER, TX_STATUS_RETRY_WAIT_BACKOFF, async () => {
+        const result = await exponential_backoff_1.default(TX_NONCE_RETRY_WAIT, TX_NONCE_RETRY_NUMBER, TX_NONCE_RETRY_WAIT_BACKOFF, async () => {
             [txHash, signedTx] = await this.signTransaction(receiverId, actions);
             const publicKey = signedTx.transaction.publicKey;
             try {
-                const result = await exponential_backoff_1.default(TX_STATUS_RETRY_WAIT, TX_STATUS_RETRY_NUMBER, TX_STATUS_RETRY_WAIT_BACKOFF, async () => {
-                    try {
-                        return await this.connection.provider.sendTransaction(signedTx);
-                    }
-                    catch (error) {
-                        // TODO: Somehow getting still:
-                        // Error: send_tx_commit has timed out.
-                        if (error.type === 'TimeoutError') {
-                            console.warn(`Retrying transaction ${receiverId}:${borsh_1.baseEncode(txHash)} as it has timed out`);
-                            return null;
-                        }
-                        throw error;
-                    }
-                });
-                if (!result) {
-                    throw new providers_1.TypedError(`Exceeded ${TX_STATUS_RETRY_NUMBER} attempts for transaction ${borsh_1.baseEncode(txHash)}.`, 'RetriesExceeded', new providers_1.ErrorContext(borsh_1.baseEncode(txHash)));
-                }
-                return result;
+                return await this.connection.provider.sendTransaction(signedTx);
             }
             catch (error) {
                 if (error.message.match(/Transaction nonce \d+ must be larger than nonce of the used access key \d+/)) {

--- a/lib/providers/json-rpc-provider.js
+++ b/lib/providers/json-rpc-provider.js
@@ -11,7 +11,14 @@ const errors_1 = require("../utils/errors");
 Object.defineProperty(exports, "TypedError", { enumerable: true, get: function () { return errors_1.TypedError; } });
 Object.defineProperty(exports, "ErrorContext", { enumerable: true, get: function () { return errors_1.ErrorContext; } });
 const borsh_1 = require("borsh");
+const exponential_backoff_1 = __importDefault(require("../utils/exponential-backoff"));
 const rpc_errors_1 = require("../utils/rpc_errors");
+// Default number of retries before giving up on a request.
+const REQUEST_RETRY_NUMBER = 12;
+// Default wait until next retry in millis.
+const REQUEST_RETRY_WAIT = 500;
+// Exponential back off for waiting to retry.
+const REQUEST_RETRY_WAIT_BACKOFF = 1.5;
 /// Keep ids unique across all connections.
 let _nextId = 123;
 class JsonRpcProvider extends provider_1.Provider {
@@ -135,36 +142,51 @@ class JsonRpcProvider extends provider_1.Provider {
      * @param params Parameters to the method
      */
     async sendJsonRpc(method, params) {
-        const request = {
-            method,
-            params,
-            id: (_nextId++),
-            jsonrpc: '2.0'
-        };
-        const response = await web_1.fetchJson(this.connection, JSON.stringify(request));
-        if (response.error) {
-            if (typeof response.error.data === 'object') {
-                if (typeof response.error.data.error_message === 'string' && typeof response.error.data.error_type === 'string') {
-                    // if error data has error_message and error_type properties, we consider that node returned an error in the old format
-                    throw new errors_1.TypedError(response.error.data.error_message, response.error.data.error_type);
+        const result = await exponential_backoff_1.default(REQUEST_RETRY_WAIT, REQUEST_RETRY_NUMBER, REQUEST_RETRY_WAIT_BACKOFF, async () => {
+            try {
+                const request = {
+                    method,
+                    params,
+                    id: (_nextId++),
+                    jsonrpc: '2.0'
+                };
+                const response = await web_1.fetchJson(this.connection, JSON.stringify(request));
+                if (response.error) {
+                    if (typeof response.error.data === 'object') {
+                        if (typeof response.error.data.error_message === 'string' && typeof response.error.data.error_type === 'string') {
+                            // if error data has error_message and error_type properties, we consider that node returned an error in the old format
+                            throw new errors_1.TypedError(response.error.data.error_message, response.error.data.error_type);
+                        }
+                        throw rpc_errors_1.parseRpcError(response.error.data);
+                    }
+                    else {
+                        const errorMessage = `[${response.error.code}] ${response.error.message}: ${response.error.data}`;
+                        // NOTE: All this hackery is happening because structured errors not implemented
+                        // TODO: Fix when https://github.com/nearprotocol/nearcore/issues/1839 gets resolved
+                        if (response.error.data === 'Timeout' || errorMessage.includes('Timeout error')
+                            || errorMessage.includes('query has timed out')) {
+                            throw new errors_1.TypedError(errorMessage, 'TimeoutError');
+                        }
+                        throw new errors_1.TypedError(errorMessage);
+                    }
                 }
-                else {
-                    throw rpc_errors_1.parseRpcError(response.error.data);
-                }
+                return response.result;
             }
-            else {
-                const errorMessage = `[${response.error.code}] ${response.error.message}: ${response.error.data}`;
-                // NOTE: All this hackery is happening because structured errors not implemented
-                // TODO: Fix when https://github.com/nearprotocol/nearcore/issues/1839 gets resolved
-                if (response.error.data === 'Timeout' || errorMessage.includes('Timeout error')) {
-                    throw new errors_1.TypedError('send_tx_commit has timed out.', 'TimeoutError');
+            catch (error) {
+                // TODO: Somehow getting still:
+                // Error: send_tx_commit has timed out.
+                // TODO: Check if nearcore still sends this or some other messages for timeout
+                if (error.type === 'TimeoutError') {
+                    console.warn(`Retrying request to ${method} as it has timed out`, params);
+                    return null;
                 }
-                else {
-                    throw new errors_1.TypedError(errorMessage);
-                }
+                throw error;
             }
+        });
+        if (!result) {
+            throw new errors_1.TypedError(`Exceeded ${REQUEST_RETRY_NUMBER} attempts for request to ${method}.`, 'RetriesExceeded');
         }
-        return response.result;
+        return result;
     }
 }
 exports.JsonRpcProvider = JsonRpcProvider;

--- a/src/account.ts
+++ b/src/account.ts
@@ -39,14 +39,11 @@ const DEFAULT_FUNC_CALL_GAS = new BN('30000000000000');
 // Default number of retries with different nonce before giving up on a transaction.
 const TX_NONCE_RETRY_NUMBER = 12;
 
-// Default number of retries before giving up on a transaction.
-const TX_STATUS_RETRY_NUMBER = 12;
-
 // Default wait until next retry in millis.
-const TX_STATUS_RETRY_WAIT = 500;
+const TX_NONCE_RETRY_WAIT = 500;
 
 // Exponential back off for waiting to retry.
-const TX_STATUS_RETRY_WAIT_BACKOFF = 1.5;
+const TX_NONCE_RETRY_WAIT_BACKOFF = 1.5;
 
 export interface AccountState {
     amount: string;
@@ -151,32 +148,12 @@ export class Account {
 
         let txHash, signedTx;
         // TODO: TX_NONCE (different constants for different uses of exponentialBackoff?)
-        const result = await exponentialBackoff(TX_STATUS_RETRY_WAIT, TX_NONCE_RETRY_NUMBER, TX_STATUS_RETRY_WAIT_BACKOFF, async () => {
+        const result = await exponentialBackoff(TX_NONCE_RETRY_WAIT, TX_NONCE_RETRY_NUMBER, TX_NONCE_RETRY_WAIT_BACKOFF, async () => {
             [txHash, signedTx] = await this.signTransaction(receiverId, actions);
             const publicKey = signedTx.transaction.publicKey;
 
             try {
-                const result = await exponentialBackoff(TX_STATUS_RETRY_WAIT, TX_STATUS_RETRY_NUMBER, TX_STATUS_RETRY_WAIT_BACKOFF, async () => {
-                    try {
-                        return await this.connection.provider.sendTransaction(signedTx);
-                    } catch (error) {
-                        // TODO: Somehow getting still:
-                        // Error: send_tx_commit has timed out.
-                        if (error.type === 'TimeoutError') {
-                            console.warn(`Retrying transaction ${receiverId}:${baseEncode(txHash)} as it has timed out`);
-                            return null;
-                        }
-
-                        throw error;
-                    }
-                });
-                if (!result) {
-                    throw new TypedError(
-                        `Exceeded ${TX_STATUS_RETRY_NUMBER} attempts for transaction ${baseEncode(txHash)}.`,
-                        'RetriesExceeded',
-                        new ErrorContext(baseEncode(txHash)));
-                }
-                return result;
+                return await this.connection.provider.sendTransaction(signedTx);
             } catch (error) {
                 if (error.message.match(/Transaction nonce \d+ must be larger than nonce of the used access key \d+/)) {
                     console.warn(`Retrying transaction ${receiverId}:${baseEncode(txHash)} with new nonce.`);

--- a/src/providers/json-rpc-provider.ts
+++ b/src/providers/json-rpc-provider.ts
@@ -193,9 +193,6 @@ export class JsonRpcProvider extends Provider {
                 }
                 return response.result;
             } catch (error) {
-                // TODO: Somehow getting still:
-                // Error: send_tx_commit has timed out.
-                // TODO: Check if nearcore still sends this or some other messages for timeout
                 if (error.type === 'TimeoutError') {
                     console.warn(`Retrying request to ${method} as it has timed out`, params);
                     return null;

--- a/src/providers/json-rpc-provider.ts
+++ b/src/providers/json-rpc-provider.ts
@@ -8,10 +8,20 @@ import { Network } from '../utils/network';
 import { ConnectionInfo, fetchJson } from '../utils/web';
 import { TypedError, ErrorContext } from '../utils/errors';
 import { baseEncode } from 'borsh';
+import exponentialBackoff from '../utils/exponential-backoff';
 import { parseRpcError } from '../utils/rpc_errors';
 import { SignedTransaction } from '../transaction';
 
 export { TypedError, ErrorContext };
+
+// Default number of retries before giving up on a request.
+const REQUEST_RETRY_NUMBER = 12;
+
+// Default wait until next retry in millis.
+const REQUEST_RETRY_WAIT = 500;
+
+// Exponential back off for waiting to retry.
+const REQUEST_RETRY_WAIT_BACKOFF = 1.5;
 
 /// Keep ids unique across all connections.
 let _nextId = 123;
@@ -152,32 +162,52 @@ export class JsonRpcProvider extends Provider {
      * @param params Parameters to the method
      */
     async sendJsonRpc(method: string, params: object): Promise<any> {
-        const request = {
-            method,
-            params,
-            id: (_nextId++),
-            jsonrpc: '2.0'
-        };
-        const response = await fetchJson(this.connection, JSON.stringify(request));
-        if (response.error) {
-            if (typeof response.error.data === 'object') {
-                if (typeof response.error.data.error_message === 'string' && typeof response.error.data.error_type === 'string') {
-                    // if error data has error_message and error_type properties, we consider that node returned an error in the old format
-                    throw new TypedError(response.error.data.error_message, response.error.data.error_type);
-                } else {
-                    throw parseRpcError(response.error.data);
+        const result = await exponentialBackoff(REQUEST_RETRY_WAIT, REQUEST_RETRY_NUMBER, REQUEST_RETRY_WAIT_BACKOFF, async () => {
+            try {
+                const request = {
+                    method,
+                    params,
+                    id: (_nextId++),
+                    jsonrpc: '2.0'
+                };
+                const response = await fetchJson(this.connection, JSON.stringify(request));
+                if (response.error) {
+                    if (typeof response.error.data === 'object') {
+                        if (typeof response.error.data.error_message === 'string' && typeof response.error.data.error_type === 'string') {
+                            // if error data has error_message and error_type properties, we consider that node returned an error in the old format
+                            throw new TypedError(response.error.data.error_message, response.error.data.error_type);
+                        }
+                        
+                        throw parseRpcError(response.error.data);
+                    } else {
+                        const errorMessage = `[${response.error.code}] ${response.error.message}: ${response.error.data}`;
+                        // NOTE: All this hackery is happening because structured errors not implemented
+                        // TODO: Fix when https://github.com/nearprotocol/nearcore/issues/1839 gets resolved
+                        if (response.error.data === 'Timeout' || errorMessage.includes('Timeout error')
+                                || errorMessage.includes('query has timed out')) {
+                            throw new TypedError(errorMessage, 'TimeoutError');
+                        }
+
+                        throw new TypedError(errorMessage);
+                    }
                 }
-            } else {
-                const errorMessage = `[${response.error.code}] ${response.error.message}: ${response.error.data}`;
-                // NOTE: All this hackery is happening because structured errors not implemented
-                // TODO: Fix when https://github.com/nearprotocol/nearcore/issues/1839 gets resolved
-                if (response.error.data === 'Timeout' || errorMessage.includes('Timeout error')) {
-                    throw new TypedError('send_tx_commit has timed out.', 'TimeoutError');
-                } else {
-                    throw new TypedError(errorMessage);
+                return response.result;
+            } catch (error) {
+                // TODO: Somehow getting still:
+                // Error: send_tx_commit has timed out.
+                // TODO: Check if nearcore still sends this or some other messages for timeout
+                if (error.type === 'TimeoutError') {
+                    console.warn(`Retrying request to ${method} as it has timed out`, params);
+                    return null;
                 }
+
+                throw error;
             }
+        });
+        if (!result) {
+            throw new TypedError(
+                `Exceeded ${REQUEST_RETRY_NUMBER} attempts for request to ${method}.`, 'RetriesExceeded');
         }
-        return response.result;
+        return result;
     }
 }


### PR DESCRIPTION
This change basically moves existing exponential retry logic from Account deeper.

Also handling `query has timed out` popping up on some endpoints under load.

This fixes multiples problems which are both reported on users and popping up on Sentry (once nearcore RPC is failing under load):
https://sentry.io/organizations/near-protocol/issues/1953747896/?project=5396205&query=is%3Aunresolved&sort=freq&statsPeriod=14d
https://sentry.io/organizations/near-protocol/issues/2124349518/?project=5396205&query=is%3Aunresolved&sort=freq&statsPeriod=14d
https://sentry.io/organizations/near-protocol/issues/1927563464/?project=5396205&query=is%3Aunresolved&sort=freq&statsPeriod=14d
https://sentry.io/organizations/near-protocol/issues/2112717975/?project=5396205&query=is%3Aunresolved&sort=freq&statsPeriod=14d
https://sentry.io/organizations/near-protocol/issues/2125663232/?project=5396205&query=is%3Aunresolved&sort=freq&statsPeriod=14d