### PR TITLE
Fix documentation links for JSON-RPC provider

### DIFF
--- a/src/providers/json-rpc-provider.ts
+++ b/src/providers/json-rpc-provider.ts
@@ -57,7 +57,7 @@ export class JsonRpcProvider extends Provider {
 
     /**
      * Gets the RPC's status
-     * See [docs for more info](https://docs.nearprotocol.com/docs/interaction/rpc#status)
+     * See [docs for more info](https://docs.near.org/docs/develop/front-end/rpc#general-validator-status)
      * @returns {Promise<NodeStatusResult>}
      */
     async status(): Promise<NodeStatusResult> {
@@ -66,7 +66,7 @@ export class JsonRpcProvider extends Provider {
 
     /**
      * Sends a signed transaction to the RPC
-     * See [docs for more info](https://docs.nearprotocol.com/docs/interaction/rpc#send-transaction-wait-until-done)
+     * See [docs for more info](https://docs.near.org/docs/develop/front-end/rpc#send-transaction-await)
      * @param signedTransaction The signed transaction being sent
      * @returns {Promise<FinalExecutionOutcome>}
      */
@@ -77,7 +77,7 @@ export class JsonRpcProvider extends Provider {
 
     /**
      * Gets a transaction's status from the RPC
-     * See [docs for more info](https://docs.nearprotocol.com/docs/interaction/rpc#status)
+     * See [docs for more info](https://docs.near.org/docs/develop/front-end/rpc#transaction-status)
      * @param txHash The hash of the transaction
      * @param accountId The NEAR account that signed the transaction
      * @returns {Promise<FinalExecutionOutcome>}
@@ -87,7 +87,7 @@ export class JsonRpcProvider extends Provider {
     }
 
     /**
-     * Query the RPC as [shown in the docs](https://docs.nearprotocol.com/docs/interaction/rpc#query)
+     * Query the RPC as [shown in the docs](https://docs.near.org/docs/develop/front-end/rpc#accounts--contracts)
      */
     async query(...args: any[]): Promise<any> {
         let result;
@@ -107,7 +107,7 @@ export class JsonRpcProvider extends Provider {
 
     /**
      * Query for block info from the RPC
-     * See [docs for more info](https://docs.nearprotocol.com/docs/interaction/rpc#block)
+     * See [docs for more info](https://docs.near.org/docs/interaction/rpc#block)
      */
     async block(blockQuery: BlockId | BlockReference): Promise<BlockResult> {
         const { finality } = blockQuery as any;
@@ -124,7 +124,7 @@ export class JsonRpcProvider extends Provider {
 
     /**
      * Queries for details of a specific chunk appending details of receipts and transactions to the same chunk data provided by a block
-     * See [docs for more info](https://docs.nearprotocol.com/docs/interaction/rpc#chunk)
+     * See [docs for more info](https://docs.near.org/docs/interaction/rpc#chunk)
      * @param chunkId Hash of a chunk ID or shard ID
      * @returns {Promise<ChunkResult>}
      */
@@ -134,7 +134,7 @@ export class JsonRpcProvider extends Provider {
 
     /**
      * Query validators of the epoch defined by given block id.
-     * See [docs for more info](https://docs.nearprotocol.com/docs/interaction/rpc#validators)
+     * See [docs for more info](https://docs.near.org/docs/develop/front-end/rpc#detailed-validator-status)
      * @param blockId Block hash or height, or null for latest.
      */
     async validators(blockId: BlockId | null): Promise<EpochValidatorInfo> {


### PR DESCRIPTION
Most of the links to the documentation for the RPC endpoints were broken and all domain names were outdated.
This PR fixes that.