### PR TITLE
getNetwork deleted from Provider

### DIFF
--- a/lib/providers/json-rpc-provider.d.ts
+++ b/lib/providers/json-rpc-provider.d.ts
@@ -1,5 +1,4 @@
 import { Provider, FinalExecutionOutcome, NodeStatusResult, BlockId, BlockReference, BlockResult, ChunkId, ChunkResult, EpochValidatorInfo, NearProtocolConfig, LightClientProof, LightClientProofRequest, GasPrice } from './provider';
-import { Network } from '../utils/network';
 import { ConnectionInfo } from '../utils/web';
 import { TypedError, ErrorContext } from '../utils/errors';
 import { SignedTransaction } from '../transaction';
@@ -7,11 +6,6 @@ export { TypedError, ErrorContext };
 export declare class JsonRpcProvider extends Provider {
     readonly connection: ConnectionInfo;
     constructor(url?: string);
-    /**
-     * Get the current network (ex. test, beta, etc…)
-     * @returns {Promise<Network>}
-     */
-    getNetwork(): Promise<Network>;
     /**
      * Gets the RPC's status
      * See [docs for more info](https://docs.near.org/docs/develop/front-end/rpc#general-validator-status)

--- a/lib/providers/json-rpc-provider.js
+++ b/lib/providers/json-rpc-provider.js
@@ -27,16 +27,6 @@ class JsonRpcProvider extends provider_1.Provider {
         this.connection = { url };
     }
     /**
-     * Get the current network (ex. test, beta, etc…)
-     * @returns {Promise<Network>}
-     */
-    async getNetwork() {
-        return {
-            name: 'test',
-            chainId: 'test'
-        };
-    }
-    /**
      * Gets the RPC's status
      * See [docs for more info](https://docs.near.org/docs/develop/front-end/rpc#general-validator-status)
      * @returns {Promise<NodeStatusResult>}

--- a/lib/providers/provider.d.ts
+++ b/lib/providers/provider.d.ts
@@ -1,4 +1,3 @@
-import { Network } from '../utils/network';
 import { SignedTransaction } from '../transaction';
 export interface SyncInfo {
     latest_block_hash: string;
@@ -204,7 +203,6 @@ export interface GasPrice {
     gas_price: string;
 }
 export declare abstract class Provider {
-    abstract getNetwork(): Promise<Network>;
     abstract status(): Promise<NodeStatusResult>;
     abstract sendTransaction(signedTransaction: SignedTransaction): Promise<FinalExecutionOutcome>;
     abstract txStatus(txHash: Uint8Array, accountId: string): Promise<FinalExecutionOutcome>;

--- a/lib/utils/index.d.ts
+++ b/lib/utils/index.d.ts
@@ -1,9 +1,8 @@
 import * as key_pair from './key_pair';
-import * as network from './network';
 import * as serialize from './serialize';
 import * as web from './web';
 import * as enums from './enums';
 import * as format from './format';
 import * as rpc_errors from './rpc_errors';
 import { PublicKey, KeyPair, KeyPairEd25519 } from './key_pair';
-export { key_pair, network, serialize, web, enums, format, PublicKey, KeyPair, KeyPairEd25519, rpc_errors };
+export { key_pair, serialize, web, enums, format, PublicKey, KeyPair, KeyPairEd25519, rpc_errors };

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -19,11 +19,9 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.rpc_errors = exports.KeyPairEd25519 = exports.KeyPair = exports.PublicKey = exports.format = exports.enums = exports.web = exports.serialize = exports.network = exports.key_pair = void 0;
+exports.rpc_errors = exports.KeyPairEd25519 = exports.KeyPair = exports.PublicKey = exports.format = exports.enums = exports.web = exports.serialize = exports.key_pair = void 0;
 const key_pair = __importStar(require("./key_pair"));
 exports.key_pair = key_pair;
-const network = __importStar(require("./network"));
-exports.network = network;
 const serialize = __importStar(require("./serialize"));
 exports.serialize = serialize;
 const web = __importStar(require("./web"));

--- a/src/providers/json-rpc-provider.ts
+++ b/src/providers/json-rpc-provider.ts
@@ -14,7 +14,6 @@ import {
     LightClientProofRequest,
     GasPrice
 } from './provider';
-import { Network } from '../utils/network';
 import { ConnectionInfo, fetchJson } from '../utils/web';
 import { TypedError, ErrorContext } from '../utils/errors';
 import { baseEncode } from 'borsh';
@@ -42,17 +41,6 @@ export class JsonRpcProvider extends Provider {
     constructor(url?: string) {
         super();
         this.connection = { url };
-    }
-
-    /**
-     * Get the current network (ex. test, beta, etc…)
-     * @returns {Promise<Network>}
-     */
-    async getNetwork(): Promise<Network> {
-        return {
-            name: 'test',
-            chainId: 'test'
-        };
     }
 
     /**

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -1,4 +1,3 @@
-import { Network } from '../utils/network';
 import { SignedTransaction } from '../transaction';
 
 export interface SyncInfo {
@@ -242,7 +241,6 @@ export interface GasPrice {
 }
 
 export abstract class Provider {
-    abstract getNetwork(): Promise<Network>;
     abstract status(): Promise<NodeStatusResult>;
 
     abstract sendTransaction(signedTransaction: SignedTransaction): Promise<FinalExecutionOutcome>;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,6 +1,5 @@
 
 import * as key_pair from './key_pair';
-import * as network from './network';
 import * as serialize from './serialize';
 import * as web from './web';
 import * as enums from './enums';
@@ -11,7 +10,6 @@ import { PublicKey, KeyPair, KeyPairEd25519 } from './key_pair';
 
 export {
     key_pair,
-    network,
     serialize,
     web,
     enums,

--- a/src/utils/network.ts
+++ b/src/utils/network.ts
@@ -1,5 +1,0 @@
-export interface Network {
-    name: string;
-    chainId: string;
-    _defaultProvider?: (providers: any) => any;
-}


### PR DESCRIPTION
closes #282 

`getNetwork()` deleted from `Provider` interface and `JsonRpcProvider`.
@vgrichina @mikedotexe it's a breaking change, but we don't have any mentions about `getNetwork` in our docs. I have also deleted `Network` interface since it's never used (YAGNI).