### PR TITLE
Fix passing result back from 2FA account

### DIFF
--- a/lib/account_multisig.d.ts
+++ b/lib/account_multisig.d.ts
@@ -27,7 +27,6 @@ export declare class AccountMultisig extends Account {
     constructor(connection: Connection, accountId: string, options: any);
     signAndSendTransactionWithAccount(receiverId: string, actions: Action[]): Promise<FinalExecutionOutcome>;
     signAndSendTransaction(receiverId: string, actions: Action[]): Promise<FinalExecutionOutcome>;
-    signAndSendTransactions(transactions: any): Promise<void>;
     deleteUnconfirmedRequests(): Promise<void>;
     getRequestNonce(): Promise<Number>;
     getRequestIds(): Promise<string>;

--- a/lib/account_multisig.js
+++ b/lib/account_multisig.js
@@ -55,11 +55,6 @@ class AccountMultisig extends account_1.Account {
         }
         return result;
     }
-    async signAndSendTransactions(transactions) {
-        for (let { receiverId, actions } of transactions) {
-            await this.signAndSendTransaction(receiverId, actions);
-        }
-    }
     async deleteUnconfirmedRequests() {
         const { contract } = this;
         const request_ids = await this.getRequestIds();
@@ -110,6 +105,7 @@ class Account2FA extends AccountMultisig {
     }
     async signAndSendTransaction(receiverId, actions) {
         await super.signAndSendTransaction(receiverId, actions);
+        // TODO: Should following override onRequestResult in superclass instead of doing custom signAndSendTransaction?
         await this.sendCode();
         const result = await this.promptAndVerify();
         if (this.onConfirmResult) {
@@ -180,19 +176,16 @@ class Account2FA extends AccountMultisig {
         const method = await this.get2faMethod();
         const securityCode = await this.getCode(method);
         try {
-            const { success, res: result } = await this.verifyCode(securityCode);
-            if (!success || result === false) {
-                throw new Error('Request failed with error: ' + JSON.stringify(result));
-            }
-            return typeof result === 'string' && result.length === 0 ? 'true' : result;
+            const result = await this.verifyCode(securityCode);
+            // TODO: Parse error from result for real (like in normal account.signAndSendTransaction)
+            return result;
         }
         catch (e) {
             console.warn('Error validating security code:', e);
-            // TODO: Check if any other errors should be handled as non-recoverable
-            if (e.toString().includes('2fa code expired')) {
-                throw e;
+            if (e.toString().includes('invalid 2fa code provided') || e.toString().includes('2fa code not valid')) {
+                return await this.promptAndVerify();
             }
-            return await this.promptAndVerify();
+            throw e;
         }
     }
     async verifyCodeDefault(securityCode) {

--- a/test/account_multisig.test.js
+++ b/test/account_multisig.test.js
@@ -27,7 +27,7 @@ const getAccount2FA = async (account, keyMapping = ({ public_key: publicKey }) =
         getCode: () => {},
         sendCode: () => {},
         // auto accept "code"
-        verifyCode: () => ({ success: true, res: '' }),
+        verifyCode: () => ({  }), // TODO: Is there any content needed in result?
         onAddRequestResult: async () => {
             const { requestId } = account2fa.getRequest();
             // set confirmKey as signer


### PR DESCRIPTION
- Pass transaction result back (contract helper requires update to return it) https://github.com/near/near-contract-helper/pull/347
- Only repeat loop on what is explicitly user error (wrong code)
