### PR TITLE
Feat/json rpc query types

### DIFF
--- a/lib/account.d.ts
+++ b/lib/account.d.ts
@@ -122,7 +122,7 @@ export declare class Account {
      * @param prefix allows to filter which keys should be returned. Empty prefix means all keys. String prefix is utf-8 encoded.
      * @param blockQuery specifies which block to query state at. By default returns last "optimistic" block (i.e. not necessarily finalized).
      */
-    viewState(prefix: string | Uint8Array, blockQuery: {
+    viewState(prefix: string | Uint8Array, blockQuery?: {
         blockId: BlockId;
     } | {
         finality: Finality;

--- a/lib/account.d.ts
+++ b/lib/account.d.ts
@@ -110,7 +110,7 @@ export declare class Account {
      * @param args Any arguments to the view contract method, wrapped in JSON
      * @returns {Promise<any>}
      */
-    viewFunction(contractId: string, methodName: string, args: any, { parse }?: {
+    viewFunction(contractId: string, methodName: string, args?: any, { parse }?: {
         parse?: typeof parseJsonFromRawResponse;
     }): Promise<any>;
     /**

--- a/lib/account.d.ts
+++ b/lib/account.d.ts
@@ -1,21 +1,20 @@
 /// <reference types="node" />
 import BN from 'bn.js';
-import { AccessKey, Action, SignedTransaction } from './transaction';
+import { Action, SignedTransaction } from './transaction';
 import { FinalExecutionOutcome } from './providers';
-import { Finality, BlockId } from './providers/provider';
+import { Finality, BlockId, AccountView, AccessKeyView, AccessKeyInfoView } from './providers/provider';
 import { Connection } from './connection';
 import { PublicKey } from './utils/key_pair';
-export interface AccountState {
-    amount: string;
-    code_hash: string;
-    storage_usage: number;
-    locked: string;
-}
 export interface AccountBalance {
     total: string;
     stateStaked: string;
     staked: string;
     available: string;
+}
+export interface AccountAuthorizedApp {
+    contractId: string;
+    amount: string;
+    publicKey: PublicKey;
 }
 declare function parseJsonFromRawResponse(response: Uint8Array): any;
 /**
@@ -29,9 +28,9 @@ export declare class Account {
     fetchState(): Promise<void>;
     /**
      * Returns the state of a NEAR account
-     * @returns {Promise<AccountState>}
+     * @returns {Promise<AccountView>}
      */
-    state(): Promise<AccountState>;
+    state(): Promise<AccountView>;
     private printLogsAndFailures;
     private printLogs;
     protected signTransaction(receiverId: string, actions: Action[]): Promise<[Uint8Array, SignedTransaction]>;
@@ -42,7 +41,7 @@ export declare class Account {
      */
     protected signAndSendTransaction(receiverId: string, actions: Action[]): Promise<FinalExecutionOutcome>;
     accessKeyByPublicKeyCache: {
-        [key: string]: AccessKey;
+        [key: string]: AccessKeyView;
     };
     private findAccessKey;
     /**
@@ -132,14 +131,16 @@ export declare class Account {
         value: Buffer;
     }>>;
     /**
-     * @returns array of {access_key: AccessKey, public_key: PublicKey} items.
+     * @returns AccessKeyInfoView[].
      */
-    getAccessKeys(): Promise<any>;
+    getAccessKeys(): Promise<AccessKeyInfoView[]>;
     /**
      * Returns account details in terms of authorized apps and transactions
-     * @returns {Promise<any>}
+     * @returns {Promise<{ authorizedApps: AccountAuthorizedApp[] }>}
      */
-    getAccountDetails(): Promise<any>;
+    getAccountDetails(): Promise<{
+        authorizedApps: AccountAuthorizedApp[];
+    }>;
     /**
      * Returns calculated account balance
      * @returns {Promise<AccountBalance>}

--- a/lib/account.js
+++ b/lib/account.js
@@ -335,7 +335,7 @@ class Account {
         // Also if we need this function, or getAccessKeys is good enough.
         const accessKeys = await this.getAccessKeys();
         const authorizedApps = accessKeys
-            .filter(item => item.access_key.permission['FunctionCall'] !== undefined)
+            .filter(item => item.access_key.permission !== 'FullAccess')
             .map(item => {
             const perm = item.access_key.permission;
             return {

--- a/lib/account.js
+++ b/lib/account.js
@@ -274,14 +274,13 @@ class Account {
      * @param args Any arguments to the view contract method, wrapped in JSON
      * @returns {Promise<any>}
      */
-    async viewFunction(contractId, methodName, args, { parse = parseJsonFromRawResponse } = {}) {
-        args = args || {};
+    async viewFunction(contractId, methodName, args = {}, { parse = parseJsonFromRawResponse } = {}) {
         this.validateArgs(args);
         const result = await this.connection.provider.query({
             request_type: 'call_function',
             account_id: contractId,
             method_name: methodName,
-            args_base64: borsh_1.baseEncode(JSON.stringify(args)),
+            args_base64: Buffer.from(JSON.stringify(args)).toString('base64'),
             finality: 'optimistic'
         });
         if (result.logs) {

--- a/lib/account.js
+++ b/lib/account.js
@@ -52,7 +52,11 @@ class Account {
      * @returns {Promise<AccountView>}
      */
     async state() {
-        return await this.connection.provider.query(`account/${this.accountId}`, '');
+        return this.connection.provider.query({
+            request_type: 'view_account',
+            account_id: this.accountId,
+            finality: 'optimistic'
+        });
     }
     printLogsAndFailures(contractId, results) {
         for (const result of results) {
@@ -143,7 +147,12 @@ class Account {
             return { publicKey, accessKey: cachedAccessKey };
         }
         try {
-            const accessKey = await this.connection.provider.query(`access_key/${this.accountId}/${publicKey.toString()}`, '');
+            const accessKey = await this.connection.provider.query({
+                request_type: 'view_access_key',
+                account_id: this.accountId,
+                public_key: publicKey.toString(),
+                finality: 'optimistic'
+            });
             this.accessKeyByPublicKeyCache[publicKey.toString()] = accessKey;
             return { publicKey, accessKey };
         }
@@ -268,7 +277,13 @@ class Account {
     async viewFunction(contractId, methodName, args, { parse = parseJsonFromRawResponse } = {}) {
         args = args || {};
         this.validateArgs(args);
-        const result = await this.connection.provider.query(`call/${contractId}/${methodName}`, borsh_1.baseEncode(JSON.stringify(args)));
+        const result = await this.connection.provider.query({
+            request_type: 'call_function',
+            account_id: contractId,
+            method_name: methodName,
+            args_base64: borsh_1.baseEncode(JSON.stringify(args)),
+            finality: 'optimistic'
+        });
         if (result.logs) {
             this.printLogs(contractId, result.logs);
         }
@@ -283,12 +298,10 @@ class Account {
      * @param prefix allows to filter which keys should be returned. Empty prefix means all keys. String prefix is utf-8 encoded.
      * @param blockQuery specifies which block to query state at. By default returns last "optimistic" block (i.e. not necessarily finalized).
      */
-    async viewState(prefix, blockQuery) {
-        const { blockId, finality } = blockQuery || {};
+    async viewState(prefix, blockQuery = { finality: 'optimistic' }) {
         const { values } = await this.connection.provider.query({
             request_type: 'view_state',
-            block_id: blockId,
-            finality: blockId ? undefined : finality || 'optimistic',
+            ...blockQuery,
             account_id: this.accountId,
             prefix_base64: Buffer.from(prefix).toString('base64')
         });
@@ -301,7 +314,11 @@ class Account {
      * @returns AccessKeyInfoView[].
      */
     async getAccessKeys() {
-        const response = await this.connection.provider.query(`access_key/${this.accountId}`, '');
+        const response = await this.connection.provider.query({
+            request_type: 'view_access_key_list',
+            account_id: this.accountId,
+            finality: 'optimistic'
+        });
         // A breaking API change introduced extra information into the
         // response, so it now returns an object with a `keys` field instead
         // of an array: https://github.com/nearprotocol/nearcore/pull/1789

--- a/lib/account.js
+++ b/lib/account.js
@@ -49,7 +49,7 @@ class Account {
     }
     /**
      * Returns the state of a NEAR account
-     * @returns {Promise<AccountState>}
+     * @returns {Promise<AccountView>}
      */
     async state() {
         return await this.connection.provider.query(`account/${this.accountId}`, '');
@@ -298,7 +298,7 @@ class Account {
         }));
     }
     /**
-     * @returns array of {access_key: AccessKey, public_key: PublicKey} items.
+     * @returns AccessKeyInfoView[].
      */
     async getAccessKeys() {
         const response = await this.connection.provider.query(`access_key/${this.accountId}`, '');
@@ -312,24 +312,23 @@ class Account {
     }
     /**
      * Returns account details in terms of authorized apps and transactions
-     * @returns {Promise<any>}
+     * @returns {Promise<{ authorizedApps: AccountAuthorizedApp[] }>}
      */
     async getAccountDetails() {
         // TODO: update the response value to return all the different keys, not just app keys.
         // Also if we need this function, or getAccessKeys is good enough.
         const accessKeys = await this.getAccessKeys();
-        const result = { authorizedApps: [], transactions: [] };
-        accessKeys.map((item) => {
-            if (item.access_key.permission.FunctionCall !== undefined) {
-                const perm = item.access_key.permission.FunctionCall;
-                result.authorizedApps.push({
-                    contractId: perm.receiver_id,
-                    amount: perm.allowance,
-                    publicKey: item.public_key,
-                });
-            }
+        const authorizedApps = accessKeys
+            .filter(item => item.access_key.permission['FunctionCall'] !== undefined)
+            .map(item => {
+            const perm = item.access_key.permission;
+            return {
+                contractId: perm.FunctionCall.receiver_id,
+                amount: perm.FunctionCall.allowance,
+                publicKey: item.public_key,
+            };
         });
-        return result;
+        return { authorizedApps };
     }
     /**
      * Returns calculated account balance

--- a/lib/account_multisig.d.ts
+++ b/lib/account_multisig.d.ts
@@ -29,9 +29,9 @@ export declare class AccountMultisig extends Account {
     signAndSendTransaction(receiverId: string, actions: Action[]): Promise<FinalExecutionOutcome>;
     signAndSendTransactions(transactions: any): Promise<void>;
     deleteUnconfirmedRequests(): Promise<void>;
-    getRequestNonce(): Promise<Number>;
+    getRequestNonce(): Promise<number>;
     getRequestIds(): Promise<string>;
-    isDeleteAction(actions: any): Boolean;
+    isDeleteAction(actions: any): boolean;
     getRequest(): any;
     setRequest(data: any): any;
 }

--- a/lib/account_multisig.js
+++ b/lib/account_multisig.js
@@ -140,7 +140,7 @@ class Account2FA extends AccountMultisig {
         const { accountId } = this;
         const accessKeys = await this.getAccessKeys();
         const lak2fak = accessKeys
-            .filter(({ access_key }) => access_key.permission['FunctionCall'] !== undefined)
+            .filter(({ access_key }) => access_key.permission !== 'FullAccess')
             .filter(({ access_key }) => {
             const perm = access_key.permission.FunctionCall;
             return perm.receiver_id === accountId &&

--- a/lib/account_multisig.js
+++ b/lib/account_multisig.js
@@ -18,9 +18,8 @@ exports.MULTISIG_DEPOSIT = new bn_js_1.default('0');
 exports.MULTISIG_CHANGE_METHODS = ['add_request', 'add_request_and_confirm', 'delete_request', 'confirm'];
 exports.MULTISIG_VIEW_METHODS = ['get_request_nonce', 'list_request_ids'];
 exports.MULTISIG_CONFIRM_METHODS = ['confirm'];
-;
 // in memory request cache for node w/o localStorage
-let storageFallback = {
+const storageFallback = {
     [exports.MULTISIG_STORAGE_KEY]: null
 };
 class AccountMultisig extends account_1.Account {
@@ -56,7 +55,7 @@ class AccountMultisig extends account_1.Account {
         return result;
     }
     async signAndSendTransactions(transactions) {
-        for (let { receiverId, actions } of transactions) {
+        for (const { receiverId, actions } of transactions) {
             await this.signAndSendTransaction(receiverId, actions);
         }
     }
@@ -68,7 +67,7 @@ class AccountMultisig extends account_1.Account {
                 await contract.delete_request({ request_id });
             }
             catch (e) {
-                console.warn("Attempt to delete an earlier request before 15 minutes failed. Will try again.");
+                console.warn('Attempt to delete an earlier request before 15 minutes failed. Will try again.');
             }
         }
     }
@@ -84,7 +83,7 @@ class AccountMultisig extends account_1.Account {
     }
     getRequest() {
         if (this.storage) {
-            return JSON.parse(this.storage.getItem(exports.MULTISIG_STORAGE_KEY) || `{}`);
+            return JSON.parse(this.storage.getItem(exports.MULTISIG_STORAGE_KEY) || '{}');
         }
         return storageFallback[exports.MULTISIG_STORAGE_KEY];
     }
@@ -144,11 +143,14 @@ class Account2FA extends AccountMultisig {
     async disable(contractBytes) {
         const { accountId } = this;
         const accessKeys = await this.getAccessKeys();
-        const lak2fak = accessKeys.filter(({ access_key }) => access_key && access_key.permission && access_key.permission.FunctionCall &&
-            access_key.permission.FunctionCall.receiver_id === accountId &&
-            access_key.permission.FunctionCall.method_names &&
-            access_key.permission.FunctionCall.method_names.length === 4 &&
-            access_key.permission.FunctionCall.method_names.includes('add_request_and_confirm'));
+        const lak2fak = accessKeys
+            .filter(({ access_key }) => access_key.permission['FunctionCall'] !== undefined)
+            .filter(({ access_key }) => {
+            const perm = access_key.permission.FunctionCall;
+            return perm.receiver_id === accountId &&
+                perm.method_names.length === 4 &&
+                perm.method_names.includes('add_request_and_confirm');
+        });
         const confirmOnlyKey = key_pair_1.PublicKey.from((await this.postSignedJson('/2fa/getAccessKey', { accountId })).publicKey);
         const actions = [
             transaction_1.deleteKey(confirmOnlyKey),

--- a/lib/providers/json-rpc-provider.d.ts
+++ b/lib/providers/json-rpc-provider.d.ts
@@ -1,4 +1,4 @@
-import { Provider, FinalExecutionOutcome, NodeStatusResult, BlockId, BlockReference, BlockResult, ChunkId, ChunkResult, EpochValidatorInfo, NearProtocolConfig, LightClientProof, LightClientProofRequest, GasPrice } from './provider';
+import { Provider, FinalExecutionOutcome, NodeStatusResult, BlockId, BlockReference, BlockResult, ChunkId, ChunkResult, EpochValidatorInfo, NearProtocolConfig, LightClientProof, LightClientProofRequest, GasPrice, QueryResponseKind } from './provider';
 import { Network } from '../utils/network';
 import { ConnectionInfo } from '../utils/web';
 import { TypedError, ErrorContext } from '../utils/errors';
@@ -36,7 +36,7 @@ export declare class JsonRpcProvider extends Provider {
     /**
      * Query the RPC as [shown in the docs](https://docs.near.org/docs/develop/front-end/rpc#accounts--contracts)
      */
-    query(...args: any[]): Promise<any>;
+    query<T extends QueryResponseKind>(...args: any[]): Promise<T>;
     /**
      * Query for block info from the RPC
      * See [docs for more info](https://docs.near.org/docs/interaction/rpc#block)
@@ -81,7 +81,7 @@ export declare class JsonRpcProvider extends Provider {
      * @param method RPC method
      * @param params Parameters to the method
      */
-    sendJsonRpc(method: string, params: object): Promise<any>;
+    sendJsonRpc<T>(method: string, params: object): Promise<T>;
     /**
      * Returns gas price for a specific block_height or block_hash.
      * See [docs for more info](https://docs.near.org/docs/develop/front-end/rpc#gas-price)

--- a/lib/providers/provider.d.ts
+++ b/lib/providers/provider.d.ts
@@ -1,5 +1,6 @@
 import { Network } from '../utils/network';
 import { SignedTransaction } from '../transaction';
+import { PublicKey } from '../utils/key_pair';
 export interface SyncInfo {
     latest_block_hash: string;
     latest_block_height: number;
@@ -203,13 +204,59 @@ export interface LightClientProofRequest {
 export interface GasPrice {
     gas_price: string;
 }
+export interface QueryResponseKind {
+    block_height: BlockHeight;
+    block_hash: BlockHash;
+}
+export interface AccountView extends QueryResponseKind {
+    amount: string;
+    locked: string;
+    code_hash: string;
+    storage_usage: number;
+    storage_paid_at: BlockHeight;
+}
+interface StateItem {
+    key: string;
+    value: string;
+    proof: string[];
+}
+export interface ViewStateResult extends QueryResponseKind {
+    values: StateItem[];
+    proof: string[];
+}
+export interface CodeResult extends QueryResponseKind {
+    result: number[];
+    logs: string[];
+}
+export interface ContractCodeView extends QueryResponseKind {
+    code_base64: string;
+    hash: string;
+}
+export interface FunctionCallPermissionView {
+    FunctionCall: {
+        allowance: string;
+        receiver_id: string;
+        method_names: string[];
+    };
+}
+export interface AccessKeyView extends QueryResponseKind {
+    nonce: number;
+    permission: 'FullAccess' | FunctionCallPermissionView;
+}
+export interface AccessKeyInfoView {
+    public_key: PublicKey;
+    access_key: AccessKeyView;
+}
+export interface AccessKeyList extends QueryResponseKind {
+    keys: AccessKeyInfoView[];
+}
 export declare abstract class Provider {
     abstract getNetwork(): Promise<Network>;
     abstract status(): Promise<NodeStatusResult>;
     abstract sendTransaction(signedTransaction: SignedTransaction): Promise<FinalExecutionOutcome>;
     abstract txStatus(txHash: Uint8Array, accountId: string): Promise<FinalExecutionOutcome>;
-    abstract query(params: object): Promise<any>;
-    abstract query(path: string, data: string): Promise<any>;
+    abstract query<T extends QueryResponseKind>(params: object): Promise<T>;
+    abstract query<T extends QueryResponseKind>(path: string, data: string): Promise<T>;
     abstract block(blockQuery: BlockId | BlockReference): Promise<BlockResult>;
     abstract chunk(chunkId: ChunkId): Promise<ChunkResult>;
     abstract validators(blockId: BlockId): Promise<EpochValidatorInfo>;

--- a/lib/providers/provider.d.ts
+++ b/lib/providers/provider.d.ts
@@ -250,12 +250,41 @@ export interface AccessKeyInfoView {
 export interface AccessKeyList extends QueryResponseKind {
     keys: AccessKeyInfoView[];
 }
+export interface ViewAccountRequest {
+    request_type: 'view_account';
+    account_id: string;
+}
+export interface ViewCodeRequest {
+    request_type: 'view_code';
+    account_id: string;
+}
+export interface ViewStateRequest {
+    request_type: 'view_state';
+    account_id: string;
+    prefix_base64: string;
+}
+export interface ViewAccessKeyRequest {
+    request_type: 'view_access_key';
+    account_id: string;
+    public_key: string;
+}
+export interface ViewAccessKeyListRequest {
+    request_type: 'view_access_key_list';
+    account_id: string;
+}
+export interface CallFunctionRequest {
+    request_type: 'call_function';
+    account_id: string;
+    method_name: string;
+    args_base64: string;
+}
+export declare type RpcQueryRequest = (ViewAccountRequest | ViewCodeRequest | ViewStateRequest | ViewAccountRequest | ViewAccessKeyRequest | ViewAccessKeyListRequest | CallFunctionRequest) & BlockReference;
 export declare abstract class Provider {
     abstract getNetwork(): Promise<Network>;
     abstract status(): Promise<NodeStatusResult>;
     abstract sendTransaction(signedTransaction: SignedTransaction): Promise<FinalExecutionOutcome>;
     abstract txStatus(txHash: Uint8Array, accountId: string): Promise<FinalExecutionOutcome>;
-    abstract query<T extends QueryResponseKind>(params: object): Promise<T>;
+    abstract query<T extends QueryResponseKind>(params: RpcQueryRequest): Promise<T>;
     abstract query<T extends QueryResponseKind>(path: string, data: string): Promise<T>;
     abstract block(blockQuery: BlockId | BlockReference): Promise<BlockResult>;
     abstract chunk(chunkId: ChunkId): Promise<ChunkResult>;

--- a/lib/transaction.d.ts
+++ b/lib/transaction.d.ts
@@ -6,7 +6,7 @@ import { Signer } from './signer';
 export declare class FunctionCallPermission extends Assignable {
     allowance?: BN;
     receiverId: string;
-    methodNames: String[];
+    methodNames: string[];
 }
 export declare class FullAccessPermission extends Assignable {
 }
@@ -19,7 +19,7 @@ export declare class AccessKey extends Assignable {
     permission: AccessKeyPermission;
 }
 export declare function fullAccessKey(): AccessKey;
-export declare function functionCallAccessKey(receiverId: string, methodNames: String[], allowance?: BN): AccessKey;
+export declare function functionCallAccessKey(receiverId: string, methodNames: string[], allowance?: BN): AccessKey;
 export declare class IAction extends Assignable {
 }
 export declare class CreateAccount extends IAction {

--- a/lib/wallet-account.js
+++ b/lib/wallet-account.js
@@ -226,7 +226,7 @@ class ConnectedWalletAccount extends account_1.Account {
     async accessKeyForTransaction(receiverId, actions, localKey) {
         const accessKeys = await this.getAccessKeys();
         if (localKey) {
-            const accessKey = accessKeys.find(key => key.public_key === localKey.toString());
+            const accessKey = accessKeys.find(key => key.public_key.toString() === localKey.toString());
             if (accessKey && await this.accessKeyMatchesTransaction(accessKey, receiverId, actions)) {
                 return accessKey;
             }

--- a/src/account.ts
+++ b/src/account.ts
@@ -417,7 +417,7 @@ export class Account {
         // Also if we need this function, or getAccessKeys is good enough.
         const accessKeys = await this.getAccessKeys();
         const authorizedApps = accessKeys
-            .filter(item => item.access_key.permission['FunctionCall'] !== undefined)
+            .filter(item => item.access_key.permission !== 'FullAccess')
             .map(item => {
                 const perm = (item.access_key.permission as FunctionCallPermissionView);
                 return {

--- a/src/account.ts
+++ b/src/account.ts
@@ -347,24 +347,23 @@ export class Account {
     async viewFunction(
         contractId: string,
         methodName: string,
-        args: any,
+        args: any = {},
         { parse = parseJsonFromRawResponse } = {}
     ): Promise<any> {
-        args = args || {};
         this.validateArgs(args);
         
         const result = await this.connection.provider.query<CodeResult>({
             request_type: 'call_function',
             account_id: contractId,
             method_name: methodName,
-            args_base64: baseEncode(JSON.stringify(args)),
+            args_base64: Buffer.from(JSON.stringify(args)).toString('base64'),
             finality: 'optimistic'
         });
 
         if (result.logs) {
             this.printLogs(contractId, result.logs);
         }
-        
+
         return result.result && result.result.length > 0 && parse(Buffer.from(result.result));
     }
 

--- a/src/account_multisig.ts
+++ b/src/account_multisig.ts
@@ -188,7 +188,7 @@ export class Account2FA extends AccountMultisig {
         const { accountId } = this;
         const accessKeys = await this.getAccessKeys();
         const lak2fak = accessKeys
-            .filter(({ access_key }) => access_key.permission['FunctionCall'] !== undefined)
+            .filter(({ access_key }) => access_key.permission !== 'FullAccess')
             .filter(({ access_key }) => {
                 const perm = (access_key.permission as FunctionCallPermissionView).FunctionCall;
                 return  perm.receiver_id === accountId &&

--- a/src/providers/json-rpc-provider.ts
+++ b/src/providers/json-rpc-provider.ts
@@ -12,7 +12,8 @@ import {
     NearProtocolConfig,
     LightClientProof,
     LightClientProofRequest,
-    GasPrice
+    GasPrice,
+    QueryResponseKind
 } from './provider';
 import { Network } from '../utils/network';
 import { ConnectionInfo, fetchJson } from '../utils/web';
@@ -89,13 +90,13 @@ export class JsonRpcProvider extends Provider {
     /**
      * Query the RPC as [shown in the docs](https://docs.near.org/docs/develop/front-end/rpc#accounts--contracts)
      */
-    async query(...args: any[]): Promise<any> {
+    async query<T extends QueryResponseKind>(...args: any[]): Promise<T> {
         let result;
         if (args.length === 1) {
-            result = await this.sendJsonRpc('query', args[0]);
+            result = await this.sendJsonRpc<T>('query', args[0]);
         } else {
             const [path, data] = args;
-            result = await this.sendJsonRpc('query', [path, data]);
+            result = await this.sendJsonRpc<T>('query', [path, data]);
         }
         if (result && result.error) {
             throw new TypedError(
@@ -183,7 +184,7 @@ export class JsonRpcProvider extends Provider {
      * @param method RPC method
      * @param params Parameters to the method
      */
-    async sendJsonRpc(method: string, params: object): Promise<any> {
+    async sendJsonRpc<T>(method: string, params: object): Promise<T> {
         const result = await exponentialBackoff(REQUEST_RETRY_WAIT, REQUEST_RETRY_NUMBER, REQUEST_RETRY_WAIT_BACKOFF, async () => {
             try {
                 const request = {

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -1,5 +1,6 @@
 import { Network } from '../utils/network';
 import { SignedTransaction } from '../transaction';
+import { PublicKey } from '../utils/key_pair';
 
 export interface SyncInfo {
     latest_block_hash: string;
@@ -241,14 +242,69 @@ export interface GasPrice {
     gas_price: string;
 }
 
+export interface QueryResponseKind {
+    block_height: BlockHeight;
+    block_hash: BlockHash;
+}
+
+export interface AccountView extends QueryResponseKind {
+    amount: string;
+    locked: string;
+    code_hash: string;
+    storage_usage: number;
+    storage_paid_at: BlockHeight;
+}
+
+interface StateItem {
+    key: string;
+    value: string;
+    proof: string[];
+}
+
+export interface ViewStateResult extends QueryResponseKind {
+    values: StateItem[];
+    proof: string[];
+}
+
+export interface CodeResult extends QueryResponseKind {
+    result: number[];
+    logs: string[];
+}
+
+export interface ContractCodeView extends QueryResponseKind {
+    code_base64: string;
+    hash: string;
+}
+
+export interface FunctionCallPermissionView {
+    FunctionCall: {
+        allowance: string;
+        receiver_id: string;
+        method_names: string[];
+    };
+}
+export interface AccessKeyView extends QueryResponseKind {
+    nonce: number;
+    permission: 'FullAccess' | FunctionCallPermissionView;
+}
+
+export interface AccessKeyInfoView {
+    public_key: PublicKey;
+    access_key: AccessKeyView;
+}
+
+export interface AccessKeyList extends QueryResponseKind {
+    keys: AccessKeyInfoView[];
+}
+
 export abstract class Provider {
     abstract getNetwork(): Promise<Network>;
     abstract status(): Promise<NodeStatusResult>;
 
     abstract sendTransaction(signedTransaction: SignedTransaction): Promise<FinalExecutionOutcome>;
     abstract txStatus(txHash: Uint8Array, accountId: string): Promise<FinalExecutionOutcome>;
-    abstract query(params: object): Promise<any>;
-    abstract query(path: string, data: string): Promise<any>;
+    abstract query<T extends QueryResponseKind>(params: object): Promise<T>;
+    abstract query<T extends QueryResponseKind>(path: string, data: string): Promise<T>;
     // TODO: BlockQuery type?
     abstract block(blockQuery: BlockId | BlockReference): Promise<BlockResult>;
     abstract chunk(chunkId: ChunkId): Promise<ChunkResult>;

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -297,13 +297,55 @@ export interface AccessKeyList extends QueryResponseKind {
     keys: AccessKeyInfoView[];
 }
 
+export interface ViewAccountRequest {
+    request_type: 'view_account';
+    account_id: string;
+}
+
+export interface ViewCodeRequest {
+    request_type: 'view_code';
+    account_id: string;
+}
+
+export interface ViewStateRequest {
+    request_type: 'view_state';
+    account_id: string;
+    prefix_base64: string;
+}
+
+export interface ViewAccessKeyRequest {
+    request_type: 'view_access_key';
+    account_id: string;
+    public_key: string;
+}
+
+export interface ViewAccessKeyListRequest {
+    request_type: 'view_access_key_list';
+    account_id: string;
+}
+
+export interface CallFunctionRequest {
+    request_type: 'call_function';
+    account_id: string;
+    method_name: string;
+    args_base64: string;
+}
+
+export type RpcQueryRequest = (ViewAccountRequest |
+    ViewCodeRequest |
+    ViewStateRequest |
+    ViewAccountRequest |
+    ViewAccessKeyRequest |
+    ViewAccessKeyListRequest |
+    CallFunctionRequest) & BlockReference
+
 export abstract class Provider {
     abstract getNetwork(): Promise<Network>;
     abstract status(): Promise<NodeStatusResult>;
 
     abstract sendTransaction(signedTransaction: SignedTransaction): Promise<FinalExecutionOutcome>;
     abstract txStatus(txHash: Uint8Array, accountId: string): Promise<FinalExecutionOutcome>;
-    abstract query<T extends QueryResponseKind>(params: object): Promise<T>;
+    abstract query<T extends QueryResponseKind>(params: RpcQueryRequest): Promise<T>;
     abstract query<T extends QueryResponseKind>(path: string, data: string): Promise<T>;
     // TODO: BlockQuery type?
     abstract block(blockQuery: BlockId | BlockReference): Promise<BlockResult>;

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -9,7 +9,7 @@ import { Signer } from './signer';
 export class FunctionCallPermission extends Assignable {
     allowance?: BN;
     receiverId: string;
-    methodNames: String[];
+    methodNames: string[];
 }
 
 export class FullAccessPermission extends Assignable {}
@@ -28,7 +28,7 @@ export function fullAccessKey(): AccessKey {
     return new AccessKey({ nonce: 0, permission: new AccessKeyPermission({fullAccess: new FullAccessPermission({})}) });
 }
 
-export function functionCallAccessKey(receiverId: string, methodNames: String[], allowance?: BN): AccessKey {
+export function functionCallAccessKey(receiverId: string, methodNames: string[], allowance?: BN): AccessKey {
     return new AccessKey({ nonce: 0, permission: new AccessKeyPermission({functionCall: new FunctionCallPermission({receiverId, allowance, methodNames})})});
 }
 

--- a/src/wallet-account.ts
+++ b/src/wallet-account.ts
@@ -263,7 +263,7 @@ class ConnectedWalletAccount extends Account {
         const accessKeys = await this.getAccessKeys();
 
         if (localKey) {
-            const accessKey = accessKeys.find(key => key.public_key === localKey.toString());
+            const accessKey = accessKeys.find(key => key.public_key.toString() === localKey.toString());
             if (accessKey && await this.accessKeyMatchesTransaction(accessKey, receiverId, actions)) {
                 return accessKey;
             }

--- a/test/providers.test.js
+++ b/test/providers.test.js
@@ -1,4 +1,4 @@
-const nearApi = require('../src/index');
+const nearApi = require('../lib/index');
 const testUtils  = require('./test-utils');
 const BN = require('bn.js');
 

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -1,7 +1,7 @@
 const fs = require('fs').promises;
 const BN = require('bn.js');
 
-const nearApi = require('../lib/index');
+const nearApi = require('../src/index');
 
 const networkId = 'unittest';
 
@@ -82,6 +82,22 @@ function sleep(time) {
     });
 }
 
+function waitFor(fn) {
+    const _waitFor = async (count = 10) => {
+        try {
+            return await fn();
+        } catch(e) {
+            if(count > 0) {
+                await sleep(500);
+                return _waitFor(count - 1);
+            }
+            else throw e;
+        }
+    };
+
+    return _waitFor();
+}
+
 async function ensureDir(dirpath) {
     try {
         await fs.mkdir(dirpath, { recursive: true });
@@ -98,6 +114,7 @@ module.exports = {
     createAccountMultisig,
     deployContract,
     sleep,
+    waitFor,
     ensureDir,
     HELLO_WASM_PATH,
     HELLO_WASM_BALANCE,

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -1,7 +1,7 @@
 const fs = require('fs').promises;
 const BN = require('bn.js');
 
-const nearApi = require('../src/index');
+const nearApi = require('../lib/index');
 
 const networkId = 'unittest';
 

--- a/test/wallet-account.test.js
+++ b/test/wallet-account.test.js
@@ -135,22 +135,21 @@ function setupWalletConnectionForSigning({ allKeys, accountAccessKeys }) {
         accountId: 'signer.near'
     };
     nearFake.connection.provider = {
-        query(path, data) {
-            if (path === 'account/signer.near') {
+        query(params) {
+            if (params.request_type === 'view_account' && params.account_id === 'signer.near') {
                 return { };
             }
-            if (path === 'access_key/signer.near') {
+            if (params.request_type === 'view_access_key_list' && params.account_id === 'signer.near') {
                 return { keys: accountAccessKeys };
             }
-            if (path.startsWith('access_key/signer.near')) {
-                const [,,publicKey] = path.split('/');
+            if (params.request_type === 'view_access_key' && params.account_id === 'signer.near') {
                 for (let accessKey of accountAccessKeys) {
-                    if (accessKey.public_key === publicKey) {
+                    if (accessKey.public_key === params.public_key) {
                         return accessKey;
                     }
                 }
             }
-            fail(`Unexpected query: ${path} ${data}`);
+            fail(`Unexpected query: ${JSON.stringify(params)}`);
         },
         sendTransaction(signedTransaction) {
             lastTransaction = signedTransaction;


### PR DESCRIPTION
Fixes #525

In this PR:

* RPC query request typing in `src/providers/provider.ts` see `RpcQueryRequest`
* RPC query response typing in `src/providers/provider.ts` see`QueryResponseKind`
* update `src/account.ts` to use params object to take advantage of the request typing
* update `src/accounts.ts` to use `query<T>` response typing

Follow up: It would be nice to figure out how to separate the types from the `provider.ts` file. Maybe into separate files by type. `rpc-block-views.ts`, `rpc-query-views.ts`, etc. But this may leave some of the files a bit anemic.

Very open to any feedback on this.