### PR TITLE
fix tx status rpc call

### DIFF
--- a/src/providers/json-rpc-provider.ts
+++ b/src/providers/json-rpc-provider.ts
@@ -71,8 +71,8 @@ export class JsonRpcProvider extends Provider {
      * @param accountId The NEAR account that signed the transaction
      * @returns {Promise<FinalExecutionOutcome>}
      */
-    async txStatus(txHash: Uint8Array, accountId: string): Promise<FinalExecutionOutcome> {
-        return this.sendJsonRpc('tx', [baseEncode(txHash), accountId]);
+    async txStatus(txHash: string, accountId: string): Promise<FinalExecutionOutcome> {
+        return this.sendJsonRpc('tx', [txHash, accountId]);
     }
 
     /**

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -342,7 +342,7 @@ export abstract class Provider {
     abstract status(): Promise<NodeStatusResult>;
 
     abstract sendTransaction(signedTransaction: SignedTransaction): Promise<FinalExecutionOutcome>;
-    abstract txStatus(txHash: Uint8Array, accountId: string): Promise<FinalExecutionOutcome>;
+    abstract txStatus(txHash: string, accountId: string): Promise<FinalExecutionOutcome>;
     abstract query<T extends QueryResponseKind>(params: RpcQueryRequest): Promise<T>;
     abstract query<T extends QueryResponseKind>(path: string, data: string): Promise<T>;
     // TODO: BlockQuery type?


### PR DESCRIPTION
The `txHash` should be just be a string. This is a breaking change so I'm fine making a new method for this if we think its best, but as it is right now someone would have to:  take a transaction hash -> convert it to `UInt8Array` -> then the method turns it back into a string.

Like here: https://github.com/near/near-cli/blob/aa7642d414c8a8ee8737e46e9d96c2f5dd002122/commands/tx-status.js#L33.