### PR TITLE
Feat/batch transactions wallet

### DIFF
--- a/lib/browser-connect.d.ts
+++ b/lib/browser-connect.d.ts
@@ -3,9 +3,7 @@
  *
  * {@link ConnectConfig.networkId} and {@link ConnectConfig.nodeUrl} are required.
  *
- * To sign transactions you can also pass:
- * 1. {@link ConnectConfig.keyStore}
- * 2. {@link ConnectConfig.deps | ConnectConfig.deps.keyStore}
+ * To sign transactions you can also pass: {@link ConnectConfig.keyStore}
  *
  * Both are passed they are prioritize in that order.
  *
@@ -22,7 +20,7 @@
  *
  * @module browserConnect
  */
-import { Near, NearConfig } from './near';
+import { Near, NearConfig } from "./near";
 export interface ConnectConfig extends NearConfig {
     /** @hidden */
     keyPath?: string;

--- a/lib/browser-connect.js
+++ b/lib/browser-connect.js
@@ -6,9 +6,7 @@ exports.connect = void 0;
  *
  * {@link ConnectConfig.networkId} and {@link ConnectConfig.nodeUrl} are required.
  *
- * To sign transactions you can also pass:
- * 1. {@link ConnectConfig.keyStore}
- * 2. {@link ConnectConfig.deps | ConnectConfig.deps.keyStore}
+ * To sign transactions you can also pass: {@link ConnectConfig.keyStore}
  *
  * Both are passed they are prioritize in that order.
  *

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -8,8 +8,7 @@ exports.connect = void 0;
  *
  * To sign transactions you can also pass:
  * 1. {@link ConnectConfig.keyStore}
- * 2. {@link ConnectConfig.deps | ConnectConfig.deps.keyStore}
- * 3. {@link ConnectConfig.keyPath}
+ * 2. {@link ConnectConfig.keyPath}
  *
  * If all three are passed they are prioritize in that order.
  *

--- a/lib/wallet-account.d.ts
+++ b/lib/wallet-account.d.ts
@@ -5,6 +5,14 @@ import { FinalExecutionOutcome } from './providers';
 import { Transaction, Action } from './transaction';
 import { PublicKey } from './utils';
 import { Connection } from './connection';
+/**
+ * used to create batched transactions
+ * @see {@link WalletConnection.batchSendTransactions}
+ */
+interface TransactionOptions {
+    receiverId: string;
+    actions: Action[];
+}
 interface SignInOptions {
     contractId?: string;
     successUrl?: string;
@@ -80,6 +88,30 @@ export declare class WalletConnection {
      * @param callbackUrl The url to navigate to after the user is prompted to sign
      */
     requestSignTransactions(transactions: Transaction[], callbackUrl?: string): Promise<void>;
+    /**
+     * Allows the user to send a batch of transactions to one or multiple recievers with only one redirect to the NEAR wallet.
+     * @param transactionOptions Array of Transaction options that will be requested to sign
+     * @param callbackUrl The url to navigate to after the user is prompted to sign
+     *
+     * @example
+     * ```js
+     * async function run() {
+     *      const near = await connect({
+     *          keyStore: new keyStores.BrowserLocalStorageKeyStore(),
+     *          networkId: "testnet",
+     *          walletUrl: 'https://wallet.testnet.near.org',
+     *          nodeUrl: "https://rpc.testnet.near.org",
+     *      })
+     *
+     *      const wallet = new WalletConnection(near);
+     *      wallet.batchSendTransactions([
+     *          { receiverId: 'contract-1.testnet', actions: [functionCall('contractMethod', { arg: 'value' }, new BN('30000000000000'), new BN(utils.format.parseNearAmount('1')))] },
+     *          { receiverId: 'user-account-1.testnet', actions: [transfer(new BN(utils.format.parseNearAmount('1'))), transfer(new BN(utils.format.parseNearAmount('4')))] }
+     *      ]);
+     * }
+     * ```
+     */
+    batchSendTransactions(transactionOptions: TransactionOptions[], callbackUrl?: string): Promise<void>;
     /**
      * @hidden
      * Complete sign in for a given account id and public key. To be invoked by the app when getting a callback from the wallet.

--- a/lib/wallet-account.js
+++ b/lib/wallet-account.js
@@ -128,6 +128,46 @@ class WalletConnection {
         window.location.assign(newUrl.toString());
     }
     /**
+     * Allows the user to send a batch of transactions to one or multiple recievers with only one redirect to the NEAR wallet.
+     * @param transactionOptions Array of Transaction options that will be requested to sign
+     * @param callbackUrl The url to navigate to after the user is prompted to sign
+     *
+     * @example
+     * ```js
+     * async function run() {
+     *      const near = await connect({
+     *          keyStore: new keyStores.BrowserLocalStorageKeyStore(),
+     *          networkId: "testnet",
+     *          walletUrl: 'https://wallet.testnet.near.org',
+     *          nodeUrl: "https://rpc.testnet.near.org",
+     *      })
+     *
+     *      const wallet = new WalletConnection(near);
+     *      wallet.batchSendTransactions([
+     *          { receiverId: 'contract-1.testnet', actions: [functionCall('contractMethod', { arg: 'value' }, new BN('30000000000000'), new BN(utils.format.parseNearAmount('1')))] },
+     *          { receiverId: 'user-account-1.testnet', actions: [transfer(new BN(utils.format.parseNearAmount('1'))), transfer(new BN(utils.format.parseNearAmount('4')))] }
+     *      ]);
+     * }
+     * ```
+     */
+    async batchSendTransactions(transactionOptions, callbackUrl) {
+        const accountId = this.getAccountId();
+        const localKey = await this._near.connection.signer.getPublicKey(accountId, this._near.connection.networkId);
+        const block = await this._near.connection.provider.block({ finality: 'final' });
+        const blockHash = borsh_1.baseDecode(block.header.hash);
+        const transactions = await Promise.all(transactionOptions.map(async ({ receiverId, actions }, index) => {
+            // TODO: Cache & listen for nonce updates for given access key
+            const accessKey = await this.account().accessKeyForTransaction(receiverId, actions, localKey);
+            if (!accessKey) {
+                throw new Error(`Cannot find matching key for transaction sent to ${receiverId}`);
+            }
+            const publicKey = utils_1.PublicKey.from(accessKey.public_key);
+            const nonce = accessKey.access_key.nonce + index + 1;
+            return transaction_1.createTransaction(accountId, publicKey, receiverId, nonce, actions, blockHash);
+        }));
+        return this.requestSignTransactions(transactions, callbackUrl);
+    }
+    /**
      * @hidden
      * Complete sign in for a given account id and public key. To be invoked by the app when getting a callback from the wallet.
      */

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
         "doc": "typedoc src && touch docs/.nojekyll",
         "build": "yarn compile",
         "pretest": "yarn build",
-        "test": "jest --runInBand",
+        "test": "jest test --runInBand",
         "lint": "eslint test && eslint src/**/*.ts",
         "fix": "eslint test --fix && eslint src/**/*.ts --fix",
         "prefuzz": "yarn build",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
         "doc": "typedoc src && touch docs/.nojekyll",
         "build": "yarn compile",
         "pretest": "yarn build",
-        "test": "jest test --runInBand",
+        "test": "jest --runInBand",
         "lint": "eslint test && eslint src/**/*.ts",
         "fix": "eslint test --fix && eslint src/**/*.ts --fix",
         "prefuzz": "yarn build",

--- a/src/wallet-account.ts
+++ b/src/wallet-account.ts
@@ -217,7 +217,8 @@ export class WalletConnection {
             }
             const publicKey = PublicKey.from(accessKey.public_key);
         
-            const nonce = accessKey.access_key.nonce + index + 1;
+            const nonce = accessKey.access_key.nextNonce();
+            
             return createTransaction(accountId, publicKey, receiverId, nonce, actions, blockHash);
         }));
         

--- a/src/wallet-account.ts
+++ b/src/wallet-account.ts
@@ -22,10 +22,16 @@ const MULTISIG_HAS_METHOD = 'add_request_and_confirm';
 const LOCAL_STORAGE_KEY_SUFFIX = '_wallet_auth_key';
 const PENDING_ACCESS_KEY_PREFIX = 'pending_key'; // browser storage key for a pending access key (i.e. key has been generated but we are not sure it was added yet)
 
+
+/**
+ * used to create batched transactions 
+ * @see {@link WalletConnection.batchSendTransactions}
+ */
 interface TransactionOptions {
     receiverId: string;
     actions: Action[];
 }
+
 interface SignInOptions {
     contractId?: string;
     // TODO: Replace following with single callbackUrl
@@ -173,6 +179,29 @@ export class WalletConnection {
         window.location.assign(newUrl.toString());
     }
 
+    /**
+     * Allows the user to send a batch of transactions to one or multiple recievers with only one redirect to the NEAR wallet.
+     * @param transactionOptions Array of Transaction options that will be requested to sign
+     * @param callbackUrl The url to navigate to after the user is prompted to sign
+     * 
+     * @example
+     * ```js
+     * async function run() {
+     *      const near = await connect({
+     *          keyStore: new keyStores.BrowserLocalStorageKeyStore(),
+     *          networkId: "testnet",
+     *          walletUrl: 'https://wallet.testnet.near.org',
+     *          nodeUrl: "https://rpc.testnet.near.org",
+     *      })
+     *      
+     *      const wallet = new WalletConnection(near);
+     *      wallet.batchSendTransactions([
+     *          { receiverId: 'contract-1.testnet', actions: [functionCall('contractMethod', { arg: 'value' }, new BN('30000000000000'), new BN(utils.format.parseNearAmount('1')))] },
+     *          { receiverId: 'user-account-1.testnet', actions: [transfer(new BN(utils.format.parseNearAmount('1'))), transfer(new BN(utils.format.parseNearAmount('4')))] }
+     *      ]);
+     * }
+     * ```
+     */
     async batchSendTransactions(transactionOptions: TransactionOptions[], callbackUrl?: string) {
         const accountId = this.getAccountId();
         const localKey = await this._near.connection.signer.getPublicKey(accountId, this._near.connection.networkId);

--- a/test/wallet-account.test.js
+++ b/test/wallet-account.test.js
@@ -1,19 +1,20 @@
-const url = require('url');
-const localStorage = require('localstorage-memory');
-const BN = require('bn.js');
+const url = require("url");
+const localStorage = require("localstorage-memory");
+const BN = require("bn.js");
+const { functionCall, transfer } = require("../lib/transaction");
 
 // If an access key has itself as receiverId and method permission add_request_and_confirm, then it is being used in a wallet with multisig contract: https://github.com/near/core-contracts/blob/671c05f09abecabe7a7e58efe942550a35fc3292/multisig/src/lib.rs#L149-L153
-const MULTISIG_HAS_METHOD = 'add_request_and_confirm';
+const MULTISIG_HAS_METHOD = "add_request_and_confirm";
 
 let lastRedirectUrl;
 let lastTransaction;
 global.window = {
-    localStorage
+    localStorage,
 };
 global.document = {
-    title: 'documentTitle'
+    title: "documentTitle",
 };
-const nearApi = require('../lib/index');
+const nearApi = require("../lib/index");
 
 let history;
 let nearFake;
@@ -22,131 +23,216 @@ let keyStore = new nearApi.keyStores.InMemoryKeyStore();
 beforeEach(() => {
     nearFake = {
         config: {
-            networkId: 'networkId',
-            contractName: 'contractId',
-            walletUrl: 'http://example.com/wallet',
+            networkId: "networkId",
+            contractName: "contractId",
+            walletUrl: "http://example.com/wallet",
         },
         connection: {
-            networkId: 'networkId',
-            signer: new nearApi.InMemorySigner(keyStore)
+            networkId: "networkId",
+            signer: new nearApi.InMemorySigner(keyStore),
         },
         account() {
             return {
-                state() {}
+                state() {},
             };
-        }
+        },
     };
     lastRedirectUrl = null;
     history = [];
     Object.assign(global.window, {
         location: {
-            href: 'http://example.com/location',
+            href: "http://example.com/location",
             assign(url) {
                 lastRedirectUrl = url;
-            }
+            },
         },
         history: {
-            replaceState: (state, title, url) => history.push([state, title, url])
-        }
+            replaceState: (state, title, url) =>
+                history.push([state, title, url]),
+        },
     });
     walletConnection = new nearApi.WalletConnection(nearFake);
 });
 
-it('not signed in by default', () => {
+it("not signed in by default", () => {
     expect(walletConnection.isSignedIn()).not.toBeTruthy();
 });
 
-it('can request sign in', async () => {
-    await walletConnection.requestSignIn('signInContract', 'signInTitle', 'http://example.com/success',  'http://example.com/fail');
+it("can request sign in", async () => {
+    await walletConnection.requestSignIn(
+        "signInContract",
+        "signInTitle",
+        "http://example.com/success",
+        "http://example.com/fail"
+    );
 
-    let accounts = await keyStore.getAccounts('networkId');
+    let accounts = await keyStore.getAccounts("networkId");
     expect(accounts).toHaveLength(1);
     expect(accounts[0]).toMatch(/^pending_key.+/);
     expect(url.parse(lastRedirectUrl, true)).toMatchObject({
-        protocol: 'http:',
-        host: 'example.com',
+        protocol: "http:",
+        host: "example.com",
         query: {
-            contract_id: 'signInContract',
-            success_url: 'http://example.com/success',
-            failure_url: 'http://example.com/fail',
-            public_key: (await keyStore.getKey('networkId', accounts[0])).publicKey.toString()
-        }
+            contract_id: "signInContract",
+            success_url: "http://example.com/success",
+            failure_url: "http://example.com/fail",
+            public_key: (
+                await keyStore.getKey("networkId", accounts[0])
+            ).publicKey.toString(),
+        },
     });
 });
 
-it('can complete sign in', async () => {
-    const keyPair = nearApi.KeyPair.fromRandom('ed25519');
+it("can complete sign in", async () => {
+    const keyPair = nearApi.KeyPair.fromRandom("ed25519");
     global.window.location.href = `http://example.com/location?account_id=near.account&public_key=${keyPair.publicKey}`;
-    await keyStore.setKey('networkId', 'pending_key' + keyPair.publicKey, keyPair);
+    await keyStore.setKey(
+        "networkId",
+        "pending_key" + keyPair.publicKey,
+        keyPair
+    );
 
     await walletConnection._completeSignInWithAccessKey();
 
-    expect(await keyStore.getKey('networkId', 'near.account')).toEqual(keyPair);
-    expect(localStorage.getItem('contractId_wallet_auth_key'));
+    expect(await keyStore.getKey("networkId", "near.account")).toEqual(keyPair);
+    expect(localStorage.getItem("contractId_wallet_auth_key"));
     expect(history.slice(1)).toEqual([
-        [{}, 'documentTitle', 'http://example.com/location']
+        [{}, "documentTitle", "http://example.com/location"],
     ]);
 });
 
-const BLOCK_HASH = '244ZQ9cgj3CQ6bWBdytfrJMuMQ1jdXLFGnr4HhvtCTnM';
+const BLOCK_HASH = "244ZQ9cgj3CQ6bWBdytfrJMuMQ1jdXLFGnr4HhvtCTnM";
 const blockHash = nearApi.utils.serialize.base_decode(BLOCK_HASH);
 function createTransferTx() {
-    const actions = [
-        nearApi.transactions.transfer(1),
-    ];
+    const actions = [nearApi.transactions.transfer(1)];
     return nearApi.transactions.createTransaction(
-        'test.near',
-        nearApi.utils.PublicKey.fromString('Anu7LYDfpLtkP7E16LT9imXF694BdQaa9ufVkQiwTQxC'),
-        'whatever.near',
+        "test.near",
+        nearApi.utils.PublicKey.fromString(
+            "Anu7LYDfpLtkP7E16LT9imXF694BdQaa9ufVkQiwTQxC"
+        ),
+        "whatever.near",
         1,
         actions,
-        blockHash);
+        blockHash
+    );
 }
 
-it('can request transaction signing', async () => {
-    await walletConnection.requestSignTransactions([createTransferTx()], 'http://example.com/callback');
+it("can request transaction signing", async () => {
+    await walletConnection.requestSignTransactions(
+        [createTransferTx()],
+        "http://example.com/callback"
+    );
 
     expect(url.parse(lastRedirectUrl, true)).toMatchObject({
-        protocol: 'http:',
-        host: 'example.com',
+        protocol: "http:",
+        host: "example.com",
         query: {
-            callbackUrl: 'http://example.com/callback',
-            transactions: 'CQAAAHRlc3QubmVhcgCRez0mjUtY9/7BsVC9aNab4+5dTMOYVeNBU4Rlu3eGDQEAAAAAAAAADQAAAHdoYXRldmVyLm5lYXIPpHP9JpAd8pa+atxMxN800EDvokNSJLaYaRDmMML+9gEAAAADAQAAAAAAAAAAAAAAAAAAAA=='
-        }
+            callbackUrl: "http://example.com/callback",
+            transactions:
+                "CQAAAHRlc3QubmVhcgCRez0mjUtY9/7BsVC9aNab4+5dTMOYVeNBU4Rlu3eGDQEAAAAAAAAADQAAAHdoYXRldmVyLm5lYXIPpHP9JpAd8pa+atxMxN800EDvokNSJLaYaRDmMML+9gEAAAADAQAAAAAAAAAAAAAAAAAAAA==",
+        },
     });
+});
+
+it("can send a batch of transactions with only one redirect", async () => {
+    let localKeyPair = nearApi.KeyPair.fromRandom("ed25519");
+    let walletKeyPair = nearApi.KeyPair.fromRandom("ed25519");
+    setupWalletConnectionForSigning({
+        allKeys: [walletKeyPair.publicKey.toString()],
+        accountAccessKeys: [
+            {
+                access_key: {
+                    nonce: 1,
+                    permission: {
+                        FunctionCall: {
+                            allowance: "1000000000",
+                            receiver_id: "receiver.near",
+                            method_names: [],
+                        },
+                    },
+                },
+                public_key: localKeyPair.publicKey.toString(),
+            },
+            {
+                access_key: {
+                    nonce: 1,
+                    permission: "FullAccess",
+                },
+                public_key: walletKeyPair.publicKey.toString(),
+            },
+        ],
+    });
+    await keyStore.setKey("networkId", "signer.near", localKeyPair);
+
+    await walletConnection.batchSendTransactions([
+        {
+            receiverId: "contract-1.testnet",
+            actions: [
+                functionCall(
+                    "contractMethod",
+                    { arg: "value" },
+                    new BN("30000000000000"),
+                    new BN(nearApi.utils.format.parseNearAmount("1"))
+                ),
+            ],
+        },
+        {
+            receiverId: "user-account-1.testnet",
+            actions: [
+                transfer(new BN(nearApi.utils.format.parseNearAmount("1"))),
+                transfer(new BN(nearApi.utils.format.parseNearAmount("4"))),
+            ],
+        },
+    ]);
+
+    const transactions = parseTransactionsFromUrl(lastRedirectUrl);
+    expect(transactions).toHaveLength(2);
 });
 
 function parseTransactionsFromUrl(urlToParse) {
     const parsedUrl = url.parse(urlToParse, true);
     expect(parsedUrl).toMatchObject({
-        protocol: 'http:',
-        host: 'example.com',
+        protocol: "http:",
+        host: "example.com",
         query: {
-            callbackUrl: 'http://example.com/location'
-        }
+            callbackUrl: "http://example.com/location",
+        },
     });
-    const transactions = parsedUrl.query.transactions.split(',')
-        .map(txBase64 => nearApi.utils.serialize.deserialize(
-            nearApi.transactions.SCHEMA,
-            nearApi.transactions.Transaction,
-            Buffer.from(txBase64, 'base64')));
+    const transactions = parsedUrl.query.transactions
+        .split(",")
+        .map((txBase64) =>
+            nearApi.utils.serialize.deserialize(
+                nearApi.transactions.SCHEMA,
+                nearApi.transactions.Transaction,
+                Buffer.from(txBase64, "base64")
+            )
+        );
     return transactions;
 }
 
 function setupWalletConnectionForSigning({ allKeys, accountAccessKeys }) {
     walletConnection._authData = {
         allKeys: allKeys,
-        accountId: 'signer.near'
+        accountId: "signer.near",
     };
     nearFake.connection.provider = {
         query(params) {
-            if (params.request_type === 'view_account' && params.account_id === 'signer.near') {
-                return { };
+            if (
+                params.request_type === "view_account" &&
+                params.account_id === "signer.near"
+            ) {
+                return {};
             }
-            if (params.request_type === 'view_access_key_list' && params.account_id === 'signer.near') {
+            if (
+                params.request_type === "view_access_key_list" &&
+                params.account_id === "signer.near"
+            ) {
                 return { keys: accountAccessKeys };
             }
-            if (params.request_type === 'view_access_key' && params.account_id === 'signer.near') {
+            if (
+                params.request_type === "view_access_key" &&
+                params.account_id === "signer.near"
+            ) {
                 for (let accessKey of accountAccessKeys) {
                     if (accessKey.public_key === params.public_key) {
                         return accessKey;
@@ -159,196 +245,256 @@ function setupWalletConnectionForSigning({ allKeys, accountAccessKeys }) {
             lastTransaction = signedTransaction;
             return {
                 transaction_outcome: { outcome: { logs: [] } },
-                receipts_outcome: []
+                receipts_outcome: [],
             };
         },
         block() {
             return {
                 header: {
-                    hash: BLOCK_HASH
-                }
+                    hash: BLOCK_HASH,
+                },
             };
-        }
+        },
     };
 }
 
-it('requests transaction signing automatically when there is no local key', async () => {
-    let keyPair = nearApi.KeyPair.fromRandom('ed25519');
+it("requests transaction signing automatically when there is no local key", async () => {
+    let keyPair = nearApi.KeyPair.fromRandom("ed25519");
     setupWalletConnectionForSigning({
-        allKeys: [ 'no_such_access_key', keyPair.publicKey.toString() ],
-        accountAccessKeys: [{
-            access_key: {
-                nonce: 1,
-                permission: 'FullAccess'
+        allKeys: ["no_such_access_key", keyPair.publicKey.toString()],
+        accountAccessKeys: [
+            {
+                access_key: {
+                    nonce: 1,
+                    permission: "FullAccess",
+                },
+                public_key: keyPair.publicKey.toString(),
             },
-            public_key: keyPair.publicKey.toString()
-        }]
+        ],
     });
 
     try {
-        await walletConnection.account().signAndSendTransaction('receiver.near', [nearApi.transactions.transfer(1)]);
-        fail('expected to throw');
+        await walletConnection
+            .account()
+            .signAndSendTransaction("receiver.near", [
+                nearApi.transactions.transfer(1),
+            ]);
+        fail("expected to throw");
     } catch (e) {
-        expect(e.message).toEqual('Failed to redirect to sign transaction');
+        expect(e.message).toEqual("Failed to redirect to sign transaction");
     }
 
     const transactions = parseTransactionsFromUrl(lastRedirectUrl);
     expect(transactions).toHaveLength(1);
     expect(transactions[0]).toMatchObject({
-        signerId: 'signer.near',
+        signerId: "signer.near",
         // nonce: new BN(2)
-        receiverId: 'receiver.near',
-        actions: [{
-            transfer: {
-                // deposit: new BN(1)
-            }
-        }]
+        receiverId: "receiver.near",
+        actions: [
+            {
+                transfer: {
+                    // deposit: new BN(1)
+                },
+            },
+        ],
     });
-    expect(transactions[0].nonce.toString()).toEqual('2');
-    expect(transactions[0].actions[0].transfer.deposit.toString()).toEqual('1');
-    expect(Buffer.from(transactions[0].publicKey.data)).toEqual(Buffer.from(keyPair.publicKey.data));
+    expect(transactions[0].nonce.toString()).toEqual("2");
+    expect(transactions[0].actions[0].transfer.deposit.toString()).toEqual("1");
+    expect(Buffer.from(transactions[0].publicKey.data)).toEqual(
+        Buffer.from(keyPair.publicKey.data)
+    );
 });
 
-it('requests transaction signing automatically when function call has attached deposit', async () => {
-    let localKeyPair = nearApi.KeyPair.fromRandom('ed25519');
-    let walletKeyPair = nearApi.KeyPair.fromRandom('ed25519');
+it("requests transaction signing automatically when function call has attached deposit", async () => {
+    let localKeyPair = nearApi.KeyPair.fromRandom("ed25519");
+    let walletKeyPair = nearApi.KeyPair.fromRandom("ed25519");
     setupWalletConnectionForSigning({
-        allKeys: [ walletKeyPair.publicKey.toString() ],
-        accountAccessKeys: [{
-            access_key: {
-                nonce: 1,
-                permission: {
-                    FunctionCall: {
-                        allowance: '1000000000',
-                        receiver_id: 'receiver.near',
-                        method_names: []
-                    }
-                }
+        allKeys: [walletKeyPair.publicKey.toString()],
+        accountAccessKeys: [
+            {
+                access_key: {
+                    nonce: 1,
+                    permission: {
+                        FunctionCall: {
+                            allowance: "1000000000",
+                            receiver_id: "receiver.near",
+                            method_names: [],
+                        },
+                    },
+                },
+                public_key: localKeyPair.publicKey.toString(),
             },
-            public_key: localKeyPair.publicKey.toString()
-        }, {
-            access_key: {
-                nonce: 1,
-                permission: 'FullAccess'
+            {
+                access_key: {
+                    nonce: 1,
+                    permission: "FullAccess",
+                },
+                public_key: walletKeyPair.publicKey.toString(),
             },
-            public_key: walletKeyPair.publicKey.toString()
-        }]
+        ],
     });
-    await keyStore.setKey('networkId', 'signer.near', localKeyPair);
+    await keyStore.setKey("networkId", "signer.near", localKeyPair);
 
     try {
-        await walletConnection.account().signAndSendTransaction('receiver.near', [
-            nearApi.transactions.functionCall('someMethod', new Uint8Array(), new BN('1'), new BN('1'))
-        ]);
-        fail('expected to throw');
+        await walletConnection
+            .account()
+            .signAndSendTransaction("receiver.near", [
+                nearApi.transactions.functionCall(
+                    "someMethod",
+                    new Uint8Array(),
+                    new BN("1"),
+                    new BN("1")
+                ),
+            ]);
+        fail("expected to throw");
     } catch (e) {
-        expect(e.message).toEqual('Failed to redirect to sign transaction');
+        expect(e.message).toEqual("Failed to redirect to sign transaction");
     }
 
     const transactions = parseTransactionsFromUrl(lastRedirectUrl);
     expect(transactions).toHaveLength(1);
 });
 
-it('requests transaction signing with 2fa access key', async () => {
-    let localKeyPair = nearApi.KeyPair.fromRandom('ed25519');
-    let walletKeyPair = nearApi.KeyPair.fromRandom('ed25519');
+it("requests transaction signing with 2fa access key", async () => {
+    let localKeyPair = nearApi.KeyPair.fromRandom("ed25519");
+    let walletKeyPair = nearApi.KeyPair.fromRandom("ed25519");
     setupWalletConnectionForSigning({
-        allKeys: [ walletKeyPair.publicKey.toString() ],
-        accountAccessKeys: [{
-            access_key: {
-                nonce: 1,
-                permission: {
-                    FunctionCall: {
-                        allowance: '1000000000',
-                        receiver_id: 'signer.near',
-                        method_names: [MULTISIG_HAS_METHOD]
-                    }
-                }
+        allKeys: [walletKeyPair.publicKey.toString()],
+        accountAccessKeys: [
+            {
+                access_key: {
+                    nonce: 1,
+                    permission: {
+                        FunctionCall: {
+                            allowance: "1000000000",
+                            receiver_id: "signer.near",
+                            method_names: [MULTISIG_HAS_METHOD],
+                        },
+                    },
+                },
+                public_key: localKeyPair.publicKey.toString(),
             },
-            public_key: localKeyPair.publicKey.toString()
-        }]
+        ],
     });
-    await keyStore.setKey('networkId', 'signer.near', localKeyPair);
+    await keyStore.setKey("networkId", "signer.near", localKeyPair);
 
     let res;
     try {
-        res = await walletConnection.account().signAndSendTransaction('receiver.near', [
-            nearApi.transactions.functionCall('someMethod', new Uint8Array(), new BN('1'), new BN('1'))
-        ]);
+        res = await walletConnection
+            .account()
+            .signAndSendTransaction("receiver.near", [
+                nearApi.transactions.functionCall(
+                    "someMethod",
+                    new Uint8Array(),
+                    new BN("1"),
+                    new BN("1")
+                ),
+            ]);
     } catch (e) {
-        fail('expected transaction outcome');
+        fail("expected transaction outcome");
     }
     // multisig access key is accepted res is object representing transaction, populated upon wallet redirect to app
-    expect(res).toHaveProperty('transaction_outcome');
-    expect(res).toHaveProperty('receipts_outcome');
+    expect(res).toHaveProperty("transaction_outcome");
+    expect(res).toHaveProperty("receipts_outcome");
 });
 
-it('fails requests transaction signing without 2fa access key', async () => {
-    let localKeyPair = nearApi.KeyPair.fromRandom('ed25519');
-    let walletKeyPair = nearApi.KeyPair.fromRandom('ed25519');
+it("fails requests transaction signing without 2fa access key", async () => {
+    let localKeyPair = nearApi.KeyPair.fromRandom("ed25519");
+    let walletKeyPair = nearApi.KeyPair.fromRandom("ed25519");
     setupWalletConnectionForSigning({
-        allKeys: [ walletKeyPair.publicKey.toString() ],
-        accountAccessKeys: [{
-            access_key: {
-                nonce: 1,
-                permission: {
-                    FunctionCall: {
-                        allowance: '1000000000',
-                        receiver_id: 'signer.near',
-                        method_names: ['not_a_valid_2fa_method']
-                    }
-                }
+        allKeys: [walletKeyPair.publicKey.toString()],
+        accountAccessKeys: [
+            {
+                access_key: {
+                    nonce: 1,
+                    permission: {
+                        FunctionCall: {
+                            allowance: "1000000000",
+                            receiver_id: "signer.near",
+                            method_names: ["not_a_valid_2fa_method"],
+                        },
+                    },
+                },
+                public_key: localKeyPair.publicKey.toString(),
             },
-            public_key: localKeyPair.publicKey.toString()
-        }]
+        ],
     });
-    await keyStore.setKey('networkId', 'signer.near', localKeyPair);
+    await keyStore.setKey("networkId", "signer.near", localKeyPair);
 
     try {
-        await walletConnection.account().signAndSendTransaction('receiver.near', [
-            nearApi.transactions.functionCall('someMethod', new Uint8Array(), new BN('1'), new BN('1'))
-        ]);
-        fail('expected to throw');
+        await walletConnection
+            .account()
+            .signAndSendTransaction("receiver.near", [
+                nearApi.transactions.functionCall(
+                    "someMethod",
+                    new Uint8Array(),
+                    new BN("1"),
+                    new BN("1")
+                ),
+            ]);
+        fail("expected to throw");
     } catch (e) {
-        expect(e.message).toEqual('Cannot find matching key for transaction sent to receiver.near');
+        expect(e.message).toEqual(
+            "Cannot find matching key for transaction sent to receiver.near"
+        );
     }
 });
 
 it.each([
-    nearApi.transactions.functionCall('someMethod', new Uint8Array(), new BN('1'), new BN('0')),
-    nearApi.transactions.functionCall('someMethod', new Uint8Array(), new BN('1')),
-    nearApi.transactions.functionCall('someMethod', new Uint8Array())
-])('can sign transaction locally when function call has no attached deposit', async (functionCall) => {
-    let localKeyPair = nearApi.KeyPair.fromRandom('ed25519');
-    setupWalletConnectionForSigning({
-        allKeys: [ /* no keys in wallet needed */ ],
-        accountAccessKeys: [{
-            access_key: {
-                nonce: 1,
-                permission: {
-                    FunctionCall: {
-                        allowance: '1000000000',
-                        receiver_id: 'receiver.near',
-                        method_names: []
-                    }
-                }
-            },
-            public_key: localKeyPair.publicKey.toString()
-        }]
-    });
-    keyStore.setKey('networkId', 'signer.near', localKeyPair);
+    nearApi.transactions.functionCall(
+        "someMethod",
+        new Uint8Array(),
+        new BN("1"),
+        new BN("0")
+    ),
+    nearApi.transactions.functionCall(
+        "someMethod",
+        new Uint8Array(),
+        new BN("1")
+    ),
+    nearApi.transactions.functionCall("someMethod", new Uint8Array()),
+])(
+    "can sign transaction locally when function call has no attached deposit",
+    async (functionCall) => {
+        let localKeyPair = nearApi.KeyPair.fromRandom("ed25519");
+        setupWalletConnectionForSigning({
+            allKeys: [
+                /* no keys in wallet needed */
+            ],
+            accountAccessKeys: [
+                {
+                    access_key: {
+                        nonce: 1,
+                        permission: {
+                            FunctionCall: {
+                                allowance: "1000000000",
+                                receiver_id: "receiver.near",
+                                method_names: [],
+                            },
+                        },
+                    },
+                    public_key: localKeyPair.publicKey.toString(),
+                },
+            ],
+        });
+        keyStore.setKey("networkId", "signer.near", localKeyPair);
 
-    await walletConnection.account().signAndSendTransaction('receiver.near', [ functionCall ]);
-    // NOTE: Transaction gets signed without wallet in this test
-    expect(lastTransaction).toMatchObject({
-        transaction: {
-            receiverId: 'receiver.near',
-            signerId: 'signer.near',
-            actions: [{
-                functionCall: {
-                    methodName: 'someMethod',
-                }
-            }]
-        }
-    });
-});
+        await walletConnection
+            .account()
+            .signAndSendTransaction("receiver.near", [functionCall]);
+        // NOTE: Transaction gets signed without wallet in this test
+        expect(lastTransaction).toMatchObject({
+            transaction: {
+                receiverId: "receiver.near",
+                signerId: "signer.near",
+                actions: [
+                    {
+                        functionCall: {
+                            methodName: "someMethod",
+                        },
+                    },
+                ],
+            },
+        });
+    }
+);

--- a/test/wallet-account.test.js
+++ b/test/wallet-account.test.js
@@ -171,7 +171,7 @@ it('can send a batch of transactions with only one redirect', async () => {
                 functionCall(
                     'contractMethod',
                     { arg: 'value' },
-                    new BN('30000000000000'),
+                    new BN('300000000000000'),
                     new BN(nearApi.utils.format.parseNearAmount('1'))
                 ),
             ],

--- a/test/wallet-account.test.js
+++ b/test/wallet-account.test.js
@@ -1,10 +1,10 @@
-const url = require("url");
-const localStorage = require("localstorage-memory");
-const BN = require("bn.js");
-const { functionCall, transfer } = require("../lib/transaction");
+const url = require('url');
+const localStorage = require('localstorage-memory');
+const BN = require('bn.js');
+const { functionCall, transfer } = require('../lib/transaction');
 
 // If an access key has itself as receiverId and method permission add_request_and_confirm, then it is being used in a wallet with multisig contract: https://github.com/near/core-contracts/blob/671c05f09abecabe7a7e58efe942550a35fc3292/multisig/src/lib.rs#L149-L153
-const MULTISIG_HAS_METHOD = "add_request_and_confirm";
+const MULTISIG_HAS_METHOD = 'add_request_and_confirm';
 
 let lastRedirectUrl;
 let lastTransaction;
@@ -12,9 +12,9 @@ global.window = {
     localStorage,
 };
 global.document = {
-    title: "documentTitle",
+    title: 'documentTitle',
 };
-const nearApi = require("../lib/index");
+const nearApi = require('../lib/index');
 
 let history;
 let nearFake;
@@ -23,12 +23,12 @@ let keyStore = new nearApi.keyStores.InMemoryKeyStore();
 beforeEach(() => {
     nearFake = {
         config: {
-            networkId: "networkId",
-            contractName: "contractId",
-            walletUrl: "http://example.com/wallet",
+            networkId: 'networkId',
+            contractName: 'contractId',
+            walletUrl: 'http://example.com/wallet',
         },
         connection: {
-            networkId: "networkId",
+            networkId: 'networkId',
             signer: new nearApi.InMemorySigner(keyStore),
         },
         account() {
@@ -41,7 +41,7 @@ beforeEach(() => {
     history = [];
     Object.assign(global.window, {
         location: {
-            href: "http://example.com/location",
+            href: 'http://example.com/location',
             assign(url) {
                 lastRedirectUrl = url;
             },
@@ -54,89 +54,89 @@ beforeEach(() => {
     walletConnection = new nearApi.WalletConnection(nearFake);
 });
 
-it("not signed in by default", () => {
+it('not signed in by default', () => {
     expect(walletConnection.isSignedIn()).not.toBeTruthy();
 });
 
-it("can request sign in", async () => {
+it('can request sign in', async () => {
     await walletConnection.requestSignIn(
-        "signInContract",
-        "signInTitle",
-        "http://example.com/success",
-        "http://example.com/fail"
+        'signInContract',
+        'signInTitle',
+        'http://example.com/success',
+        'http://example.com/fail'
     );
 
-    let accounts = await keyStore.getAccounts("networkId");
+    let accounts = await keyStore.getAccounts('networkId');
     expect(accounts).toHaveLength(1);
     expect(accounts[0]).toMatch(/^pending_key.+/);
     expect(url.parse(lastRedirectUrl, true)).toMatchObject({
-        protocol: "http:",
-        host: "example.com",
+        protocol: 'http:',
+        host: 'example.com',
         query: {
-            contract_id: "signInContract",
-            success_url: "http://example.com/success",
-            failure_url: "http://example.com/fail",
+            contract_id: 'signInContract',
+            success_url: 'http://example.com/success',
+            failure_url: 'http://example.com/fail',
             public_key: (
-                await keyStore.getKey("networkId", accounts[0])
+                await keyStore.getKey('networkId', accounts[0])
             ).publicKey.toString(),
         },
     });
 });
 
-it("can complete sign in", async () => {
-    const keyPair = nearApi.KeyPair.fromRandom("ed25519");
+it('can complete sign in', async () => {
+    const keyPair = nearApi.KeyPair.fromRandom('ed25519');
     global.window.location.href = `http://example.com/location?account_id=near.account&public_key=${keyPair.publicKey}`;
     await keyStore.setKey(
-        "networkId",
-        "pending_key" + keyPair.publicKey,
+        'networkId',
+        'pending_key' + keyPair.publicKey,
         keyPair
     );
 
     await walletConnection._completeSignInWithAccessKey();
 
-    expect(await keyStore.getKey("networkId", "near.account")).toEqual(keyPair);
-    expect(localStorage.getItem("contractId_wallet_auth_key"));
+    expect(await keyStore.getKey('networkId', 'near.account')).toEqual(keyPair);
+    expect(localStorage.getItem('contractId_wallet_auth_key'));
     expect(history.slice(1)).toEqual([
-        [{}, "documentTitle", "http://example.com/location"],
+        [{}, 'documentTitle', 'http://example.com/location'],
     ]);
 });
 
-const BLOCK_HASH = "244ZQ9cgj3CQ6bWBdytfrJMuMQ1jdXLFGnr4HhvtCTnM";
+const BLOCK_HASH = '244ZQ9cgj3CQ6bWBdytfrJMuMQ1jdXLFGnr4HhvtCTnM';
 const blockHash = nearApi.utils.serialize.base_decode(BLOCK_HASH);
 function createTransferTx() {
     const actions = [nearApi.transactions.transfer(1)];
     return nearApi.transactions.createTransaction(
-        "test.near",
+        'test.near',
         nearApi.utils.PublicKey.fromString(
-            "Anu7LYDfpLtkP7E16LT9imXF694BdQaa9ufVkQiwTQxC"
+            'Anu7LYDfpLtkP7E16LT9imXF694BdQaa9ufVkQiwTQxC'
         ),
-        "whatever.near",
+        'whatever.near',
         1,
         actions,
         blockHash
     );
 }
 
-it("can request transaction signing", async () => {
+it('can request transaction signing', async () => {
     await walletConnection.requestSignTransactions(
         [createTransferTx()],
-        "http://example.com/callback"
+        'http://example.com/callback'
     );
 
     expect(url.parse(lastRedirectUrl, true)).toMatchObject({
-        protocol: "http:",
-        host: "example.com",
+        protocol: 'http:',
+        host: 'example.com',
         query: {
-            callbackUrl: "http://example.com/callback",
+            callbackUrl: 'http://example.com/callback',
             transactions:
-                "CQAAAHRlc3QubmVhcgCRez0mjUtY9/7BsVC9aNab4+5dTMOYVeNBU4Rlu3eGDQEAAAAAAAAADQAAAHdoYXRldmVyLm5lYXIPpHP9JpAd8pa+atxMxN800EDvokNSJLaYaRDmMML+9gEAAAADAQAAAAAAAAAAAAAAAAAAAA==",
+                'CQAAAHRlc3QubmVhcgCRez0mjUtY9/7BsVC9aNab4+5dTMOYVeNBU4Rlu3eGDQEAAAAAAAAADQAAAHdoYXRldmVyLm5lYXIPpHP9JpAd8pa+atxMxN800EDvokNSJLaYaRDmMML+9gEAAAADAQAAAAAAAAAAAAAAAAAAAA==',
         },
     });
 });
 
-it("can send a batch of transactions with only one redirect", async () => {
-    let localKeyPair = nearApi.KeyPair.fromRandom("ed25519");
-    let walletKeyPair = nearApi.KeyPair.fromRandom("ed25519");
+it('can send a batch of transactions with only one redirect', async () => {
+    let localKeyPair = nearApi.KeyPair.fromRandom('ed25519');
+    let walletKeyPair = nearApi.KeyPair.fromRandom('ed25519');
     setupWalletConnectionForSigning({
         allKeys: [walletKeyPair.publicKey.toString()],
         accountAccessKeys: [
@@ -145,8 +145,8 @@ it("can send a batch of transactions with only one redirect", async () => {
                     nonce: 1,
                     permission: {
                         FunctionCall: {
-                            allowance: "1000000000",
-                            receiver_id: "receiver.near",
+                            allowance: '1000000000',
+                            receiver_id: 'receiver.near',
                             method_names: [],
                         },
                     },
@@ -156,31 +156,31 @@ it("can send a batch of transactions with only one redirect", async () => {
             {
                 access_key: {
                     nonce: 1,
-                    permission: "FullAccess",
+                    permission: 'FullAccess',
                 },
                 public_key: walletKeyPair.publicKey.toString(),
             },
         ],
     });
-    await keyStore.setKey("networkId", "signer.near", localKeyPair);
+    await keyStore.setKey('networkId', 'signer.near', localKeyPair);
 
     await walletConnection.batchSendTransactions([
         {
-            receiverId: "contract-1.testnet",
+            receiverId: 'contract-1.testnet',
             actions: [
                 functionCall(
-                    "contractMethod",
-                    { arg: "value" },
-                    new BN("30000000000000"),
-                    new BN(nearApi.utils.format.parseNearAmount("1"))
+                    'contractMethod',
+                    { arg: 'value' },
+                    new BN('30000000000000'),
+                    new BN(nearApi.utils.format.parseNearAmount('1'))
                 ),
             ],
         },
         {
-            receiverId: "user-account-1.testnet",
+            receiverId: 'user-account-1.testnet',
             actions: [
-                transfer(new BN(nearApi.utils.format.parseNearAmount("1"))),
-                transfer(new BN(nearApi.utils.format.parseNearAmount("4"))),
+                transfer(new BN(nearApi.utils.format.parseNearAmount('1'))),
+                transfer(new BN(nearApi.utils.format.parseNearAmount('4'))),
             ],
         },
     ]);
@@ -192,19 +192,19 @@ it("can send a batch of transactions with only one redirect", async () => {
 function parseTransactionsFromUrl(urlToParse) {
     const parsedUrl = url.parse(urlToParse, true);
     expect(parsedUrl).toMatchObject({
-        protocol: "http:",
-        host: "example.com",
+        protocol: 'http:',
+        host: 'example.com',
         query: {
-            callbackUrl: "http://example.com/location",
+            callbackUrl: 'http://example.com/location',
         },
     });
     const transactions = parsedUrl.query.transactions
-        .split(",")
+        .split(',')
         .map((txBase64) =>
             nearApi.utils.serialize.deserialize(
                 nearApi.transactions.SCHEMA,
                 nearApi.transactions.Transaction,
-                Buffer.from(txBase64, "base64")
+                Buffer.from(txBase64, 'base64')
             )
         );
     return transactions;
@@ -213,25 +213,25 @@ function parseTransactionsFromUrl(urlToParse) {
 function setupWalletConnectionForSigning({ allKeys, accountAccessKeys }) {
     walletConnection._authData = {
         allKeys: allKeys,
-        accountId: "signer.near",
+        accountId: 'signer.near',
     };
     nearFake.connection.provider = {
         query(params) {
             if (
-                params.request_type === "view_account" &&
-                params.account_id === "signer.near"
+                params.request_type === 'view_account' &&
+                params.account_id === 'signer.near'
             ) {
                 return {};
             }
             if (
-                params.request_type === "view_access_key_list" &&
-                params.account_id === "signer.near"
+                params.request_type === 'view_access_key_list' &&
+                params.account_id === 'signer.near'
             ) {
                 return { keys: accountAccessKeys };
             }
             if (
-                params.request_type === "view_access_key" &&
-                params.account_id === "signer.near"
+                params.request_type === 'view_access_key' &&
+                params.account_id === 'signer.near'
             ) {
                 for (let accessKey of accountAccessKeys) {
                     if (accessKey.public_key === params.public_key) {
@@ -258,15 +258,15 @@ function setupWalletConnectionForSigning({ allKeys, accountAccessKeys }) {
     };
 }
 
-it("requests transaction signing automatically when there is no local key", async () => {
-    let keyPair = nearApi.KeyPair.fromRandom("ed25519");
+it('requests transaction signing automatically when there is no local key', async () => {
+    let keyPair = nearApi.KeyPair.fromRandom('ed25519');
     setupWalletConnectionForSigning({
-        allKeys: ["no_such_access_key", keyPair.publicKey.toString()],
+        allKeys: ['no_such_access_key', keyPair.publicKey.toString()],
         accountAccessKeys: [
             {
                 access_key: {
                     nonce: 1,
-                    permission: "FullAccess",
+                    permission: 'FullAccess',
                 },
                 public_key: keyPair.publicKey.toString(),
             },
@@ -276,20 +276,20 @@ it("requests transaction signing automatically when there is no local key", asyn
     try {
         await walletConnection
             .account()
-            .signAndSendTransaction("receiver.near", [
+            .signAndSendTransaction('receiver.near', [
                 nearApi.transactions.transfer(1),
             ]);
-        fail("expected to throw");
+        fail('expected to throw');
     } catch (e) {
-        expect(e.message).toEqual("Failed to redirect to sign transaction");
+        expect(e.message).toEqual('Failed to redirect to sign transaction');
     }
 
     const transactions = parseTransactionsFromUrl(lastRedirectUrl);
     expect(transactions).toHaveLength(1);
     expect(transactions[0]).toMatchObject({
-        signerId: "signer.near",
+        signerId: 'signer.near',
         // nonce: new BN(2)
-        receiverId: "receiver.near",
+        receiverId: 'receiver.near',
         actions: [
             {
                 transfer: {
@@ -298,16 +298,16 @@ it("requests transaction signing automatically when there is no local key", asyn
             },
         ],
     });
-    expect(transactions[0].nonce.toString()).toEqual("2");
-    expect(transactions[0].actions[0].transfer.deposit.toString()).toEqual("1");
+    expect(transactions[0].nonce.toString()).toEqual('2');
+    expect(transactions[0].actions[0].transfer.deposit.toString()).toEqual('1');
     expect(Buffer.from(transactions[0].publicKey.data)).toEqual(
         Buffer.from(keyPair.publicKey.data)
     );
 });
 
-it("requests transaction signing automatically when function call has attached deposit", async () => {
-    let localKeyPair = nearApi.KeyPair.fromRandom("ed25519");
-    let walletKeyPair = nearApi.KeyPair.fromRandom("ed25519");
+it('requests transaction signing automatically when function call has attached deposit', async () => {
+    let localKeyPair = nearApi.KeyPair.fromRandom('ed25519');
+    let walletKeyPair = nearApi.KeyPair.fromRandom('ed25519');
     setupWalletConnectionForSigning({
         allKeys: [walletKeyPair.publicKey.toString()],
         accountAccessKeys: [
@@ -316,8 +316,8 @@ it("requests transaction signing automatically when function call has attached d
                     nonce: 1,
                     permission: {
                         FunctionCall: {
-                            allowance: "1000000000",
-                            receiver_id: "receiver.near",
+                            allowance: '1000000000',
+                            receiver_id: 'receiver.near',
                             method_names: [],
                         },
                     },
@@ -327,37 +327,37 @@ it("requests transaction signing automatically when function call has attached d
             {
                 access_key: {
                     nonce: 1,
-                    permission: "FullAccess",
+                    permission: 'FullAccess',
                 },
                 public_key: walletKeyPair.publicKey.toString(),
             },
         ],
     });
-    await keyStore.setKey("networkId", "signer.near", localKeyPair);
+    await keyStore.setKey('networkId', 'signer.near', localKeyPair);
 
     try {
         await walletConnection
             .account()
-            .signAndSendTransaction("receiver.near", [
+            .signAndSendTransaction('receiver.near', [
                 nearApi.transactions.functionCall(
-                    "someMethod",
+                    'someMethod',
                     new Uint8Array(),
-                    new BN("1"),
-                    new BN("1")
+                    new BN('1'),
+                    new BN('1')
                 ),
             ]);
-        fail("expected to throw");
+        fail('expected to throw');
     } catch (e) {
-        expect(e.message).toEqual("Failed to redirect to sign transaction");
+        expect(e.message).toEqual('Failed to redirect to sign transaction');
     }
 
     const transactions = parseTransactionsFromUrl(lastRedirectUrl);
     expect(transactions).toHaveLength(1);
 });
 
-it("requests transaction signing with 2fa access key", async () => {
-    let localKeyPair = nearApi.KeyPair.fromRandom("ed25519");
-    let walletKeyPair = nearApi.KeyPair.fromRandom("ed25519");
+it('requests transaction signing with 2fa access key', async () => {
+    let localKeyPair = nearApi.KeyPair.fromRandom('ed25519');
+    let walletKeyPair = nearApi.KeyPair.fromRandom('ed25519');
     setupWalletConnectionForSigning({
         allKeys: [walletKeyPair.publicKey.toString()],
         accountAccessKeys: [
@@ -366,8 +366,8 @@ it("requests transaction signing with 2fa access key", async () => {
                     nonce: 1,
                     permission: {
                         FunctionCall: {
-                            allowance: "1000000000",
-                            receiver_id: "signer.near",
+                            allowance: '1000000000',
+                            receiver_id: 'signer.near',
                             method_names: [MULTISIG_HAS_METHOD],
                         },
                     },
@@ -376,31 +376,31 @@ it("requests transaction signing with 2fa access key", async () => {
             },
         ],
     });
-    await keyStore.setKey("networkId", "signer.near", localKeyPair);
+    await keyStore.setKey('networkId', 'signer.near', localKeyPair);
 
     let res;
     try {
         res = await walletConnection
             .account()
-            .signAndSendTransaction("receiver.near", [
+            .signAndSendTransaction('receiver.near', [
                 nearApi.transactions.functionCall(
-                    "someMethod",
+                    'someMethod',
                     new Uint8Array(),
-                    new BN("1"),
-                    new BN("1")
+                    new BN('1'),
+                    new BN('1')
                 ),
             ]);
     } catch (e) {
-        fail("expected transaction outcome");
+        fail('expected transaction outcome');
     }
     // multisig access key is accepted res is object representing transaction, populated upon wallet redirect to app
-    expect(res).toHaveProperty("transaction_outcome");
-    expect(res).toHaveProperty("receipts_outcome");
+    expect(res).toHaveProperty('transaction_outcome');
+    expect(res).toHaveProperty('receipts_outcome');
 });
 
-it("fails requests transaction signing without 2fa access key", async () => {
-    let localKeyPair = nearApi.KeyPair.fromRandom("ed25519");
-    let walletKeyPair = nearApi.KeyPair.fromRandom("ed25519");
+it('fails requests transaction signing without 2fa access key', async () => {
+    let localKeyPair = nearApi.KeyPair.fromRandom('ed25519');
+    let walletKeyPair = nearApi.KeyPair.fromRandom('ed25519');
     setupWalletConnectionForSigning({
         allKeys: [walletKeyPair.publicKey.toString()],
         accountAccessKeys: [
@@ -409,9 +409,9 @@ it("fails requests transaction signing without 2fa access key", async () => {
                     nonce: 1,
                     permission: {
                         FunctionCall: {
-                            allowance: "1000000000",
-                            receiver_id: "signer.near",
-                            method_names: ["not_a_valid_2fa_method"],
+                            allowance: '1000000000',
+                            receiver_id: 'signer.near',
+                            method_names: ['not_a_valid_2fa_method'],
                         },
                     },
                 },
@@ -419,44 +419,44 @@ it("fails requests transaction signing without 2fa access key", async () => {
             },
         ],
     });
-    await keyStore.setKey("networkId", "signer.near", localKeyPair);
+    await keyStore.setKey('networkId', 'signer.near', localKeyPair);
 
     try {
         await walletConnection
             .account()
-            .signAndSendTransaction("receiver.near", [
+            .signAndSendTransaction('receiver.near', [
                 nearApi.transactions.functionCall(
-                    "someMethod",
+                    'someMethod',
                     new Uint8Array(),
-                    new BN("1"),
-                    new BN("1")
+                    new BN('1'),
+                    new BN('1')
                 ),
             ]);
-        fail("expected to throw");
+        fail('expected to throw');
     } catch (e) {
         expect(e.message).toEqual(
-            "Cannot find matching key for transaction sent to receiver.near"
+            'Cannot find matching key for transaction sent to receiver.near'
         );
     }
 });
 
 it.each([
     nearApi.transactions.functionCall(
-        "someMethod",
+        'someMethod',
         new Uint8Array(),
-        new BN("1"),
-        new BN("0")
+        new BN('1'),
+        new BN('0')
     ),
     nearApi.transactions.functionCall(
-        "someMethod",
+        'someMethod',
         new Uint8Array(),
-        new BN("1")
+        new BN('1')
     ),
-    nearApi.transactions.functionCall("someMethod", new Uint8Array()),
+    nearApi.transactions.functionCall('someMethod', new Uint8Array()),
 ])(
-    "can sign transaction locally when function call has no attached deposit",
+    'can sign transaction locally when function call has no attached deposit',
     async (functionCall) => {
-        let localKeyPair = nearApi.KeyPair.fromRandom("ed25519");
+        let localKeyPair = nearApi.KeyPair.fromRandom('ed25519');
         setupWalletConnectionForSigning({
             allKeys: [
                 /* no keys in wallet needed */
@@ -467,8 +467,8 @@ it.each([
                         nonce: 1,
                         permission: {
                             FunctionCall: {
-                                allowance: "1000000000",
-                                receiver_id: "receiver.near",
+                                allowance: '1000000000',
+                                receiver_id: 'receiver.near',
                                 method_names: [],
                             },
                         },
@@ -477,20 +477,20 @@ it.each([
                 },
             ],
         });
-        keyStore.setKey("networkId", "signer.near", localKeyPair);
+        keyStore.setKey('networkId', 'signer.near', localKeyPair);
 
         await walletConnection
             .account()
-            .signAndSendTransaction("receiver.near", [functionCall]);
+            .signAndSendTransaction('receiver.near', [functionCall]);
         // NOTE: Transaction gets signed without wallet in this test
         expect(lastTransaction).toMatchObject({
             transaction: {
-                receiverId: "receiver.near",
-                signerId: "signer.near",
+                receiverId: 'receiver.near',
+                signerId: 'signer.near',
                 actions: [
                     {
                         functionCall: {
-                            methodName: "someMethod",
+                            methodName: 'someMethod',
                         },
                     },
                 ],


### PR DESCRIPTION
Created Batch Transaction function to make it easier for  users to send multiple transactions at once without having to hand roll transactions, or having multiple redirections to the Near wallet 

fixes #504 
fixes #356  