### PR TITLE
remove node-fetch added to global in node env

### DIFF
--- a/lib/browser-connect.d.ts
+++ b/lib/browser-connect.d.ts
@@ -3,9 +3,7 @@
  *
  * {@link ConnectConfig.networkId} and {@link ConnectConfig.nodeUrl} are required.
  *
- * To sign transactions you can also pass:
- * 1. {@link ConnectConfig.keyStore}
- * 2. {@link ConnectConfig.deps | ConnectConfig.deps.keyStore}
+ * To sign transactions you can also pass: {@link ConnectConfig.keyStore}
  *
  * Both are passed they are prioritize in that order.
  *
@@ -22,7 +20,7 @@
  *
  * @module browserConnect
  */
-import { Near, NearConfig } from './near';
+import { Near, NearConfig } from "./near";
 export interface ConnectConfig extends NearConfig {
     /** @hidden */
     keyPath?: string;

--- a/lib/browser-connect.js
+++ b/lib/browser-connect.js
@@ -6,9 +6,7 @@ exports.connect = void 0;
  *
  * {@link ConnectConfig.networkId} and {@link ConnectConfig.nodeUrl} are required.
  *
- * To sign transactions you can also pass:
- * 1. {@link ConnectConfig.keyStore}
- * 2. {@link ConnectConfig.deps | ConnectConfig.deps.keyStore}
+ * To sign transactions you can also pass: {@link ConnectConfig.keyStore}
  *
  * Both are passed they are prioritize in that order.
  *

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -1,4 +1,7 @@
 "use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.connect = void 0;
 /**
@@ -8,8 +11,7 @@ exports.connect = void 0;
  *
  * To sign transactions you can also pass:
  * 1. {@link ConnectConfig.keyStore}
- * 2. {@link ConnectConfig.deps | ConnectConfig.deps.keyStore}
- * 3. {@link ConnectConfig.keyPath}
+ * 2. {@link ConnectConfig.keyPath}
  *
  * If all three are passed they are prioritize in that order.
  *
@@ -28,6 +30,8 @@ exports.connect = void 0;
 const unencrypted_file_system_keystore_1 = require("./key_stores/unencrypted_file_system_keystore");
 const key_stores_1 = require("./key_stores");
 const near_1 = require("./near");
+const setup_node_fetch_1 = __importDefault(require("./utils/setup-node-fetch"));
+global.fetch = setup_node_fetch_1.default;
 /**
  * Initialize connection to Near network.
  */

--- a/lib/utils/setup-node-fetch.d.ts
+++ b/lib/utils/setup-node-fetch.d.ts
@@ -1,0 +1,1 @@
+export default function (resource: any, init: any): any;

--- a/lib/utils/setup-node-fetch.js
+++ b/lib/utils/setup-node-fetch.js
@@ -9,7 +9,7 @@ const https_1 = __importDefault(require("https"));
 const httpAgent = new http_1.default.Agent({ keepAlive: true });
 const httpsAgent = new https_1.default.Agent({ keepAlive: true });
 function agent(_parsedURL) {
-    if (_parsedURL.protocol === "http:") {
+    if (_parsedURL.protocol === 'http:') {
         return httpAgent;
     }
     else {

--- a/lib/utils/setup-node-fetch.js
+++ b/lib/utils/setup-node-fetch.js
@@ -1,0 +1,25 @@
+"use strict";
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+const node_fetch_1 = __importDefault(require("node-fetch"));
+const http_1 = __importDefault(require("http"));
+const https_1 = __importDefault(require("https"));
+const httpAgent = new http_1.default.Agent({ keepAlive: true });
+const httpsAgent = new https_1.default.Agent({ keepAlive: true });
+function agent(_parsedURL) {
+    if (_parsedURL.protocol === "http:") {
+        return httpAgent;
+    }
+    else {
+        return httpsAgent;
+    }
+}
+function default_1(resource, init) {
+    return node_fetch_1.default(resource, {
+        agent: agent(new URL(resource.toString())),
+        ...init,
+    });
+}
+exports.default = default_1;

--- a/lib/utils/web.js
+++ b/lib/utils/web.js
@@ -10,31 +10,6 @@ const providers_1 = require("../providers");
 const START_WAIT_TIME_MS = 1000;
 const BACKOFF_MULTIPLIER = 1.5;
 const RETRY_NUMBER = 10;
-// TODO: Move into separate module and exclude node-fetch kludge from browser build
-let fetch;
-if (typeof window === 'undefined' || window.name === 'nodejs') {
-    /* eslint-disable @typescript-eslint/no-var-requires */
-    const nodeFetch = require('node-fetch');
-    const http = require('http');
-    const https = require('https');
-    /* eslint-enable @typescript-eslint/no-var-requires */
-    const httpAgent = new http.Agent({ keepAlive: true });
-    const httpsAgent = new https.Agent({ keepAlive: true });
-    function agent(_parsedURL) {
-        if (_parsedURL.protocol === 'http:') {
-            return httpAgent;
-        }
-        else {
-            return httpsAgent;
-        }
-    }
-    fetch = function (resource, init) {
-        return nodeFetch(resource, { agent: agent(new URL(resource)), ...init });
-    };
-}
-else {
-    fetch = window.fetch;
-}
 async function fetchJson(connection, json) {
     let url = null;
     if (typeof (connection) === 'string') {

--- a/src/connect.ts
+++ b/src/connect.ts
@@ -24,6 +24,9 @@
 import { readKeyFile } from './key_stores/unencrypted_file_system_keystore';
 import { InMemoryKeyStore, MergeKeyStore } from './key_stores';
 import { Near, NearConfig } from './near';
+import fetch from './utils/setup-node-fetch';
+
+global.fetch = fetch;
 
 export interface ConnectConfig extends NearConfig {
     /**

--- a/src/utils/setup-node-fetch.ts
+++ b/src/utils/setup-node-fetch.ts
@@ -6,7 +6,7 @@ const httpAgent = new http.Agent({ keepAlive: true });
 const httpsAgent = new https.Agent({ keepAlive: true });
 
 function agent(_parsedURL) {
-    if (_parsedURL.protocol === "http:") {
+    if (_parsedURL.protocol === 'http:') {
         return httpAgent;
     } else {
         return httpsAgent;

--- a/src/utils/setup-node-fetch.ts
+++ b/src/utils/setup-node-fetch.ts
@@ -1,0 +1,21 @@
+import fetch from 'node-fetch';
+import http from 'http';
+import https from 'https';
+
+const httpAgent = new http.Agent({ keepAlive: true });
+const httpsAgent = new https.Agent({ keepAlive: true });
+
+function agent(_parsedURL) {
+    if (_parsedURL.protocol === "http:") {
+        return httpAgent;
+    } else {
+        return httpsAgent;
+    }
+}
+
+export default function (resource, init) {
+    return fetch(resource, {
+        agent: agent(new URL(resource.toString())),
+        ...init,
+    });
+}

--- a/src/utils/web.ts
+++ b/src/utils/web.ts
@@ -16,33 +16,6 @@ export interface ConnectionInfo {
     headers?: { [key: string]: string | number };
 }
 
-// TODO: Move into separate module and exclude node-fetch kludge from browser build
-let fetch;
-if (typeof window === 'undefined' || window.name === 'nodejs') {
-    /* eslint-disable @typescript-eslint/no-var-requires */
-    const nodeFetch = require('node-fetch');
-    const http = require('http');
-    const https = require('https');
-    /* eslint-enable @typescript-eslint/no-var-requires */
-
-    const httpAgent = new http.Agent({ keepAlive: true });
-    const httpsAgent = new https.Agent({ keepAlive: true });
-
-    function agent(_parsedURL) {
-        if (_parsedURL.protocol === 'http:') {
-            return httpAgent;
-        } else {
-            return httpsAgent;
-        }
-    }
-
-    fetch = function(resource, init) {
-        return nodeFetch(resource, { agent: agent(new URL(resource)), ...init });
-    };
-} else {
-    fetch = window.fetch;
-}
-
 export async function fetchJson(connection: string | ConnectionInfo, json?: string): Promise<any> {
     let url: string = null;
     if (typeof(connection) === 'string') {


### PR DESCRIPTION
Fixes #415 and removes a todo.

Adds the import of `node-fetch` into a separate module and attaches `node-fetch` to `global` only in the node import path.