### PR TITLE
fix bug in exponentialBackoff

### DIFF
--- a/src/utils/exponential-backoff.ts
+++ b/src/utils/exponential-backoff.ts
@@ -10,7 +10,6 @@ export default async function exponentialBackoff(startWaitTime, retryNumber, wai
 
         await sleep(waitTime);
         waitTime *= waitBackoff;
-        i++;
     }
 
     return null;


### PR DESCRIPTION
The counter in the loop was incremented twice, effectively halving the
retryNumber.