### PR TITLE
feat: make signAndSendTransaction public

### DIFF
--- a/src/account.ts
+++ b/src/account.ts
@@ -153,7 +153,7 @@ export class Account {
      * @param receiverId NEAR account receiving the transaction
      * @param actions list of actions to perform as part of the transaction
      */
-    protected async signAndSendTransaction(receiverId: string, actions: Action[]): Promise<FinalExecutionOutcome> {
+    async signAndSendTransaction(receiverId: string, actions: Action[]): Promise<FinalExecutionOutcome> {
         let txHash, signedTx;
         // TODO: TX_NONCE (different constants for different uses of exponentialBackoff?)
         const result = await exponentialBackoff(TX_NONCE_RETRY_WAIT, TX_NONCE_RETRY_NUMBER, TX_NONCE_RETRY_WAIT_BACKOFF, async () => {


### PR DESCRIPTION
We have a few use cases that need to use signAndSendTransaction as a
public method in TypeScript. For example, to create an account and add
multiple access keys without signature from such keys.

```ts
const actions = [
        createAccount(),
        transfer(amount),
        addKey(PublicKey.from(publicKey), fullAccessKey()),
        addKey(PublicKey.from(accessKeys[0].public_key), fullAccessKey()),
      ];

      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
      // @ts-ignore `signAndSendTransaction` is a protected method
      await masterAccount.signAndSendTransaction(accountId, actions);
```
```ts
const actions = [
      deployContract(contractBytes),
      functionCall('new', newArgs, DEFAULT_GAS_FOR_FUNCTION_CALL, new BN(0)),
    ];

    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
    // @ts-ignore `signAndSendTransaction` is a protected method
    const result = await tokenAccount.signAndSendTransaction(
      tokenAccount!.accountId,
      actions,
    );
```

Signed-off-by: Raymond Feng <enjoyjava@gmail.com>

cc @mattlockyer 