### PR TITLE
fix: configure browser to use dist/near-api-js.min.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     },
     "homepage": "https://github.com/near/near-api-js",
     "main": "lib/index.js",
-    "browser": "lib/browser-index.js",
+    "browser": "dist/near-api-js.min.js",
     "types": "lib/index.d.ts",
     "dependencies": {
         "@types/bn.js": "^5.1.0",


### PR DESCRIPTION
This is needed to allow usage of near-api-js in html pages, such as:

```
<script src="https://cdn.jsdelivr.net/npm/near-api-js@0.39.0"></script>
```

Without this fix, it fails to load `near-api-js` as `exports` is not defined.

Signed-off-by: Raymond Feng <enjoyjava@gmail.com>

CC: @mattlockyer 