### PR TITLE
Check cache for access key after network request

### DIFF
--- a/lib/account.js
+++ b/lib/account.js
@@ -178,6 +178,9 @@ class Account {
                 public_key: publicKey.toString(),
                 finality: 'optimistic'
             });
+            if (this.accessKeyByPublicKeyCache[publicKey.toString()]) {
+                return { publicKey, accessKey: this.accessKeyByPublicKeyCache[publicKey.toString()] };
+            }
             this.accessKeyByPublicKeyCache[publicKey.toString()] = accessKey;
             return { publicKey, accessKey };
         }

--- a/src/account.ts
+++ b/src/account.ts
@@ -235,6 +235,15 @@ export class Account {
                 public_key: publicKey.toString(),
                 finality: 'optimistic'
             });
+
+            // this function can be called multiple times and retrieve the same access key
+            // this checks to see if the access key was already retrieved and cached while
+            // the above network call was in flight. To keep nonce values in line, we return
+            // the cached access key.
+            if(this.accessKeyByPublicKeyCache[publicKey.toString()]) {
+                return { publicKey, accessKey: this.accessKeyByPublicKeyCache[publicKey.toString()] };
+            }
+
             this.accessKeyByPublicKeyCache[publicKey.toString()] = accessKey;
             return { publicKey, accessKey };
         } catch (e) {

--- a/test/account.test.js
+++ b/test/account.test.js
@@ -67,7 +67,7 @@ test('multiple parallel transactions', async () => {
     }));
 });
 
-test('access keys', async() => {
+test('findAccessKey returns the same access key when fetched simultaneously', async() => {
     const account = await testUtils.createAccount(nearjs);
 
     const [key1, key2] = await Promise.all([

--- a/test/account.test.js
+++ b/test/account.test.js
@@ -67,6 +67,17 @@ test('multiple parallel transactions', async () => {
     }));
 });
 
+test('access keys', async() => {
+    const account = await testUtils.createAccount(nearjs);
+
+    const [key1, key2] = await Promise.all([
+        account.findAccessKey(),
+        account.findAccessKey()
+    ]);
+
+    expect(key1.accessKey).toBe(key2.accessKey);
+});
+
 describe('errors', () => {
     let oldLog;
     let logs;


### PR DESCRIPTION
Fixes #559

Right now if you try to send multiple transactions before caching an access key you will run into nonce errors (which will automatically retry the transaction) or you will create multiple of the exact same transaction like in the linked issue.

What we want to do is lock on `findAccessKey` so that we only trying to find an access key one at a time for a public key. But, in JavaScript land this seem to not be a common approach.

Instead, this PR checks before returning the access key to see if it has already been cached while the network call was in flight.