### PR TITLE
Adding keyPath uses that keystore first

### DIFF
--- a/lib/connect.d.ts
+++ b/lib/connect.d.ts
@@ -2,8 +2,6 @@ import { Near, NearConfig } from './near';
 export interface ConnectConfig extends NearConfig {
     /**
      * Initialize an {@link InMemoryKeyStore} by reading the file at keyPath.
-     *
-     * @important {@link ConnectConfig.keyStore | keyStore} and {@link ConnectConfig.deps | deps.keyStore} take priority over keyPath.
      */
     keyPath?: string;
 }

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -37,7 +37,7 @@ global.fetch = setup_node_fetch_1.default;
  */
 async function connect(config) {
     // Try to find extra key in `KeyPath` if provided.
-    if (config.keyPath && config.deps && config.deps.keyStore) {
+    if (config.keyPath && (config.keyStore || config.deps?.keyStore)) {
         try {
             const accountKeyFile = await unencrypted_file_system_keystore_1.readKeyFile(config.keyPath);
             if (accountKeyFile[0]) {
@@ -48,7 +48,7 @@ async function connect(config) {
                 if (!config.masterAccount) {
                     config.masterAccount = accountKeyFile[0];
                 }
-                config.deps.keyStore = new key_stores_1.MergeKeyStore([config.deps.keyStore, keyPathStore]);
+                config.keyStore = new key_stores_1.MergeKeyStore([keyPathStore, (config.keyStore || config.deps.keyStore)], 1);
                 console.log(`Loaded master account ${accountKeyFile[0]} key from ${config.keyPath} with public key = ${keyPair.getPublicKey()}`);
             }
         }

--- a/lib/key_stores/merge_key_store.d.ts
+++ b/lib/key_stores/merge_key_store.d.ts
@@ -34,11 +34,13 @@ import { KeyPair } from '../utils/key_pair';
  * ```
  */
 export declare class MergeKeyStore extends KeyStore {
+    private writeIndex;
     keyStores: KeyStore[];
     /**
-     * @param keyStores first keystore gets all write calls, read calls are attempted from start to end of array
+     * @param keyStores read calls are attempted from start to end of array
+     * @param writeIndex the keystore index that will receive all write calls
      */
-    constructor(keyStores: KeyStore[]);
+    constructor(keyStores: KeyStore[], writeIndex?: number);
     /**
      * Store a {@link KeyPain} to the first index of a key store array
      * @param networkId The targeted network. (ex. default, betanet, etc…)

--- a/lib/key_stores/merge_key_store.js
+++ b/lib/key_stores/merge_key_store.js
@@ -37,10 +37,12 @@ const keystore_1 = require("./keystore");
  */
 class MergeKeyStore extends keystore_1.KeyStore {
     /**
-     * @param keyStores first keystore gets all write calls, read calls are attempted from start to end of array
+     * @param keyStores read calls are attempted from start to end of array
+     * @param writeIndex the keystore index that will receive all write calls
      */
-    constructor(keyStores) {
+    constructor(keyStores, writeIndex = 0) {
         super();
+        this.writeIndex = writeIndex;
         this.keyStores = keyStores;
     }
     /**
@@ -50,7 +52,7 @@ class MergeKeyStore extends keystore_1.KeyStore {
      * @param keyPair The key pair to store in local storage
      */
     async setKey(networkId, accountId, keyPair) {
-        await this.keyStores[0].setKey(networkId, accountId, keyPair);
+        await this.keyStores[this.writeIndex].setKey(networkId, accountId, keyPair);
     }
     /**
      * Gets a {@link KeyPair} from the array of key stores

--- a/src/connect.ts
+++ b/src/connect.ts
@@ -51,7 +51,10 @@ export async function connect(config: ConnectConfig): Promise<Near> {
                 if (!config.masterAccount) {
                     config.masterAccount = accountKeyFile[0];
                 }
-                config.keyStore = new MergeKeyStore([keyPathStore, (config.keyStore || config.deps.keyStore)], 1);
+                config.keyStore = new MergeKeyStore([
+                    keyPathStore,
+                    (config.keyStore || config.deps.keyStore)
+                ], { writeKeyStoreIndex: 1 });
                 console.log(`Loaded master account ${accountKeyFile[0]} key from ${config.keyPath} with public key = ${keyPair.getPublicKey()}`);
             }
         } catch (error) {

--- a/src/connect.ts
+++ b/src/connect.ts
@@ -31,8 +31,6 @@ global.fetch = fetch;
 export interface ConnectConfig extends NearConfig {
     /**
      * Initialize an {@link InMemoryKeyStore} by reading the file at keyPath.
-     *
-     * @important {@link ConnectConfig.keyStore | keyStore} and {@link ConnectConfig.deps | deps.keyStore} take priority over keyPath.
      */
     keyPath?: string;
 }
@@ -42,7 +40,7 @@ export interface ConnectConfig extends NearConfig {
  */
 export async function connect(config: ConnectConfig): Promise<Near> {
     // Try to find extra key in `KeyPath` if provided.
-    if (config.keyPath && config.deps && config.deps.keyStore) {
+    if (config.keyPath && (config.keyStore || config.deps?.keyStore)) {
         try {
             const accountKeyFile = await readKeyFile(config.keyPath);
             if (accountKeyFile[0]) {
@@ -53,7 +51,7 @@ export async function connect(config: ConnectConfig): Promise<Near> {
                 if (!config.masterAccount) {
                     config.masterAccount = accountKeyFile[0];
                 }
-                config.deps.keyStore = new MergeKeyStore([config.deps.keyStore, keyPathStore]);
+                config.keyStore = new MergeKeyStore([keyPathStore, (config.keyStore || config.deps.keyStore)], 1);
                 console.log(`Loaded master account ${accountKeyFile[0]} key from ${config.keyPath} with public key = ${keyPair.getPublicKey()}`);
             }
         } catch (error) {

--- a/src/connect.ts
+++ b/src/connect.ts
@@ -40,7 +40,7 @@ export interface ConnectConfig extends NearConfig {
  */
 export async function connect(config: ConnectConfig): Promise<Near> {
     // Try to find extra key in `KeyPath` if provided.
-    if (config.keyPath && (config.keyStore || config.deps?.keyStore)) {
+    if (config.keyPath && (config.keyStore || config.deps && config.deps.keyStore)) {
         try {
             const accountKeyFile = await readKeyFile(config.keyPath);
             if (accountKeyFile[0]) {

--- a/src/key_stores/merge_key_store.ts
+++ b/src/key_stores/merge_key_store.ts
@@ -34,17 +34,22 @@ import { KeyPair } from '../utils/key_pair';
  * const near = await connect(config)
  * ```
  */
+
+interface MergeKeyStoreOptions {
+    writeKeyStoreIndex: number;
+}
+
 export class MergeKeyStore extends KeyStore {
-    private writeIndex: number;
+    private options: MergeKeyStoreOptions;
     keyStores: KeyStore[];
 
     /**
      * @param keyStores read calls are attempted from start to end of array
-     * @param writeIndex the keystore index that will receive all write calls
+     * @param options.writeKeyStoreIndex the keystore index that will receive all write calls
      */
-    constructor(keyStores: KeyStore[], writeIndex = 0) {
+    constructor(keyStores: KeyStore[], options: MergeKeyStoreOptions) {
         super();
-        this.writeIndex = writeIndex;
+        this.options = options;
         this.keyStores = keyStores;
     }
 
@@ -55,7 +60,7 @@ export class MergeKeyStore extends KeyStore {
      * @param keyPair The key pair to store in local storage
      */
     async setKey(networkId: string, accountId: string, keyPair: KeyPair): Promise<void> {
-        await this.keyStores[this.writeIndex].setKey(networkId, accountId, keyPair);
+        await this.keyStores[this.options.writeKeyStoreIndex].setKey(networkId, accountId, keyPair);
     }
 
     /**

--- a/src/key_stores/merge_key_store.ts
+++ b/src/key_stores/merge_key_store.ts
@@ -35,13 +35,16 @@ import { KeyPair } from '../utils/key_pair';
  * ```
  */
 export class MergeKeyStore extends KeyStore {
+    private writeIndex: number;
     keyStores: KeyStore[];
 
     /**
-     * @param keyStores first keystore gets all write calls, read calls are attempted from start to end of array
+     * @param keyStores read calls are attempted from start to end of array
+     * @param writeIndex the keystore index that will receive all write calls
      */
-    constructor(keyStores: KeyStore[]) {
+    constructor(keyStores: KeyStore[], writeIndex = 0) {
         super();
+        this.writeIndex = writeIndex;
         this.keyStores = keyStores;
     }
 
@@ -52,7 +55,7 @@ export class MergeKeyStore extends KeyStore {
      * @param keyPair The key pair to store in local storage
      */
     async setKey(networkId: string, accountId: string, keyPair: KeyPair): Promise<void> {
-        await this.keyStores[0].setKey(networkId, accountId, keyPair);
+        await this.keyStores[this.writeIndex].setKey(networkId, accountId, keyPair);
     }
 
     /**

--- a/src/key_stores/merge_key_store.ts
+++ b/src/key_stores/merge_key_store.ts
@@ -47,7 +47,7 @@ export class MergeKeyStore extends KeyStore {
      * @param keyStores read calls are attempted from start to end of array
      * @param options.writeKeyStoreIndex the keystore index that will receive all write calls
      */
-    constructor(keyStores: KeyStore[], options: MergeKeyStoreOptions) {
+    constructor(keyStores: KeyStore[], options: MergeKeyStoreOptions = { writeKeyStoreIndex: 0 }) {
         super();
         this.options = options;
         this.keyStores = keyStores;


### PR DESCRIPTION
See #469

From @mikedotexe 

> I've noticed this on and off and finally figured out it's a one-liner.
When I create a function-call access key for an account and then specify it as the keyPath, the full access key was being used.
When a person specifies the keyPath, I believe that means, "Please use this keystore first, as I'm specifying to use it." Instead it's added to the end of the MergeKeyStore, so it's the last keystore to be checked.
This simply flips that so the first keystore used is the one specified by keyPath.

Keep in mind this comment: https://github.com/near/near-api-js/pull/469#issuecomment-772398493

> keyPathStore is an InMemoryKeyStore. It gets precedence so all new keys are written to it. So if you e.g. try to create new account while specifying keyPath to provide key for you masterAccount you would lose a key to newly created account.