### PR TITLE
fix: jsonrpc empty string response should success

### DIFF
--- a/lib/account.d.ts
+++ b/lib/account.d.ts
@@ -131,7 +131,7 @@ export declare class Account {
      * @param contractId NEAR account where the contract is deployed
      * @param publicKey The public key to add to the created contract account
      * @param data The compiled contract code
-     * @param amount NEAR to transfer to the created contract account. Transfer enough to pay for storage https://docs.near.org/docs/concepts/storage-staking
+     * @param amount of NEAR to transfer to the created contract account. Transfer enough to pay for storage https://docs.near.org/docs/concepts/storage-staking
      */
     createAndDeployContract(contractId: string, publicKey: string | PublicKey, data: Uint8Array, amount: BN): Promise<Account>;
     /**

--- a/lib/account.js
+++ b/lib/account.js
@@ -201,7 +201,7 @@ class Account {
      * @param contractId NEAR account where the contract is deployed
      * @param publicKey The public key to add to the created contract account
      * @param data The compiled contract code
-     * @param amount NEAR to transfer to the created contract account. Transfer enough to pay for storage https://docs.near.org/docs/concepts/storage-staking
+     * @param amount of NEAR to transfer to the created contract account. Transfer enough to pay for storage https://docs.near.org/docs/concepts/storage-staking
      */
     async createAndDeployContract(contractId, publicKey, data, amount) {
         const accessKey = transaction_1.fullAccessKey();

--- a/lib/providers/json-rpc-provider.js
+++ b/lib/providers/json-rpc-provider.js
@@ -294,7 +294,7 @@ class JsonRpcProvider extends provider_1.Provider {
      * @param params Parameters to the method
      */
     async sendJsonRpc(method, params) {
-        const result = await exponential_backoff_1.default(REQUEST_RETRY_WAIT, REQUEST_RETRY_NUMBER, REQUEST_RETRY_WAIT_BACKOFF, async () => {
+        const response = await exponential_backoff_1.default(REQUEST_RETRY_WAIT, REQUEST_RETRY_NUMBER, REQUEST_RETRY_WAIT_BACKOFF, async () => {
             try {
                 const request = {
                     method,
@@ -322,7 +322,8 @@ class JsonRpcProvider extends provider_1.Provider {
                         throw new errors_1.TypedError(errorMessage, rpc_errors_1.getErrorTypeFromErrorMessage(response.error.data));
                     }
                 }
-                return response.result;
+                // Success when response.error is not exist
+                return response;
             }
             catch (error) {
                 if (error.type === 'TimeoutError') {
@@ -332,7 +333,12 @@ class JsonRpcProvider extends provider_1.Provider {
                 throw error;
             }
         });
-        if (!result) {
+        const result = response.result;
+        // From jsonrpc spec:
+        // result
+        //   This member is REQUIRED on success.
+        //   This member MUST NOT exist if there was an error invoking the method.
+        if (typeof result === 'undefined') {
             throw new errors_1.TypedError(`Exceeded ${REQUEST_RETRY_NUMBER} attempts for request to ${method}.`, 'RetriesExceeded');
         }
         return result;

--- a/lib/providers/json-rpc-provider.js
+++ b/lib/providers/json-rpc-provider.js
@@ -333,7 +333,7 @@ class JsonRpcProvider extends provider_1.Provider {
                 throw error;
             }
         });
-        const result = response.result;
+        const { result } = response;
         // From jsonrpc spec:
         // result
         //   This member is REQUIRED on success.

--- a/src/providers/json-rpc-provider.ts
+++ b/src/providers/json-rpc-provider.ts
@@ -379,7 +379,7 @@ export class JsonRpcProvider extends Provider {
                 throw error;
             }
         });
-        if (!result && result !== "") {
+        if (result === undefined) {
             throw new TypedError(
                 `Exceeded ${REQUEST_RETRY_NUMBER} attempts for request to ${method}.`, 'RetriesExceeded');
         }

--- a/src/providers/json-rpc-provider.ts
+++ b/src/providers/json-rpc-provider.ts
@@ -379,7 +379,7 @@ export class JsonRpcProvider extends Provider {
                 throw error;
             }
         });
-        if (!result) {
+        if (!result && result !== "") {
             throw new TypedError(
                 `Exceeded ${REQUEST_RETRY_NUMBER} attempts for request to ${method}.`, 'RetriesExceeded');
         }

--- a/src/providers/json-rpc-provider.ts
+++ b/src/providers/json-rpc-provider.ts
@@ -340,7 +340,7 @@ export class JsonRpcProvider extends Provider {
      * @param params Parameters to the method
      */
     async sendJsonRpc<T>(method: string, params: object): Promise<T> {
-        const result = await exponentialBackoff(REQUEST_RETRY_WAIT, REQUEST_RETRY_NUMBER, REQUEST_RETRY_WAIT_BACKOFF, async () => {
+        const response = await exponentialBackoff(REQUEST_RETRY_WAIT, REQUEST_RETRY_NUMBER, REQUEST_RETRY_WAIT_BACKOFF, async () => {
             try {
                 const request = {
                     method,
@@ -369,7 +369,7 @@ export class JsonRpcProvider extends Provider {
                         throw new TypedError(errorMessage, getErrorTypeFromErrorMessage(response.error.data));
                     }
                 }
-                return response.result;
+                return response;
             } catch (error) {
                 if (error.type === 'TimeoutError') {
                     console.warn(`Retrying request to ${method} as it has timed out`, params);
@@ -379,7 +379,12 @@ export class JsonRpcProvider extends Provider {
                 throw error;
             }
         });
-        if (typeof result !== 'undefined') {
+        let result = response.result;
+        // From jsonrpc spec:
+        // result
+        //   This member is REQUIRED on success.
+        //   This member MUST NOT exist if there was an error invoking the method.
+        if (typeof result === 'undefined') {
             throw new TypedError(
                 `Exceeded ${REQUEST_RETRY_NUMBER} attempts for request to ${method}.`, 'RetriesExceeded');
         }

--- a/src/providers/json-rpc-provider.ts
+++ b/src/providers/json-rpc-provider.ts
@@ -380,7 +380,7 @@ export class JsonRpcProvider extends Provider {
                 throw error;
             }
         });
-        const result = response.result;
+        const { result } = response;
         // From jsonrpc spec:
         // result
         //   This member is REQUIRED on success.

--- a/src/providers/json-rpc-provider.ts
+++ b/src/providers/json-rpc-provider.ts
@@ -369,6 +369,7 @@ export class JsonRpcProvider extends Provider {
                         throw new TypedError(errorMessage, getErrorTypeFromErrorMessage(response.error.data));
                     }
                 }
+                // Success when response.error is not exist
                 return response;
             } catch (error) {
                 if (error.type === 'TimeoutError') {
@@ -379,7 +380,7 @@ export class JsonRpcProvider extends Provider {
                 throw error;
             }
         });
-        let result = response.result;
+        const result = response.result;
         // From jsonrpc spec:
         // result
         //   This member is REQUIRED on success.

--- a/src/providers/json-rpc-provider.ts
+++ b/src/providers/json-rpc-provider.ts
@@ -379,7 +379,7 @@ export class JsonRpcProvider extends Provider {
                 throw error;
             }
         });
-        if (result === undefined) {
+        if (typeof result !== 'undefined') {
             throw new TypedError(
                 `Exceeded ${REQUEST_RETRY_NUMBER} attempts for request to ${method}.`, 'RetriesExceeded');
         }


### PR DESCRIPTION
Right now if a jsonrpc returns this result:
```
{"jsonrpc":"2.0","result":"","id":1}
```
 near-api-js consider it as fail and retry until timeout. This behavor is incorrect. According to jsonrpc spec, Valid success jsonrpc can respond empty result, such as `""` or `null`, for example in sandbox_patch_state rpc and adversarial rpcs. Valid error response should be determined by `result` key not present or `error` key is present.

Also exponentialBackoff won't return if result is "" or null, so make this return entire json rpc response to avoid it keep retry on `{..., result: ""}` response and only retry on real error response and fetch errors