### PR TITLE
add get tx status example

### DIFF
--- a/examples/cookbook/README.md
+++ b/examples/cookbook/README.md
@@ -12,6 +12,7 @@
 | [Create Account](./accounts/create-testnet-account.js)        | Create [NEAR accounts](https://docs.near.org/docs/concepts/account) without using NEAR Wallet.                   |
 | [Access Key Rotation](./accounts/access-keys/README.md)       | Create and delete [access keys](https://docs.near.org/docs/concepts/account#access-keys) for added security.     |
 | **TRANSACTIONS**                                              |                                                                                                                  |
+| [Get Transaction Status](./transactions/get-tx-status.js)     | Gets transaction status using a tx hash and associated account/contract ID.                                      |
 | [Recent Transaction Details](./transactions/get-tx-detail.js) | Get recent transaction details without using an [indexing](https://docs.near.org/docs/concepts/indexer) service. |
 | [Batch Transactions](./transactions/batch-transactions.js)    | Sign and send multiple [transactions](https://docs.near.org/docs/concepts/transaction).                          |
 | **UTILS**                                                     |                                                                                                                  |

--- a/examples/cookbook/transactions/get-tx-status.js
+++ b/examples/cookbook/transactions/get-tx-status.js
@@ -14,6 +14,6 @@ const ACCOUNT_ID = "sender.testnet";
 getState(TX_HASH, ACCOUNT_ID);
 
 async function getState(txHash, accountId) {
-    const result = await provider.txStatus(bs58.decode(txHash), accountId);
+    const result = await provider.txStatus(txHash, accountId);
     console.log("Result: ", result);
 }

--- a/examples/cookbook/transactions/get-tx-status.js
+++ b/examples/cookbook/transactions/get-tx-status.js
@@ -1,0 +1,19 @@
+// demonstrates how to get a transaction status
+const { providers } = require("near-api-js");
+const bs58 = require("bs58");
+
+//network config (replace testnet with mainnet or betanet)
+const provider = new providers.JsonRpcProvider(
+    "https://archival-rpc.testnet.near.org"
+);
+
+const TX_HASH = "9av2U6cova7LZPA9NPij6CTUrpBbgPG6LKVkyhcCqtk3";
+// account ID associated with the transaction
+const ACCOUNT_ID = "sender.testnet";
+
+getState(TX_HASH, ACCOUNT_ID);
+
+async function getState(txHash, accountId) {
+    const result = await provider.txStatus(bs58.decode(txHash), accountId);
+    console.log("Result: ", result);
+}

--- a/examples/cookbook/transactions/get-tx-status.js
+++ b/examples/cookbook/transactions/get-tx-status.js
@@ -1,6 +1,5 @@
 // demonstrates how to get a transaction status
 const { providers } = require("near-api-js");
-const bs58 = require("bs58");
 
 //network config (replace testnet with mainnet or betanet)
 const provider = new providers.JsonRpcProvider(


### PR DESCRIPTION
Adds an example of getting a transaction status by hash. This was prompted by a [community request in Discord](https://discord.com/channels/490367152054992913/817102046725406780/852735491198418994).