### PR TITLE
feat: prepare tests for the stabilization of `EXPERIMENTAL_tx_status` method

### DIFF
--- a/test/providers.test.js
+++ b/test/providers.test.js
@@ -72,8 +72,8 @@ test('txStatus with string hash and buffer hash', withProvider(async(provider) =
 
     const responseWithString = await provider.txStatus(outcome.transaction.hash, sender.accountId);
     const responseWithUint8Array = await provider.txStatus(base58.decode(outcome.transaction.hash), sender.accountId);
-    expect(responseWithString).toEqual(outcome);
-    expect(responseWithUint8Array).toEqual(outcome);
+    expect(responseWithString).toMatchObject(outcome);
+    expect(responseWithUint8Array).toMatchObject(outcome);
 }));
 
 test('json rpc query account', withProvider(async (provider) => {


### PR DESCRIPTION
See this failing test: https://buildkite.com/nearprotocol/nearcore/builds/1547#2c89c279-4fd8-490d-8235-86531597f5d3

![image](https://user-images.githubusercontent.com/304265/121965674-c49c1b80-cd43-11eb-82da-b2a94a18a56f.png)

`tx` method was extended with one more field (`receipts`), which is not a breaking change, but the output of the broadcast_tx_commit does not return `receipts` (only returns `status`, `transaction`, `transaction_outcome`, and `receipts_outcome`), so we need to check if the response from `broadcast_tx_commit` is a strict subset of the `tx` response.