### PR TITLE
Release files whitelisted

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,0 @@
-storage
-node_modules
-
-# near-api-js files & coverage
-neardev/
-coverage/

--- a/package.json
+++ b/package.json
@@ -69,5 +69,9 @@
             }
         ]
     },
+    "files": [
+        "lib",
+        "browser-exports.js"
+    ],
     "author": "NEAR Inc"
 }

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     },
     "files": [
         "lib",
+        "dist",
         "browser-exports.js"
     ],
     "author": "NEAR Inc"


### PR DESCRIPTION
Our releases on NPM contain config files, tests, and example code snippets. Let's use whitelisting instead of `.npmignore` file.

I'm wondering if we should remain `src` folder. Can we assume that everybody is using `lib` only?
`src` folder is ~180 kByte's, it would be cool to get rid of it and reduce loading time in all our apps.

Also, it's not clear for me how  `dist/near-api-js.min.js` works and how it should be used. There are no mentions of it in our docs.