### PR TITLE
use block_id in rpc query

### DIFF
--- a/lib/providers/json-rpc-provider.js
+++ b/lib/providers/json-rpc-provider.js
@@ -106,7 +106,7 @@ class JsonRpcProvider extends provider_1.Provider {
     async query(...args) {
         let result;
         if (args.length === 1) {
-            result = await this.sendJsonRpc('query', args[0]);
+            result = await this.sendJsonRpc('query', { ...args[0], block_id: args[0].blockId });
         }
         else {
             const [path, data] = args;

--- a/src/providers/json-rpc-provider.ts
+++ b/src/providers/json-rpc-provider.ts
@@ -135,7 +135,7 @@ export class JsonRpcProvider extends Provider {
     async query<T extends QueryResponseKind>(...args: any[]): Promise<T> {
         let result;
         if (args.length === 1) {
-            result = await this.sendJsonRpc<T>('query', args[0]);
+            result = await this.sendJsonRpc<T>('query', { ...args[0], block_id: args[0].blockId });
         } else {
             const [path, data] = args;
             result = await this.sendJsonRpc<T>('query', [path, data]);

--- a/test/providers.test.js
+++ b/test/providers.test.js
@@ -76,6 +76,27 @@ test('txStatus with string hash and buffer hash', withProvider(async(provider) =
     expect(responseWithUint8Array).toMatchObject(outcome);
 }));
 
+test('json rpc query with blockId', withProvider(async(provider) => {
+    const stat = await provider.status();
+    let blockId = stat.sync_info.latest_block_height - 1;
+
+    const response = await provider.query({
+        blockId,
+        request_type: 'view_account',
+        account_id: 'test.near'
+    });
+
+    expect(response).toEqual({
+        block_height: expect.any(Number),
+        block_hash: expect.any(String),
+        amount: expect.any(String),
+        locked: expect.any(String),
+        code_hash: '11111111111111111111111111111111',
+        storage_usage: 182,
+        storage_paid_at: 0,
+    });
+}));
+
 test('json rpc query account', withProvider(async (provider) => {
     const near = await testUtils.setUpTestConnection();
     const account = await testUtils.createAccount(near);


### PR DESCRIPTION
Fixes #635 