### PR TITLE
Borsh in view

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -18,7 +18,7 @@ rules:
   semi:
     - error
     - always
-  no-console: off
+  no-console: 0
 globals:
   window: true
   fetch: true

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -18,7 +18,7 @@ rules:
   semi:
     - error
     - always
-  no-console: 0
+  no-console: off
 globals:
   window: true
   fetch: true

--- a/lib/account.d.ts
+++ b/lib/account.d.ts
@@ -60,8 +60,13 @@ export interface FunctionCallOptions {
      * @see {@link RequestSignTransactionsOptions}
      */
     walletCallbackUrl?: string;
+    /**
+     * Convert input arguments into bytes array.
+     */
+    stringify?: (input: any) => Buffer;
 }
 declare function parseJsonFromRawResponse(response: Uint8Array): any;
+declare function bytesJsonStringify(input: any): Buffer;
 /**
  * This class provides common account related RPC calls including signing transactions with a {@link KeyPair}.
  *
@@ -197,10 +202,13 @@ export declare class Account {
      * @param contractId NEAR account where the contract is deployed
      * @param methodName The view-only method (no state mutations) name on the contract as it is written in the contract code
      * @param args Any arguments to the view contract method, wrapped in JSON
+     * @param opts.parse Parse the result of the call. Receives a Buffer (bytes array) and converts it to any object. By default result will be treated as json.
+     * @param opts.stringify Convert input arguments into a bytes array. By default the input is treated as a JSON.
      * @returns {Promise<any>}
      */
-    viewFunction(contractId: string, methodName: string, args?: any, { parse }?: {
+    viewFunction(contractId: string, methodName: string, args?: any, { parse, stringify }?: {
         parse?: typeof parseJsonFromRawResponse;
+        stringify?: typeof bytesJsonStringify;
     }): Promise<any>;
     /**
      * Returns the state (key value pairs) of this account's contract based on the key prefix.

--- a/lib/account.d.ts
+++ b/lib/account.d.ts
@@ -202,8 +202,8 @@ export declare class Account {
      * @param contractId NEAR account where the contract is deployed
      * @param methodName The view-only method (no state mutations) name on the contract as it is written in the contract code
      * @param args Any arguments to the view contract method, wrapped in JSON
-     * @param opts.parse Parse the result of the call. Receives a Buffer (bytes array) and converts it to any object. By default result will be treated as json.
-     * @param opts.stringify Convert input arguments into a bytes array. By default the input is treated as a JSON.
+     * @param options.parse Parse the result of the call. Receives a Buffer (bytes array) and converts it to any object. By default result will be treated as json.
+     * @param options.stringify Convert input arguments into a bytes array. By default the input is treated as a JSON.
      * @returns {Promise<any>}
      */
     viewFunction(contractId: string, methodName: string, args?: any, { parse, stringify }?: {

--- a/lib/account.js
+++ b/lib/account.js
@@ -278,10 +278,10 @@ class Account {
     }
     functionCallV2({ contractId, methodName, args = {}, gas = constants_1.DEFAULT_FUNCTION_CALL_GAS, attachedDeposit, walletMeta, walletCallbackUrl, stringify }) {
         this.validateArgs(args);
-        const opts = stringify === undefined ? {} : { stringify };
+        const stringifyArg = stringify === undefined ? transaction_1.stringifyJsonOrBytes : stringify;
         return this.signAndSendTransaction({
             receiverId: contractId,
-            actions: [transaction_1.functionCall(methodName, args, gas, attachedDeposit, opts)],
+            actions: [transaction_1.functionCall(methodName, args, gas, attachedDeposit, stringifyArg)],
             walletMeta,
             walletCallbackUrl
         });
@@ -352,8 +352,8 @@ class Account {
      * @param contractId NEAR account where the contract is deployed
      * @param methodName The view-only method (no state mutations) name on the contract as it is written in the contract code
      * @param args Any arguments to the view contract method, wrapped in JSON
-     * @param opts.parse Parse the result of the call. Receives a Buffer (bytes array) and converts it to any object. By default result will be treated as json.
-     * @param opts.stringify Convert input arguments into a bytes array. By default the input is treated as a JSON.
+     * @param options.parse Parse the result of the call. Receives a Buffer (bytes array) and converts it to any object. By default result will be treated as json.
+     * @param options.stringify Convert input arguments into a bytes array. By default the input is treated as a JSON.
      * @returns {Promise<any>}
      */
     async viewFunction(contractId, methodName, args = {}, { parse = parseJsonFromRawResponse, stringify = bytesJsonStringify } = {}) {

--- a/lib/account.js
+++ b/lib/account.js
@@ -23,6 +23,9 @@ const TX_NONCE_RETRY_WAIT_BACKOFF = 1.5;
 function parseJsonFromRawResponse(response) {
     return JSON.parse(Buffer.from(response).toString());
 }
+function bytesJsonStringify(input) {
+    return Buffer.from(JSON.stringify(input));
+}
 /**
  * This class provides common account related RPC calls including signing transactions with a {@link KeyPair}.
  *
@@ -273,11 +276,12 @@ class Account {
             actions: [transaction_1.functionCall(methodName, args, gas || constants_1.DEFAULT_FUNCTION_CALL_GAS, amount)]
         });
     }
-    functionCallV2({ contractId, methodName, args = {}, gas = constants_1.DEFAULT_FUNCTION_CALL_GAS, attachedDeposit, walletMeta, walletCallbackUrl }) {
+    functionCallV2({ contractId, methodName, args = {}, gas = constants_1.DEFAULT_FUNCTION_CALL_GAS, attachedDeposit, walletMeta, walletCallbackUrl, stringify }) {
         this.validateArgs(args);
+        const opts = stringify === undefined ? {} : { stringify };
         return this.signAndSendTransaction({
             receiverId: contractId,
-            actions: [transaction_1.functionCall(methodName, args, gas, attachedDeposit)],
+            actions: [transaction_1.functionCall(methodName, args, gas, attachedDeposit, opts)],
             walletMeta,
             walletCallbackUrl
         });
@@ -348,17 +352,18 @@ class Account {
      * @param contractId NEAR account where the contract is deployed
      * @param methodName The view-only method (no state mutations) name on the contract as it is written in the contract code
      * @param args Any arguments to the view contract method, wrapped in JSON
+     * @param opts.parse Parse the result of the call. Receives a Buffer (bytes array) and converts it to any object. By default result will be treated as json.
+     * @param opts.stringify Convert input arguments into a bytes array. By default the input is treated as a JSON.
      * @returns {Promise<any>}
      */
-    async viewFunction(contractId, methodName, args = {}, { parse = parseJsonFromRawResponse } = {}) {
+    async viewFunction(contractId, methodName, args = {}, { parse = parseJsonFromRawResponse, stringify = bytesJsonStringify } = {}) {
         this.validateArgs(args);
-        const isUint8Array = args.byteLength !== undefined && args.byteLength === args.length;
-        const serializedArgs = isUint8Array ? args : Buffer.from(JSON.stringify(args));
+        const serializedArgs = stringify(args).toString('base64');
         const result = await this.connection.provider.query({
             request_type: 'call_function',
             account_id: contractId,
             method_name: methodName,
-            args_base64: serializedArgs.toString('base64'),
+            args_base64: serializedArgs,
             finality: 'optimistic'
         });
         if (result.logs) {

--- a/lib/account.js
+++ b/lib/account.js
@@ -352,11 +352,13 @@ class Account {
      */
     async viewFunction(contractId, methodName, args = {}, { parse = parseJsonFromRawResponse } = {}) {
         this.validateArgs(args);
+        const isUint8Array = args.byteLength !== undefined && args.byteLength === args.length;
+        const serializedArgs = isUint8Array ? args : Buffer.from(JSON.stringify(args));
         const result = await this.connection.provider.query({
             request_type: 'call_function',
             account_id: contractId,
             method_name: methodName,
-            args_base64: Buffer.from(JSON.stringify(args)).toString('base64'),
+            args_base64: serializedArgs.toString('base64'),
             finality: 'optimistic'
         });
         if (result.logs) {

--- a/lib/transaction.d.ts
+++ b/lib/transaction.d.ts
@@ -52,7 +52,7 @@ export declare class DeleteAccount extends IAction {
 }
 export declare function createAccount(): Action;
 export declare function deployContract(code: Uint8Array): Action;
-declare function stringifyJsonOrBytes(args: any): Buffer;
+export declare function stringifyJsonOrBytes(args: any): Buffer;
 /**
  * Constructs {@link Action} instance representing contract method call.
  *
@@ -63,9 +63,7 @@ declare function stringifyJsonOrBytes(args: any): Buffer;
  * @param deposit amount of NEAR (in yoctoNEAR) to send together with the call
  * @param stringify Convert input arguments into bytes array.
  */
-export declare function functionCall(methodName: string, args: Uint8Array | object, gas: BN, deposit: BN, { stringify }?: {
-    stringify?: typeof stringifyJsonOrBytes;
-}): Action;
+export declare function functionCall(methodName: string, args: Uint8Array | object, gas: BN, deposit: BN, stringify?: typeof stringifyJsonOrBytes): Action;
 export declare function transfer(deposit: BN): Action;
 export declare function stake(stake: BN, publicKey: PublicKey): Action;
 export declare function addKey(publicKey: PublicKey, accessKey: AccessKey): Action;
@@ -109,4 +107,3 @@ export declare const SCHEMA: Map<Function, any>;
 export declare function createTransaction(signerId: string, publicKey: PublicKey, receiverId: string, nonce: number, actions: Action[], blockHash: Uint8Array): Transaction;
 export declare function signTransaction(transaction: Transaction, signer: Signer, accountId?: string, networkId?: string): Promise<[Uint8Array, SignedTransaction]>;
 export declare function signTransaction(receiverId: string, nonce: number, actions: Action[], blockHash: Uint8Array, signer: Signer, accountId?: string, networkId?: string): Promise<[Uint8Array, SignedTransaction]>;
-export {};

--- a/lib/transaction.d.ts
+++ b/lib/transaction.d.ts
@@ -52,6 +52,7 @@ export declare class DeleteAccount extends IAction {
 }
 export declare function createAccount(): Action;
 export declare function deployContract(code: Uint8Array): Action;
+declare function stringifyJsonOrBytes(args: any): Buffer;
 /**
  * Constructs {@link Action} instance representing contract method call.
  *
@@ -60,8 +61,11 @@ export declare function deployContract(code: Uint8Array): Action;
  *  or `Uint8Array` instance which represents bytes passed as is.
  * @param gas max amount of gas that method call can use
  * @param deposit amount of NEAR (in yoctoNEAR) to send together with the call
+ * @param stringify Convert input arguments into bytes array.
  */
-export declare function functionCall(methodName: string, args: Uint8Array | object, gas: BN, deposit: BN): Action;
+export declare function functionCall(methodName: string, args: Uint8Array | object, gas: BN, deposit: BN, { stringify }?: {
+    stringify?: typeof stringifyJsonOrBytes;
+}): Action;
 export declare function transfer(deposit: BN): Action;
 export declare function stake(stake: BN, publicKey: PublicKey): Action;
 export declare function addKey(publicKey: PublicKey, accessKey: AccessKey): Action;
@@ -105,3 +109,4 @@ export declare const SCHEMA: Map<Function, any>;
 export declare function createTransaction(signerId: string, publicKey: PublicKey, receiverId: string, nonce: number, actions: Action[], blockHash: Uint8Array): Transaction;
 export declare function signTransaction(transaction: Transaction, signer: Signer, accountId?: string, networkId?: string): Promise<[Uint8Array, SignedTransaction]>;
 export declare function signTransaction(receiverId: string, nonce: number, actions: Action[], blockHash: Uint8Array, signer: Signer, accountId?: string, networkId?: string): Promise<[Uint8Array, SignedTransaction]>;
+export {};

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -63,6 +63,11 @@ function deployContract(code) {
     return new Action({ deployContract: new DeployContract({ code }) });
 }
 exports.deployContract = deployContract;
+function stringifyJsonOrBytes(args) {
+    const isUint8Array = args.byteLength !== undefined && args.byteLength === args.length;
+    const serializedArgs = isUint8Array ? args : Buffer.from(JSON.stringify(args));
+    return serializedArgs;
+}
 /**
  * Constructs {@link Action} instance representing contract method call.
  *
@@ -71,12 +76,10 @@ exports.deployContract = deployContract;
  *  or `Uint8Array` instance which represents bytes passed as is.
  * @param gas max amount of gas that method call can use
  * @param deposit amount of NEAR (in yoctoNEAR) to send together with the call
+ * @param stringify Convert input arguments into bytes array.
  */
-function functionCall(methodName, args, gas, deposit) {
-    const anyArgs = args;
-    const isUint8Array = anyArgs.byteLength !== undefined && anyArgs.byteLength === anyArgs.length;
-    const serializedArgs = isUint8Array ? args : Buffer.from(JSON.stringify(args));
-    return new Action({ functionCall: new FunctionCall({ methodName, args: serializedArgs, gas, deposit }) });
+function functionCall(methodName, args, gas, deposit, { stringify = stringifyJsonOrBytes } = {}) {
+    return new Action({ functionCall: new FunctionCall({ methodName, args: stringify(args), gas, deposit }) });
 }
 exports.functionCall = functionCall;
 function transfer(deposit) {

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -3,7 +3,7 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.signTransaction = exports.createTransaction = exports.SCHEMA = exports.Action = exports.SignedTransaction = exports.Transaction = exports.Signature = exports.deleteAccount = exports.deleteKey = exports.addKey = exports.stake = exports.transfer = exports.functionCall = exports.deployContract = exports.createAccount = exports.DeleteAccount = exports.DeleteKey = exports.AddKey = exports.Stake = exports.Transfer = exports.FunctionCall = exports.DeployContract = exports.CreateAccount = exports.IAction = exports.functionCallAccessKey = exports.fullAccessKey = exports.AccessKey = exports.AccessKeyPermission = exports.FullAccessPermission = exports.FunctionCallPermission = void 0;
+exports.signTransaction = exports.createTransaction = exports.SCHEMA = exports.Action = exports.SignedTransaction = exports.Transaction = exports.Signature = exports.deleteAccount = exports.deleteKey = exports.addKey = exports.stake = exports.transfer = exports.functionCall = exports.stringifyJsonOrBytes = exports.deployContract = exports.createAccount = exports.DeleteAccount = exports.DeleteKey = exports.AddKey = exports.Stake = exports.Transfer = exports.FunctionCall = exports.DeployContract = exports.CreateAccount = exports.IAction = exports.functionCallAccessKey = exports.fullAccessKey = exports.AccessKey = exports.AccessKeyPermission = exports.FullAccessPermission = exports.FunctionCallPermission = void 0;
 const js_sha256_1 = __importDefault(require("js-sha256"));
 const enums_1 = require("./utils/enums");
 const borsh_1 = require("borsh");
@@ -68,6 +68,7 @@ function stringifyJsonOrBytes(args) {
     const serializedArgs = isUint8Array ? args : Buffer.from(JSON.stringify(args));
     return serializedArgs;
 }
+exports.stringifyJsonOrBytes = stringifyJsonOrBytes;
 /**
  * Constructs {@link Action} instance representing contract method call.
  *
@@ -78,7 +79,7 @@ function stringifyJsonOrBytes(args) {
  * @param deposit amount of NEAR (in yoctoNEAR) to send together with the call
  * @param stringify Convert input arguments into bytes array.
  */
-function functionCall(methodName, args, gas, deposit, { stringify = stringifyJsonOrBytes } = {}) {
+function functionCall(methodName, args, gas, deposit, stringify = stringifyJsonOrBytes) {
     return new Action({ functionCall: new FunctionCall({ methodName, args: stringify(args), gas, deposit }) });
 }
 exports.functionCall = functionCall;

--- a/src/account.ts
+++ b/src/account.ts
@@ -503,12 +503,15 @@ export class Account {
         { parse = parseJsonFromRawResponse } = {}
     ): Promise<any> {
         this.validateArgs(args);
+
+        const isUint8Array = args.byteLength !== undefined && args.byteLength === args.length;
+        const serializedArgs = isUint8Array ? args : Buffer.from(JSON.stringify(args));
         
         const result = await this.connection.provider.query<CodeResult>({
             request_type: 'call_function',
             account_id: contractId,
             method_name: methodName,
-            args_base64: Buffer.from(JSON.stringify(args)).toString('base64'),
+            args_base64: serializedArgs.toString('base64'),
             finality: 'optimistic'
         });
 

--- a/src/account.ts
+++ b/src/account.ts
@@ -94,6 +94,10 @@ export interface FunctionCallOptions {
      * @see {@link RequestSignTransactionsOptions}
      */
     walletCallbackUrl?: string;
+    /**
+     * Convert input arguments into bytes array.
+     */
+    stringify?: (input: any) => Buffer;
 }
 
 interface ReceiptLogWithFailure {
@@ -106,9 +110,13 @@ function parseJsonFromRawResponse (response: Uint8Array): any {
     return JSON.parse(Buffer.from(response).toString());
 }
 
+function bytesJsonStringify(input: any): Buffer {
+    return Buffer.from(JSON.stringify(input));
+}
+
 /**
  * This class provides common account related RPC calls including signing transactions with a {@link KeyPair}.
- * 
+ *
  * @example {@link https://docs.near.org/docs/develop/front-end/naj-quick-reference#account}
  * @hint Use {@link WalletConnection} in the browser to redirect to {@link https://docs.near.org/docs/tools/near-wallet | NEAR Wallet} for Account/key management using the {@link BrowserLocalStorageKeyStore}.
  * @see {@link https://nomicon.io/DataStructures/Account.html | Account Spec}
@@ -195,7 +203,7 @@ export class Account {
      * @deprecated
      * Sign a transaction to preform a list of actions and broadcast it using the RPC API.
      * @see {@link JsonRpcProvider.sendTransaction}
-     * 
+     *
      * @param receiverId NEAR account receiving the transaction
      * @param actions list of actions to perform as part of the transaction
      */
@@ -274,9 +282,9 @@ export class Account {
 
     /**
      * Finds the {@link AccessKeyView} associated with the accounts {@link PublicKey} stored in the {@link KeyStore}.
-     * 
+     *
      * @todo Find matching access key based on transaction (i.e. receiverId and actions)
-     * 
+     *
      * @param receiverId currently unused (see todo)
      * @param actions currently unused (see todo)
      * @returns `{ publicKey PublicKey; accessKey: AccessKeyView }`
@@ -322,7 +330,7 @@ export class Account {
 
     /**
      * Create a new account and deploy a contract to it
-     * 
+     *
      * @param contractId NEAR account where the contract is deployed
      * @param publicKey The public key to add to the created contract account
      * @param data The compiled contract code
@@ -384,7 +392,7 @@ export class Account {
     async functionCall(props: FunctionCallOptions): Promise<FinalExecutionOutcome>;
     /**
      * @deprecated
-     * 
+     *
      * @param contractId NEAR account where the contract is deployed
      * @param methodName The method name on the contract as it is written in the contract code
      * @param args arguments to pass to method. Can be either plain JS object which gets serialized as JSON automatically
@@ -393,7 +401,7 @@ export class Account {
      * @param amount amount of NEAR (in yoctoNEAR) to send together with the call
      * @returns {Promise<FinalExecutionOutcome>}
      */
-    async functionCall(contractId: string, methodName: string, args: any, gas?: BN, amount?: BN): Promise<FinalExecutionOutcome> 
+    async functionCall(contractId: string, methodName: string, args: any, gas?: BN, amount?: BN): Promise<FinalExecutionOutcome>
     async functionCall(...args: any[]): Promise<FinalExecutionOutcome> {
         if(typeof args[0] === 'string') {
             return this.functionCallV1(args[0], args[1], args[2], args[3], args[4]);
@@ -414,11 +422,12 @@ export class Account {
         });
     }
 
-    private functionCallV2({ contractId, methodName, args = {}, gas = DEFAULT_FUNCTION_CALL_GAS, attachedDeposit, walletMeta, walletCallbackUrl }: FunctionCallOptions): Promise<FinalExecutionOutcome> {
+    private functionCallV2({ contractId, methodName, args = {}, gas = DEFAULT_FUNCTION_CALL_GAS, attachedDeposit, walletMeta, walletCallbackUrl, stringify }: FunctionCallOptions): Promise<FinalExecutionOutcome> {
         this.validateArgs(args);
+        const opts = stringify === undefined ? {} : {stringify};
         return this.signAndSendTransaction({
             receiverId: contractId,
-            actions: [functionCall(methodName, args, gas, attachedDeposit)],
+            actions: [functionCall(methodName, args, gas, attachedDeposit, opts)],
             walletMeta,
             walletCallbackUrl
         });
@@ -464,7 +473,7 @@ export class Account {
 
     /**
      * @see {@link https://docs.near.org/docs/validator/staking-overview}
-     * 
+     *
      * @param publicKey The public key for the account that's staking
      * @param amount The account to stake in yoctoⓃ
      */
@@ -490,28 +499,28 @@ export class Account {
     /**
      * Invoke a contract view function using the RPC API.
      * @see {@link https://docs.near.org/docs/develop/front-end/rpc#call-a-contract-function}
-     * 
+     *
      * @param contractId NEAR account where the contract is deployed
      * @param methodName The view-only method (no state mutations) name on the contract as it is written in the contract code
      * @param args Any arguments to the view contract method, wrapped in JSON
+     * @param opts.parse Parse the result of the call. Receives a Buffer (bytes array) and converts it to any object. By default result will be treated as json.
+     * @param opts.stringify Convert input arguments into a bytes array. By default the input is treated as a JSON.
      * @returns {Promise<any>}
      */
     async viewFunction(
         contractId: string,
         methodName: string,
         args: any = {},
-        { parse = parseJsonFromRawResponse } = {}
+        { parse = parseJsonFromRawResponse, stringify = bytesJsonStringify } = {}
     ): Promise<any> {
         this.validateArgs(args);
+        const serializedArgs = stringify(args).toString('base64');
 
-        const isUint8Array = args.byteLength !== undefined && args.byteLength === args.length;
-        const serializedArgs = isUint8Array ? args : Buffer.from(JSON.stringify(args));
-        
         const result = await this.connection.provider.query<CodeResult>({
             request_type: 'call_function',
             account_id: contractId,
             method_name: methodName,
-            args_base64: serializedArgs.toString('base64'),
+            args_base64: serializedArgs,
             finality: 'optimistic'
         });
 

--- a/src/account.ts
+++ b/src/account.ts
@@ -13,7 +13,8 @@ import {
     stake,
     deleteAccount,
     Action,
-    SignedTransaction
+    SignedTransaction,
+    stringifyJsonOrBytes
 } from './transaction';
 import { FinalExecutionOutcome, TypedError, ErrorContext } from './providers';
 import { Finality, BlockId, ViewStateResult, AccountView, AccessKeyView, CodeResult, AccessKeyList, AccessKeyInfoView, FunctionCallPermissionView } from './providers/provider';
@@ -424,10 +425,10 @@ export class Account {
 
     private functionCallV2({ contractId, methodName, args = {}, gas = DEFAULT_FUNCTION_CALL_GAS, attachedDeposit, walletMeta, walletCallbackUrl, stringify }: FunctionCallOptions): Promise<FinalExecutionOutcome> {
         this.validateArgs(args);
-        const opts = stringify === undefined ? {} : {stringify};
+        const stringifyArg = stringify === undefined ? stringifyJsonOrBytes : stringify;
         return this.signAndSendTransaction({
             receiverId: contractId,
-            actions: [functionCall(methodName, args, gas, attachedDeposit, opts)],
+            actions: [functionCall(methodName, args, gas, attachedDeposit, stringifyArg)],
             walletMeta,
             walletCallbackUrl
         });
@@ -503,8 +504,8 @@ export class Account {
      * @param contractId NEAR account where the contract is deployed
      * @param methodName The view-only method (no state mutations) name on the contract as it is written in the contract code
      * @param args Any arguments to the view contract method, wrapped in JSON
-     * @param opts.parse Parse the result of the call. Receives a Buffer (bytes array) and converts it to any object. By default result will be treated as json.
-     * @param opts.stringify Convert input arguments into a bytes array. By default the input is treated as a JSON.
+     * @param options.parse Parse the result of the call. Receives a Buffer (bytes array) and converts it to any object. By default result will be treated as json.
+     * @param options.stringify Convert input arguments into a bytes array. By default the input is treated as a JSON.
      * @returns {Promise<any>}
      */
     async viewFunction(

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -51,6 +51,12 @@ export function deployContract(code: Uint8Array): Action {
     return new Action({ deployContract: new DeployContract({code}) });
 }
 
+function stringifyJsonOrBytes(args: any): Buffer {
+    const isUint8Array = args.byteLength !== undefined && args.byteLength === args.length;
+    const serializedArgs = isUint8Array ? args : Buffer.from(JSON.stringify(args));
+    return serializedArgs;
+}
+
 /**
  * Constructs {@link Action} instance representing contract method call.
  *
@@ -59,12 +65,10 @@ export function deployContract(code: Uint8Array): Action {
  *  or `Uint8Array` instance which represents bytes passed as is.
  * @param gas max amount of gas that method call can use
  * @param deposit amount of NEAR (in yoctoNEAR) to send together with the call
+ * @param stringify Convert input arguments into bytes array.
  */
-export function functionCall(methodName: string, args: Uint8Array | object, gas: BN, deposit: BN): Action {
-    const anyArgs = args as any;
-    const isUint8Array = anyArgs.byteLength !== undefined && anyArgs.byteLength === anyArgs.length;
-    const serializedArgs = isUint8Array ? args : Buffer.from(JSON.stringify(args));
-    return new Action({functionCall: new FunctionCall({methodName, args: serializedArgs, gas, deposit }) });
+export function functionCall(methodName: string, args: Uint8Array | object, gas: BN, deposit: BN, {stringify = stringifyJsonOrBytes} = {}): Action {
+    return new Action({functionCall: new FunctionCall({methodName, args: stringify(args), gas, deposit }) });
 }
 
 export function transfer(deposit: BN): Action {

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -51,7 +51,7 @@ export function deployContract(code: Uint8Array): Action {
     return new Action({ deployContract: new DeployContract({code}) });
 }
 
-function stringifyJsonOrBytes(args: any): Buffer {
+export function stringifyJsonOrBytes(args: any): Buffer {
     const isUint8Array = args.byteLength !== undefined && args.byteLength === args.length;
     const serializedArgs = isUint8Array ? args : Buffer.from(JSON.stringify(args));
     return serializedArgs;
@@ -67,7 +67,7 @@ function stringifyJsonOrBytes(args: any): Buffer {
  * @param deposit amount of NEAR (in yoctoNEAR) to send together with the call
  * @param stringify Convert input arguments into bytes array.
  */
-export function functionCall(methodName: string, args: Uint8Array | object, gas: BN, deposit: BN, {stringify = stringifyJsonOrBytes} = {}): Action {
+export function functionCall(methodName: string, args: Uint8Array | object, gas: BN, deposit: BN, stringify = stringifyJsonOrBytes): Action {
     return new Action({functionCall: new FunctionCall({methodName, args: stringify(args), gas, deposit }) });
 }
 


### PR DESCRIPTION
Add support for custom way to stringify arguments.

The motivation was to support borsh both in view & call functions.

The implementation is based on @MaximusHaximus suggestion at https://github.com/near/near-api-js/pull/620#discussion_r656438592