### PR TITLE
build: cookbook uses root NAJ

### DIFF
--- a/examples/cookbook/package.json
+++ b/examples/cookbook/package.json
@@ -11,6 +11,6 @@
   "dependencies": {
     "chalk": "^4.1.1",
     "homedir": "^0.6.0",
-    "near-api-js": "^0.41.0"
+    "near-api-js": "file:../../lib/index.js"
   }
 }


### PR DESCRIPTION
Rather than using version published to NPM, the `examples/cookbook` folder can use the version of NAJ from the root of the project.