### PR TITLE
update links to cookbook and quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A JavaScript/TypeScript library for development of DApps on the NEAR platform
 
 # Examples
 
-## [Quick Reference](https://github.com/near/near-api-js/blob/master/examples/cookbook/README.md)
+## [Quick Reference](https://github.com/near/near-api-js/blob/master/examples/quick-reference.md)
 _(Cheat sheet / quick reference)_
 
 ## [Cookbook](https://github.com/near/near-api-js/blob/master/examples/cookbook/README.md)

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ A JavaScript/TypeScript library for development of DApps on the NEAR platform
 
 # Examples
 
-## [Quick Reference](./examples/quick-reference.md)
+## [Quick Reference](https://github.com/near/near-api-js/blob/master/examples/cookbook/README.md)
 _(Cheat sheet / quick reference)_
 
-## [Cookbook](./examples/cookbook/README.md)
+## [Cookbook](https://github.com/near/near-api-js/blob/master/examples/cookbook/README.md)
 _(Common use cases / more complex examples)_
 
 ---


### PR DESCRIPTION
Typedocs have 404 errors from the main README.md file for quickstart and cookbook. [See here](https://near.github.io/near-api-js/) This PR updates these links to have the full URL instead of pathing from the root directory.

Fixes https://github.com/near/devrel/issues/293

