### PR TITLE
Fix bug in config.js for localnet

### DIFF
--- a/test/config.js
+++ b/test/config.js
@@ -28,7 +28,7 @@ module.exports = function getConfig(env) {
         return {
             networkId: 'local',
             nodeUrl: 'http://localhost:3030',
-            keyPath: `${process.env.HOME}/.near/validator_key.json`,
+            keyPath: `${process.env.HOME}/.near/localnet/node0/validator_key.json`,
             walletUrl: 'http://localhost:4000/wallet',
         };
     case 'test':


### PR DESCRIPTION
When running locally, `nearup` creates a validator_key.json file at `~/.near/localnet/nodeN/validator_key.json`, where N is 0, 1, 2, or 3 by default.

When the environment is set to `local`, `near-api-js` [is looking for](https://github.com/near/near-api-js/blob/master/test/config.js#L27-L33) validator_key.json to be at `~/.near/validator_key.json`. This results in a `KeyNotFound` error when trying to call `near create-account`

Detailed steps to reproduce can be found [in this PR for documentation for running contracts on localnet](https://github.com/near/sdk-docs/pull/49/files?short_path=407a45a#diff-407a45ad5884e51f51a5294ddf4ef06229add5a276170c6e664e09efe9f2f262) (ctrl/cmd + f and search for "bug in nearup" to see where the bug occurs.)

near-cli 2.1.1
nearup 1.2.0