### PR TITLE
Added ability to call cookbook files regardless of terminal directory

### DIFF
--- a/examples/cookbook/README.md
+++ b/examples/cookbook/README.md
@@ -32,13 +32,25 @@
 
 ## Setup
 
-1. Install dependencies
+1. Navigate to the root directory
+
+```bash
+cd ../..
+```
+
+2. Install dependencies
 
 ```bash
 npm install
 ```
 
-3. Run Commands
+3. Navigate back to the cookbook directory
+
+```bash
+cd examples/cookbook
+```
+
+4. Run Commands
 
 Example:
 

--- a/examples/cookbook/transactions/batch-transactions.js
+++ b/examples/cookbook/transactions/batch-transactions.js
@@ -7,8 +7,7 @@ const CREDENTIALS_DIR = ".near-credentials";
 // NOTE: replace "example" with your accountId
 const CONTRACT_NAME = "contract.example.testnet";
 const WHITELIST_ACCOUNT_ID = "whitelisted-account.example.testnet";
-const WASM_PATH = "../utils/wasm-files/staking_pool_factory.wasm";
-const pathToWasm = path.join(__dirname, WASM_PATH);
+const WASM_PATH = path.join(__dirname, "../utils/wasm-files/staking_pool_factory.wasm");
 
 const credentialsPath = path.join(homedir, CREDENTIALS_DIR);
 const keyStore = new keyStores.UnencryptedFileSystemKeyStore(credentialsPath);
@@ -28,7 +27,7 @@ async function sendTransactions() {
     const result = await account.signAndSendTransaction({
         receiverId: CONTRACT_NAME,
         actions: [
-            transactions.deployContract(fs.readFileSync(pathToWasm)),
+            transactions.deployContract(fs.readFileSync(WASM_PATH)),
             transactions.functionCall(
                 "new",
                 Buffer.from(JSON.stringify(newArgs)),

--- a/examples/cookbook/transactions/batch-transactions.js
+++ b/examples/cookbook/transactions/batch-transactions.js
@@ -8,6 +8,7 @@ const CREDENTIALS_DIR = ".near-credentials";
 const CONTRACT_NAME = "contract.example.testnet";
 const WHITELIST_ACCOUNT_ID = "whitelisted-account.example.testnet";
 const WASM_PATH = "../utils/wasm-files/staking_pool_factory.wasm";
+const pathToWasm = path.join(__dirname, WASM_PATH);
 
 const credentialsPath = path.join(homedir, CREDENTIALS_DIR);
 const keyStore = new keyStores.UnencryptedFileSystemKeyStore(credentialsPath);
@@ -27,7 +28,7 @@ async function sendTransactions() {
     const result = await account.signAndSendTransaction({
         receiverId: CONTRACT_NAME,
         actions: [
-            transactions.deployContract(fs.readFileSync(WASM_PATH)),
+            transactions.deployContract(fs.readFileSync(pathToWasm)),
             transactions.functionCall(
                 "new",
                 Buffer.from(JSON.stringify(newArgs)),

--- a/examples/cookbook/utils/deploy-contract.js
+++ b/examples/cookbook/utils/deploy-contract.js
@@ -5,8 +5,7 @@ const homedir = require("os").homedir();
 
 const CREDENTIALS_DIR = ".near-credentials";
 const ACCOUNT_ID = "near-example.testnet";
-const WASM_PATH = "/wasm-files/status_message.wasm";
-const pathToWasm = path.join(__dirname, WASM_PATH);
+const WASM_PATH = path.join(__dirname, "/wasm-files/status_message.wasm");
 const credentialsPath = path.join(homedir, CREDENTIALS_DIR);
 const keyStore = new keyStores.UnencryptedFileSystemKeyStore(credentialsPath);
 
@@ -16,7 +15,7 @@ const config = {
     nodeUrl: "https://rpc.testnet.near.org",
 };
 
-deployContract(ACCOUNT_ID, pathToWasm);
+deployContract(ACCOUNT_ID, WASM_PATH);
 
 async function deployContract(accountId, wasmPath) { 
     const near = await connect(config);

--- a/examples/cookbook/utils/deploy-contract.js
+++ b/examples/cookbook/utils/deploy-contract.js
@@ -5,7 +5,8 @@ const homedir = require("os").homedir();
 
 const CREDENTIALS_DIR = ".near-credentials";
 const ACCOUNT_ID = "near-example.testnet";
-const WASM_PATH = "./wasm-files/status_message.wasm";
+const WASM_PATH = "/wasm-files/status_message.wasm";
+const pathToWasm = path.join(__dirname, WASM_PATH);
 const credentialsPath = path.join(homedir, CREDENTIALS_DIR);
 const keyStore = new keyStores.UnencryptedFileSystemKeyStore(credentialsPath);
 
@@ -15,9 +16,9 @@ const config = {
     nodeUrl: "https://rpc.testnet.near.org",
 };
 
-deployContract(ACCOUNT_ID, WASM_PATH);
+deployContract(ACCOUNT_ID, pathToWasm);
 
-async function deployContract(accountId, wasmPath) {
+async function deployContract(accountId, wasmPath) { 
     const near = await connect(config);
     const account = await near.account(accountId);
     const result = await account.deployContract(fs.readFileSync(wasmPath));


### PR DESCRIPTION
Fixes #683 

 - Went through all cookbook examples and fixed batch-transaction and deploy-contract to incorporate dirname in order to make it so that the user can run the scripts regardless of their terminal directory. 

- Fixed readme instructions
