### PR TITLE
retry json rpc request when expired

### DIFF
--- a/lib/providers/json-rpc-provider.js
+++ b/lib/providers/json-rpc-provider.js
@@ -330,6 +330,10 @@ class JsonRpcProvider extends provider_1.Provider {
                     console.warn(`Retrying request to ${method} as it has timed out`, params);
                     return null;
                 }
+                if (error.type === 'Expired') {
+                    console.warn(`Retrying request to ${method} as it has expired`, params);
+                    return null;
+                }
                 throw error;
             }
         });

--- a/src/providers/json-rpc-provider.ts
+++ b/src/providers/json-rpc-provider.ts
@@ -376,6 +376,10 @@ export class JsonRpcProvider extends Provider {
                     console.warn(`Retrying request to ${method} as it has timed out`, params);
                     return null;
                 }
+                if (error.type === 'Expired') {
+                    console.warn(`Retrying request to ${method} as it has expired`, params);
+                    return null;
+                }
 
                 throw error;
             }


### PR DESCRIPTION
We have seen more expired errors than ever. And these errors could usually be resolved by retrying the request.