### PR TITLE
block_id fix

### DIFF
--- a/lib/providers/json-rpc-provider.js
+++ b/lib/providers/json-rpc-provider.js
@@ -106,7 +106,7 @@ class JsonRpcProvider extends provider_1.Provider {
     async query(...args) {
         let result;
         if (args.length === 1) {
-            result = await this.sendJsonRpc('query', { ...args[0], block_id: args[0].blockId });
+            result = await this.sendJsonRpc('query', args[0]);
         }
         else {
             const [path, data] = args;

--- a/src/providers/json-rpc-provider.ts
+++ b/src/providers/json-rpc-provider.ts
@@ -135,7 +135,7 @@ export class JsonRpcProvider extends Provider {
     async query<T extends QueryResponseKind>(...args: any[]): Promise<T> {
         let result;
         if (args.length === 1) {
-            result = await this.sendJsonRpc<T>('query', { ...args[0], block_id: args[0].blockId });
+            result = await this.sendJsonRpc<T>('query', args[0]);
         } else {
             const [path, data] = args;
             result = await this.sendJsonRpc<T>('query', [path, data]);

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -28,7 +28,7 @@ export class ErrorContext {
 }
 
 export function logWarning(...args: any[]): void {
-  if (!process.env["NEAR_NO_LOGS"]){
-    console.warn(...args);
-  }
+    if (!process.env['NEAR_NO_LOGS']){
+        console.warn(...args);
+    }
 }

--- a/test/providers.test.js
+++ b/test/providers.test.js
@@ -76,12 +76,12 @@ test('txStatus with string hash and buffer hash', withProvider(async(provider) =
     expect(responseWithUint8Array).toMatchObject(outcome);
 }));
 
-test('json rpc query with blockId', withProvider(async(provider) => {
+test('json rpc query with block_id', withProvider(async(provider) => {
     const stat = await provider.status();
-    let blockId = stat.sync_info.latest_block_height - 1;
+    let block_id = stat.sync_info.latest_block_height - 1;
 
     const response = await provider.query({
-        blockId,
+        block_id,
         request_type: 'view_account',
         account_id: 'test.near'
     });


### PR DESCRIPTION
We have a small breaking change that I want to fix in this PR.
Somebody requested a change in this issue: https://github.com/near/near-api-js/issues/635
And it was fixed in this PR: https://github.com/near/near-api-js/pull/639
Now, when we are passing `block_id` instead of the suggested `blockId`, it's becoming `undefined`.
I think that our API should be consistent and we should support only `block_id`, so I'm basically reverting the PR mentioned above.