### PR TITLE
feat: add `returnError` to transaction options

### DIFF
--- a/lib/account.d.ts
+++ b/lib/account.d.ts
@@ -32,6 +32,7 @@ export interface SignAndSendTransactionOptions {
      * @see {@link RequestSignTransactionsOptions}
      */
     walletCallbackUrl?: string;
+    returnError?: boolean;
 }
 /**
  * Options used to initiate a function call (especially a change function call)

--- a/lib/account.js
+++ b/lib/account.js
@@ -111,7 +111,7 @@ class Account {
         deprecate('use `Account.signAndSendTransaction(SignAndSendTransactionOptions)` instead');
         return this.signAndSendTransactionV2({ receiverId, actions });
     }
-    async signAndSendTransactionV2({ receiverId, actions }) {
+    async signAndSendTransactionV2({ receiverId, actions, returnError }) {
         let txHash, signedTx;
         // TODO: TX_NONCE (different constants for different uses of exponentialBackoff?)
         const result = await exponential_backoff_1.default(TX_NONCE_RETRY_WAIT, TX_NONCE_RETRY_NUMBER, TX_NONCE_RETRY_WAIT_BACKOFF, async () => {
@@ -151,7 +151,7 @@ class Account {
                 return acc;
         }, []);
         this.printLogsAndFailures(signedTx.transaction.receiverId, flatLogs);
-        if (typeof result.status === 'object' && typeof result.status.Failure === 'object') {
+        if (!returnError && typeof result.status === 'object' && typeof result.status.Failure === 'object') {
             // if error data has error_message and error_type properties, we consider that node returned an error in the old format
             if (result.status.Failure.error_message && result.status.Failure.error_type) {
                 throw new providers_1.TypedError(`Transaction ${result.transaction_outcome.id} failed. ${result.status.Failure.error_message}`, result.status.Failure.error_type);

--- a/src/account.ts
+++ b/src/account.ts
@@ -66,6 +66,7 @@ export interface SignAndSendTransactionOptions {
      * @see {@link RequestSignTransactionsOptions}
      */
     walletCallbackUrl?: string;
+    returnError?: boolean;
 }
 
 /**
@@ -227,7 +228,7 @@ export class Account {
         return this.signAndSendTransactionV2({ receiverId, actions });
     }
 
-    private async signAndSendTransactionV2({ receiverId, actions }: SignAndSendTransactionOptions): Promise<FinalExecutionOutcome> {
+    private async signAndSendTransactionV2({ receiverId, actions, returnError }: SignAndSendTransactionOptions): Promise<FinalExecutionOutcome> {
         let txHash, signedTx;
         // TODO: TX_NONCE (different constants for different uses of exponentialBackoff?)
         const result = await exponentialBackoff(TX_NONCE_RETRY_WAIT, TX_NONCE_RETRY_NUMBER, TX_NONCE_RETRY_WAIT_BACKOFF, async () => {
@@ -268,7 +269,7 @@ export class Account {
         }, []);
         this.printLogsAndFailures(signedTx.transaction.receiverId, flatLogs);
 
-        if (typeof result.status === 'object' && typeof result.status.Failure === 'object') {
+        if (!returnError && typeof result.status === 'object' && typeof result.status.Failure === 'object') {
             // if error data has error_message and error_type properties, we consider that node returned an error in the old format
             if (result.status.Failure.error_message && result.status.Failure.error_type) {
                 throw new TypedError(


### PR DESCRIPTION
Currently this is the first part of #703.