### PR TITLE
Fix regex for error messages in getErrorTypeFromErrorMessage

### DIFF
--- a/src/utils/rpc_errors.ts
+++ b/src/utils/rpc_errors.ts
@@ -88,11 +88,11 @@ function walkSubtype(errorObj, schema, result, typeName) {
 export function getErrorTypeFromErrorMessage(errorMessage) {
     // This function should be removed when JSON RPC starts returning typed errors.
     switch (true) {
-    case /^account .*? does not exist while viewing$/.test(errorMessage):
+    case /account .*? does not exist while viewing$/.test(errorMessage):
         return 'AccountDoesNotExist';
-    case /^Account .*? doesn't exist$/.test(errorMessage):
+    case /Account .*? doesn't exist$/.test(errorMessage):
         return 'AccountDoesNotExist';
-    case /^access key .*? does not exist while viewing$/.test(errorMessage):
+    case /access key .*? does not exist while viewing$/.test(errorMessage):
         return 'AccessKeyDoesNotExist';
     case /wasm execution failed with error: FunctionCallError\(CompilationError\(CodeDoesNotExist/.test(errorMessage):
         return 'CodeDoesNotExist';


### PR DESCRIPTION
I'm pretty sure there's no way `getErrorTypeFromErrorMessage` will work in practice with these carets (`^`), so I removed them. I would challenge anyone to provide a short JavaScript file where this works.

This has come about by working on this PR:
https://github.com/near/near-api-js/pull/722