### PR TITLE
fix: add check to suppress retry log

### DIFF
--- a/lib/providers/json-rpc-provider.js
+++ b/lib/providers/json-rpc-provider.js
@@ -327,7 +327,7 @@ class JsonRpcProvider extends provider_1.Provider {
             }
             catch (error) {
                 if (error.type === 'TimeoutError') {
-                    if (!process.env["NEAR_NO_LOGS"]) {
+                    if (!process.env['NEAR_NO_LOGS']) {
                         console.warn(`Retrying request to ${method} as it has timed out`, params);
                     }
                     return null;

--- a/lib/providers/json-rpc-provider.js
+++ b/lib/providers/json-rpc-provider.js
@@ -327,7 +327,9 @@ class JsonRpcProvider extends provider_1.Provider {
             }
             catch (error) {
                 if (error.type === 'TimeoutError') {
-                    console.warn(`Retrying request to ${method} as it has timed out`, params);
+                    if (!process.env["NEAR_NO_LOGS"]) {
+                        console.warn(`Retrying request to ${method} as it has timed out`, params);
+                    }
                     return null;
                 }
                 throw error;

--- a/lib/wallet-account.js
+++ b/lib/wallet-account.js
@@ -164,6 +164,8 @@ class WalletConnection {
         currentUrl.searchParams.delete('public_key');
         currentUrl.searchParams.delete('all_keys');
         currentUrl.searchParams.delete('account_id');
+        currentUrl.searchParams.delete('meta');
+        currentUrl.searchParams.delete('transactionHashes');
         window.history.replaceState({}, document.title, currentUrl.toString());
     }
     /**

--- a/src/providers/json-rpc-provider.ts
+++ b/src/providers/json-rpc-provider.ts
@@ -373,9 +373,9 @@ export class JsonRpcProvider extends Provider {
                 return response;
             } catch (error) {
                 if (error.type === 'TimeoutError') {
-                  if (!process.env["NEAR_NO_LOGS"]){
-                    console.warn(`Retrying request to ${method} as it has timed out`, params);
-                  }
+                    if (!process.env['NEAR_NO_LOGS']){
+                        console.warn(`Retrying request to ${method} as it has timed out`, params);
+                    }
                     return null;
                 }
 

--- a/src/providers/json-rpc-provider.ts
+++ b/src/providers/json-rpc-provider.ts
@@ -373,7 +373,9 @@ export class JsonRpcProvider extends Provider {
                 return response;
             } catch (error) {
                 if (error.type === 'TimeoutError') {
+                  if (!process.env["NEAR_NO_LOGS"]){
                     console.warn(`Retrying request to ${method} as it has timed out`, params);
+                  }
                     return null;
                 }
 


### PR DESCRIPTION
Now when trying a transaction the warning can be ignore.  It was very log and made the output of workspace tests very noisy.