### PR TITLE
deployMultisig: check that there's no existing contract

### DIFF
--- a/lib/account_multisig.js
+++ b/lib/account_multisig.js
@@ -18,6 +18,12 @@ exports.MULTISIG_GAS = new bn_js_1.default('100000000000000');
 exports.MULTISIG_DEPOSIT = new bn_js_1.default('0');
 exports.MULTISIG_CHANGE_METHODS = ['add_request', 'add_request_and_confirm', 'delete_request', 'confirm'];
 exports.MULTISIG_CONFIRM_METHODS = ['confirm'];
+// We deploy an empty contract when we disable 2FA (main.wasm), so we must check for that
+// contract's hash OR no code_hash to be sure it's safe
+const ALLOW_2FA_ENABLE_HASHES = [
+    'E8jZ1giWcVrps8PcV75ATauu6gFRkcwjNtKp7NKmipZG',
+    '11111111111111111111111111111111'
+];
 // in memory request cache for node w/o localStorage
 const storageFallback = {
     [exports.MULTISIG_STORAGE_KEY]: null
@@ -154,7 +160,7 @@ class Account2FA extends AccountMultisig {
     }
     // default helpers for CH deployments of multisig
     async deployMultisig(contractBytes) {
-        if ((await this.state()).code_hash === '11111111111111111111111111111111') {
+        if (ALLOW_2FA_ENABLE_HASHES.includes((await this.state()).code_hash)) {
             const { accountId } = this;
             const seedOrLedgerKey = (await this.getRecoveryMethods()).data
                 .filter(({ kind, publicKey }) => (kind === 'phrase' || kind === 'ledger') && publicKey !== null)

--- a/lib/account_multisig.js
+++ b/lib/account_multisig.js
@@ -20,7 +20,7 @@ exports.MULTISIG_CHANGE_METHODS = ['add_request', 'add_request_and_confirm', 'de
 exports.MULTISIG_CONFIRM_METHODS = ['confirm'];
 // We deploy an empty contract when we disable 2FA (main.wasm), so we must check for that
 // contract's hash OR no code_hash to be sure it's safe
-const ALLOW_2FA_ENABLE_HASHES = [
+const ALLOW_2FA_ENABLE_HASHES = process.env.ALLOW_2FA_ENABLE_HASHES || [
     'E8jZ1giWcVrps8PcV75ATauu6gFRkcwjNtKp7NKmipZG',
     '11111111111111111111111111111111'
 ];
@@ -160,30 +160,28 @@ class Account2FA extends AccountMultisig {
     }
     // default helpers for CH deployments of multisig
     async deployMultisig(contractBytes) {
-        if (ALLOW_2FA_ENABLE_HASHES.includes((await this.state()).code_hash)) {
-            const { accountId } = this;
-            const seedOrLedgerKey = (await this.getRecoveryMethods()).data
-                .filter(({ kind, publicKey }) => (kind === 'phrase' || kind === 'ledger') && publicKey !== null)
-                .map((rm) => rm.publicKey);
-            const fak2lak = (await this.getAccessKeys())
-                .filter(({ public_key, access_key: { permission } }) => permission === 'FullAccess' && !seedOrLedgerKey.includes(public_key))
-                .map((ak) => ak.public_key)
-                .map(toPK);
-            const confirmOnlyKey = toPK((await this.postSignedJson('/2fa/getAccessKey', { accountId })).publicKey);
-            const newArgs = Buffer.from(JSON.stringify({ 'num_confirmations': 2 }));
-            const actions = [
-                ...fak2lak.map((pk) => transaction_1.deleteKey(pk)),
-                ...fak2lak.map((pk) => transaction_1.addKey(pk, transaction_1.functionCallAccessKey(accountId, exports.MULTISIG_CHANGE_METHODS, null))),
-                transaction_1.addKey(confirmOnlyKey, transaction_1.functionCallAccessKey(accountId, exports.MULTISIG_CONFIRM_METHODS, null)),
-                transaction_1.deployContract(contractBytes),
-                transaction_1.functionCall('new', newArgs, exports.MULTISIG_GAS, exports.MULTISIG_DEPOSIT)
-            ];
-            console.log('deploying multisig contract for', accountId);
-            return await super.signAndSendTransactionWithAccount(accountId, actions);
-        }
-        else {
+        if (!ALLOW_2FA_ENABLE_HASHES.includes((await this.state()).code_hash)) {
             throw new Error('Cannot deploy multisig on this account as the account already has a contract deployed.');
         }
+        const { accountId } = this;
+        const seedOrLedgerKey = (await this.getRecoveryMethods()).data
+            .filter(({ kind, publicKey }) => (kind === 'phrase' || kind === 'ledger') && publicKey !== null)
+            .map((rm) => rm.publicKey);
+        const fak2lak = (await this.getAccessKeys())
+            .filter(({ public_key, access_key: { permission } }) => permission === 'FullAccess' && !seedOrLedgerKey.includes(public_key))
+            .map((ak) => ak.public_key)
+            .map(toPK);
+        const confirmOnlyKey = toPK((await this.postSignedJson('/2fa/getAccessKey', { accountId })).publicKey);
+        const newArgs = Buffer.from(JSON.stringify({ 'num_confirmations': 2 }));
+        const actions = [
+            ...fak2lak.map((pk) => transaction_1.deleteKey(pk)),
+            ...fak2lak.map((pk) => transaction_1.addKey(pk, transaction_1.functionCallAccessKey(accountId, exports.MULTISIG_CHANGE_METHODS, null))),
+            transaction_1.addKey(confirmOnlyKey, transaction_1.functionCallAccessKey(accountId, exports.MULTISIG_CONFIRM_METHODS, null)),
+            transaction_1.deployContract(contractBytes),
+            transaction_1.functionCall('new', newArgs, exports.MULTISIG_GAS, exports.MULTISIG_DEPOSIT)
+        ];
+        console.log('deploying multisig contract for', accountId);
+        return await super.signAndSendTransactionWithAccount(accountId, actions);
     }
     async disable(contractBytes) {
         const { accountId } = this;

--- a/lib/account_multisig.js
+++ b/lib/account_multisig.js
@@ -154,27 +154,30 @@ class Account2FA extends AccountMultisig {
     }
     // default helpers for CH deployments of multisig
     async deployMultisig(contractBytes) {
-        const { accountId } = this;
-        const seedOrLedgerKey = (await this.getRecoveryMethods()).data
-            .filter(({ kind, publicKey }) => (kind === 'phrase' || kind === 'ledger') && publicKey !== null)
-            .map((rm) => rm.publicKey);
-        const fak2lak = (await this.getAccessKeys())
-            .filter(({ public_key, access_key: { permission } }) => permission === 'FullAccess' && !seedOrLedgerKey.includes(public_key))
-            .map((ak) => ak.public_key)
-            .map(toPK);
-        const confirmOnlyKey = toPK((await this.postSignedJson('/2fa/getAccessKey', { accountId })).publicKey);
-        const newArgs = Buffer.from(JSON.stringify({ 'num_confirmations': 2 }));
-        const actions = [
-            ...fak2lak.map((pk) => transaction_1.deleteKey(pk)),
-            ...fak2lak.map((pk) => transaction_1.addKey(pk, transaction_1.functionCallAccessKey(accountId, exports.MULTISIG_CHANGE_METHODS, null))),
-            transaction_1.addKey(confirmOnlyKey, transaction_1.functionCallAccessKey(accountId, exports.MULTISIG_CONFIRM_METHODS, null)),
-            transaction_1.deployContract(contractBytes),
-        ];
         if ((await this.state()).code_hash === '11111111111111111111111111111111') {
-            actions.push(transaction_1.functionCall('new', newArgs, exports.MULTISIG_GAS, exports.MULTISIG_DEPOSIT));
+            const { accountId } = this;
+            const seedOrLedgerKey = (await this.getRecoveryMethods()).data
+                .filter(({ kind, publicKey }) => (kind === 'phrase' || kind === 'ledger') && publicKey !== null)
+                .map((rm) => rm.publicKey);
+            const fak2lak = (await this.getAccessKeys())
+                .filter(({ public_key, access_key: { permission } }) => permission === 'FullAccess' && !seedOrLedgerKey.includes(public_key))
+                .map((ak) => ak.public_key)
+                .map(toPK);
+            const confirmOnlyKey = toPK((await this.postSignedJson('/2fa/getAccessKey', { accountId })).publicKey);
+            const newArgs = Buffer.from(JSON.stringify({ 'num_confirmations': 2 }));
+            const actions = [
+                ...fak2lak.map((pk) => transaction_1.deleteKey(pk)),
+                ...fak2lak.map((pk) => transaction_1.addKey(pk, transaction_1.functionCallAccessKey(accountId, exports.MULTISIG_CHANGE_METHODS, null))),
+                transaction_1.addKey(confirmOnlyKey, transaction_1.functionCallAccessKey(accountId, exports.MULTISIG_CONFIRM_METHODS, null)),
+                transaction_1.deployContract(contractBytes),
+                transaction_1.functionCall('new', newArgs, exports.MULTISIG_GAS, exports.MULTISIG_DEPOSIT)
+            ];
+            console.log('deploying multisig contract for', accountId);
+            return await super.signAndSendTransactionWithAccount(accountId, actions);
         }
-        console.log('deploying multisig contract for', accountId);
-        return await super.signAndSendTransactionWithAccount(accountId, actions);
+        else {
+            throw new Error('Cannot deploy multisig on this account as the account already has a contract deployed.');
+        }
     }
     async disable(contractBytes) {
         const { accountId } = this;

--- a/src/account_multisig.ts
+++ b/src/account_multisig.ts
@@ -19,6 +19,13 @@ export const MULTISIG_DEPOSIT = new BN('0');
 export const MULTISIG_CHANGE_METHODS = ['add_request', 'add_request_and_confirm', 'delete_request', 'confirm'];
 export const MULTISIG_CONFIRM_METHODS = ['confirm'];
 
+// We deploy an empty contract when we disable 2FA (main.wasm), so we must check for that
+// contract's hash OR no code_hash to be sure it's safe
+const ALLOW_2FA_ENABLE_HASHES = [
+    'E8jZ1giWcVrps8PcV75ATauu6gFRkcwjNtKp7NKmipZG',
+    '11111111111111111111111111111111'
+];
+
 type sendCodeFunction = () => Promise<any>;
 type getCodeFunction = (method: any) => Promise<string>;
 type verifyCodeFunction = (securityCode: any) => Promise<any>;
@@ -205,7 +212,7 @@ export class Account2FA extends AccountMultisig {
     // default helpers for CH deployments of multisig
 
     async deployMultisig(contractBytes: Uint8Array) {
-        if ((await this.state()).code_hash === '11111111111111111111111111111111') {
+        if (ALLOW_2FA_ENABLE_HASHES.includes((await this.state()).code_hash)) {
             const { accountId } = this;
             const seedOrLedgerKey = (await this.getRecoveryMethods()).data
                 .filter(({ kind, publicKey }) => (kind === 'phrase' || kind === 'ledger') && publicKey !== null)


### PR DESCRIPTION
We deploy an empty contract when we disable 2FA (main.wasm), so we must check for that contract's hash OR no code_hash to be sure it's safe to deploy multisig

Reference issue: https://github.com/near/near-wallet/issues/2261