### PR TITLE
New findSeatPrice implementation

### DIFF
--- a/lib/validators.d.ts
+++ b/lib/validators.d.ts
@@ -3,9 +3,11 @@ import { CurrentEpochValidatorInfo, NextEpochValidatorInfo } from './providers/p
 /** Finds seat price given validators stakes and number of seats.
  *  Calculation follow the spec: https://nomicon.io/Economics/README.html#validator-selection
  * @params validators: current or next epoch validators.
- * @params numSeats: number of seats.
+ * @params maxNumberOfSeats: maximum number of seats in the network.
+ * @params minimumStakeRatio: minimum stake ratio
+ * @params protocolVersion: version of the protocol from genesis config
  */
-export declare function findSeatPrice(validators: (CurrentEpochValidatorInfo | NextEpochValidatorInfo)[], numSeats: number): BN;
+export declare function findSeatPrice(validators: (CurrentEpochValidatorInfo | NextEpochValidatorInfo)[], maxNumberOfSeats: number, minimumStakeRatio: number, protocolVersion?: number): BN;
 export interface ChangedValidatorInfo {
     current: CurrentEpochValidatorInfo;
     next: NextEpochValidatorInfo;

--- a/lib/validators.js
+++ b/lib/validators.js
@@ -5,12 +5,27 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.diffEpochValidators = exports.findSeatPrice = void 0;
 const bn_js_1 = __importDefault(require("bn.js"));
+const depd_1 = __importDefault(require("depd"));
 /** Finds seat price given validators stakes and number of seats.
  *  Calculation follow the spec: https://nomicon.io/Economics/README.html#validator-selection
  * @params validators: current or next epoch validators.
- * @params numSeats: number of seats.
+ * @params maxNumberOfSeats: maximum number of seats in the network.
+ * @params minimumStakeRatio: minimum stake ratio
+ * @params protocolVersion: version of the protocol from genesis config
  */
-function findSeatPrice(validators, numSeats) {
+function findSeatPrice(validators, maxNumberOfSeats, minimumStakeRatio, protocolVersion) {
+    if (protocolVersion && protocolVersion < 49) {
+        return findSeatPriceForProtocolBefore49(validators, maxNumberOfSeats);
+    }
+    if (!minimumStakeRatio) {
+        const deprecate = depd_1.default('findSeatPrice(validators, maxNumberOfSeats)');
+        deprecate('`use `findSeatPrice(validators, maxNumberOfSeats, minimumStakeRatio)` instead');
+        minimumStakeRatio = 6250; // harcoded minimumStakeRation from 12/7/21
+    }
+    return findSeatPriceForProtocolAfter49(validators, maxNumberOfSeats, minimumStakeRatio);
+}
+exports.findSeatPrice = findSeatPrice;
+function findSeatPriceForProtocolBefore49(validators, numSeats) {
     const stakes = validators.map(v => new bn_js_1.default(v.stake, 10)).sort((a, b) => a.cmp(b));
     const num = new bn_js_1.default(numSeats);
     const stakesSum = stakes.reduce((a, b) => a.add(b));
@@ -37,7 +52,17 @@ function findSeatPrice(validators, numSeats) {
     }
     return left;
 }
-exports.findSeatPrice = findSeatPrice;
+// nearcore reference: https://github.com/near/nearcore/blob/5a8ae263ec07930cd34d0dcf5bcee250c67c02aa/chain/epoch_manager/src/validator_selection.rs#L308;L315
+function findSeatPriceForProtocolAfter49(validators, maxNumberOfSeats, minimumStakeRatio) {
+    const stakes = validators.map(v => new bn_js_1.default(v.stake, 10)).sort((a, b) => a.cmp(b));
+    const stakesSum = stakes.reduce((a, b) => a.add(b));
+    if (validators.length < maxNumberOfSeats) {
+        return stakesSum.div(new bn_js_1.default(minimumStakeRatio));
+    }
+    else {
+        return stakes[0].add(new bn_js_1.default(1));
+    }
+}
 /** Diff validators between current and next epoch.
  * Returns additions, subtractions and changes to validator set.
  * @params currentValidators: list of current validators.

--- a/src/validators.ts
+++ b/src/validators.ts
@@ -36,6 +36,16 @@ export function findSeatPrice(validators: (CurrentEpochValidatorInfo | NextEpoch
     return left;
 }
 
+export function findSeatPriceForProtocolAfter49(validators: (CurrentEpochValidatorInfo | NextEpochValidatorInfo)[], minimumStakeRatio: number, maxNumberOfSeats: number): BN {
+    const stakes = validators.map(v => new BN(v.stake, 10)).sort((a, b) => a.cmp(b));
+    const stakesSum = stakes.reduce((a, b) => a.add(b));
+    if (validators.length < maxNumberOfSeats) {
+        return stakesSum.div(new BN(minimumStakeRatio));
+    } else {
+        return stakes[0].add(new BN(1));
+    }
+}
+
 export interface ChangedValidatorInfo {
     current: CurrentEpochValidatorInfo;
     next: NextEpochValidatorInfo;

--- a/test/validator.test.js
+++ b/test/validator.test.js
@@ -2,31 +2,18 @@
 const nearApi = require('../src/index');
 const BN = require('bn.js');
 
-test('find seat price with old parameters', async () => {
-    expect(nearApi.validators.findSeatPrice(
-        [{stake: '1000000'}, {stake: '1000000'}, {stake: '10'}], 10)).toEqual(new BN('200000'));
-    expect(nearApi.validators.findSeatPrice(
-        [{ stake: '1000000000' }, { stake: '10' }], 10)).toEqual(new BN('100000000'));
-    expect(nearApi.validators.findSeatPrice(
-        [{ stake: '1000000000' }], 1000000000)).toEqual(new BN('1'));
-    expect(nearApi.validators.findSeatPrice(
-        [{ stake: '1000' }, { stake: '1' }, { stake: '1' }, { stake: '1' }, { stake: '1' }, { stake: '1' }, { stake: '1' }, { stake: '1' }, { stake: '1' }], 1)).toEqual(new BN('1000'));
-    expect(() => { nearApi.validators.findSeatPrice(
-        [{ stake: '1' }, { stake: '1' }, { stake: '2' }], 100); }).toThrow();
-});
-
-test('find seat price with new parameters', async () => {
+test('find seat price', async () => {
     expect(nearApi.validators.findSeatPrice(
         [{stake: '1000000'}, {stake: '1000000'}, {stake: '100'}], 2, 6250, 49
     )).toEqual(new BN('101'));
     expect(nearApi.validators.findSeatPrice(
-        [{stake: '1000000'}, {stake: '1000000'}, {stake: '100'}], 3, 6250, 49
+        [{stake: '1000000'}, {stake: '1000000'}, {stake: '100'}], 3, 6250
     )).toEqual(new BN('101'));
     expect(nearApi.validators.findSeatPrice(
         [{stake: '1000000'}, {stake: '1000000'}, {stake: '100'}], 4, 6250, 49
     )).toEqual(new BN('320'));
     expect(nearApi.validators.findSeatPrice(
-        [{stake: '1000'}, {stake: '1000'}, {stake: '200'}], 100, 25, 49
+        [{stake: '1000'}, {stake: '1000'}, {stake: '200'}], 100, 25
     )).toEqual(new BN('88'));
 });
 

--- a/test/validator.test.js
+++ b/test/validator.test.js
@@ -15,6 +15,29 @@ test('find seat price', async () => {
         [{ stake: '1' }, { stake: '1' }, { stake: '2' }], 100); }).toThrow();
 });
 
+test('test findSeatPriceForProtocolAfter49', async () => {
+    expect(nearApi.validators.findSeatPriceForProtocolAfter49(
+        [{stake: '1000000'}, {stake: '1000000'}, {stake: '100'}],
+        6250,
+        2
+    )).toEqual(new BN('101'));
+    expect(nearApi.validators.findSeatPriceForProtocolAfter49(
+        [{stake: '1000000'}, {stake: '1000000'}, {stake: '100'}],
+        6250,
+        3
+    )).toEqual(new BN('101'));
+    expect(nearApi.validators.findSeatPriceForProtocolAfter49(
+        [{stake: '1000000'}, {stake: '1000000'}, {stake: '100'}],
+        6250,
+        4
+    )).toEqual(new BN('320'));
+    expect(nearApi.validators.findSeatPriceForProtocolAfter49(
+        [{stake: '1000'}, {stake: '1000'}, {stake: '200'}],
+        25,
+        100
+    )).toEqual(new BN('88'));
+});
+
 test('diff validators', async () => {
     expect(nearApi.validators.diffEpochValidators(
         [{account_id: 'x', stake: '10'}],

--- a/test/validator.test.js
+++ b/test/validator.test.js
@@ -2,7 +2,7 @@
 const nearApi = require('../src/index');
 const BN = require('bn.js');
 
-test('find seat price', async () => {
+test('find seat price with old parameters', async () => {
     expect(nearApi.validators.findSeatPrice(
         [{stake: '1000000'}, {stake: '1000000'}, {stake: '10'}], 10)).toEqual(new BN('200000'));
     expect(nearApi.validators.findSeatPrice(
@@ -15,26 +15,18 @@ test('find seat price', async () => {
         [{ stake: '1' }, { stake: '1' }, { stake: '2' }], 100); }).toThrow();
 });
 
-test('test findSeatPriceForProtocolAfter49', async () => {
-    expect(nearApi.validators.findSeatPriceForProtocolAfter49(
-        [{stake: '1000000'}, {stake: '1000000'}, {stake: '100'}],
-        6250,
-        2
+test('find seat price with new parameters', async () => {
+    expect(nearApi.validators.findSeatPrice(
+        [{stake: '1000000'}, {stake: '1000000'}, {stake: '100'}], 2, 6250, 49
     )).toEqual(new BN('101'));
-    expect(nearApi.validators.findSeatPriceForProtocolAfter49(
-        [{stake: '1000000'}, {stake: '1000000'}, {stake: '100'}],
-        6250,
-        3
+    expect(nearApi.validators.findSeatPrice(
+        [{stake: '1000000'}, {stake: '1000000'}, {stake: '100'}], 3, 6250, 49
     )).toEqual(new BN('101'));
-    expect(nearApi.validators.findSeatPriceForProtocolAfter49(
-        [{stake: '1000000'}, {stake: '1000000'}, {stake: '100'}],
-        6250,
-        4
+    expect(nearApi.validators.findSeatPrice(
+        [{stake: '1000000'}, {stake: '1000000'}, {stake: '100'}], 4, 6250, 49
     )).toEqual(new BN('320'));
-    expect(nearApi.validators.findSeatPriceForProtocolAfter49(
-        [{stake: '1000'}, {stake: '1000'}, {stake: '200'}],
-        25,
-        100
+    expect(nearApi.validators.findSeatPrice(
+        [{stake: '1000'}, {stake: '1000'}, {stake: '200'}], 100, 25, 49
     )).toEqual(new BN('88'));
 });
 


### PR DESCRIPTION
Appeared that it can be done in a none breaking way, but we need to provide extra parameters.
As an option, I can add a completely new function that will get that data for us.
Something like:
```javascript
export async function getSeatPrice(validators);
``` 
Or even:
```javascript
export async function getSeatPrice(CURRENT/NEXT);
```
But I'm not sure if it's flexible enough.