### PR TITLE
Update borsh to 0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "types": "lib/index.d.ts",
     "dependencies": {
         "bn.js": "5.2.0",
-        "borsh": "^0.6.0",
+        "borsh": "^0.7.0",
         "bs58": "^4.0.0",
         "depd": "^2.0.0",
         "error-polyfill": "^0.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1149,10 +1149,10 @@ bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.11.9:
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.0.tgz#775b3f278efbb9718eec7361f483fb36fbbfea88"
   integrity sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==
 
-borsh@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/borsh/-/borsh-0.6.0.tgz#a7c9eeca6a31ca9e0607cb49f329cb659eb791e1"
-  integrity sha512-sl5k89ViqsThXQpYa9XDtz1sBl3l1lI313cFUY1HKr+wvMILnb+58xpkqTNrYbelh99dY7K8usxoCusQmqix9Q==
+borsh@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/borsh/-/borsh-0.7.0.tgz#6e9560d719d86d90dc589bca60ffc8a6c51fec2a"
+  integrity sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==
   dependencies:
     bn.js "^5.2.0"
     bs58 "^4.0.0"


### PR DESCRIPTION
This fixes the issue of `global` not defined as it occurred in `borsh`, but it doesn't remove usage of `global` in connect.ts.
I'm working on fixing the other usage of global now.  I can do a separate PR or add to this one.