### PR TITLE
Failover configuration

### DIFF
--- a/examples/cookbook/api-keys/near-connection.js
+++ b/examples/cookbook/api-keys/near-connection.js
@@ -7,16 +7,15 @@ const CREDENTIALS_DIR = ".near-credentials";
 const credentialsPath = path.join(homedir, CREDENTIALS_DIR);
 const keyStore = new keyStores.UnencryptedFileSystemKeyStore(credentialsPath);
 
-const RPC_API_ENDPOINT = '<Replace this string with your RPC server URL>';
 const API_KEY = '<Replace this string with your API KEY>';
-
 const ACCOUNT_ID = '<Replace this string with existing account ID>';
 
 const config = {
     networkId: 'testnet',
     keyStore,
-    nodeUrl: RPC_API_ENDPOINT,
-    headers: { 'x-api-key': API_KEY },
+    nodeUrl: '<Replace this string with your RPC server URL>',
+    // RPC server URL in apiKeys should match the one specified in nodeUrl
+    apiKeys: { '<Replace this string with your RPC server URL>': API_KEY },
 };
 
 async function getState(accountId) {

--- a/examples/cookbook/api-keys/provider-example.js
+++ b/examples/cookbook/api-keys/provider-example.js
@@ -5,6 +5,7 @@ const API_KEY = '<Replace this string with your API KEY>';
 
 const provider = new providers.JsonRpcProvider({
     url: '<Replace this string with your RPC server URL>',
+    // RPC server URL in apiKeys should match the one specified in url
     apiKeys: { '<Replace this string with your RPC server URL>': API_KEY }
 });
 

--- a/examples/cookbook/api-keys/provider-example.js
+++ b/examples/cookbook/api-keys/provider-example.js
@@ -1,12 +1,11 @@
 // demonstrates how to use API-KEY with provider 
 const { providers } = require("near-api-js");
 
-const RPC_API_ENDPOINT = '<Replace this string with your RPC server URL>';
 const API_KEY = '<Replace this string with your API KEY>';
 
 const provider = new providers.JsonRpcProvider({
-    url: RPC_API_ENDPOINT,
-    headers: { 'x-api-key': API_KEY },
+    url: 'https://testnet.rpc.near.dev',
+    apiKeys: { 'https://testnet.rpc.near.dev': API_KEY }
 });
 
 getNetworkStatus();

--- a/examples/cookbook/api-keys/provider-example.js
+++ b/examples/cookbook/api-keys/provider-example.js
@@ -4,8 +4,8 @@ const { providers } = require("near-api-js");
 const API_KEY = '<Replace this string with your API KEY>';
 
 const provider = new providers.JsonRpcProvider({
-    url: 'https://testnet.rpc.near.dev',
-    apiKeys: { 'https://testnet.rpc.near.dev': API_KEY }
+    url: '<Replace this string with your RPC server URL>',
+    apiKeys: { '<Replace this string with your RPC server URL>': API_KEY }
 });
 
 getNetworkStatus();

--- a/examples/cookbook/failover-configuration.js
+++ b/examples/cookbook/failover-configuration.js
@@ -1,14 +1,13 @@
-// Demonstrates how to use failover functionality with provider 
-const { providers } = require("near-api-js");
+// Demonstrates how to use failover functionality RPC Servers
+const { providers, connect } = require("near-api-js");
 
-//TODO: replace with placeholders
-const MAIN_RPC_SERVER = 'https://rpc.testnet.near.org';
-const FAILOVER_RPC_SERVER_1 = 'https://rpc.ci-testnet.near.org';
-const FAILOVER_RPC_SERVER_2 = 'https://testnet.rpc.near.dev'; //this one needs API Key
+const MAIN_RPC_SERVER = '<RPC Server 1>';
+const FAILOVER_RPC_SERVER_1 = '<RPC Server 2>';
+const FAILOVER_RPC_SERVER_2 = '<RPC Server 1>';
 
 // Provider example
 const provider = new providers.JsonRpcProvider({
-    // TODO: what is happening here
+    // preoritized list of RPC Servers
     url: [MAIN_RPC_SERVER, FAILOVER_RPC_SERVER_1, FAILOVER_RPC_SERVER_2],
 });
 
@@ -20,4 +19,18 @@ async function getNetworkStatus() {
 getNetworkStatus();
 
 // Connection example
-//TODO⏎
+const ACCOUNT_ID = "<Account ID>";
+
+const config = {
+    networkId: 'testnet',
+    nodeUrl: [MAIN_RPC_SERVER, FAILOVER_RPC_SERVER_1, FAILOVER_RPC_SERVER_2],
+};
+
+async function getState(accountId) {
+    const near = await connect(config);
+    const account = await near.account(accountId);
+    const state = await account.state();
+    console.log(state);
+}
+
+getState(ACCOUNT_ID);

--- a/examples/cookbook/failover-configuration.js
+++ b/examples/cookbook/failover-configuration.js
@@ -1,0 +1,25 @@
+// Demonstrates how to use failover functionality with provider 
+const { providers } = require("near-api-js");
+
+//TODO: replace with placeholders
+const MAIN_RPC_SERVER = 'https://rpc.testnet.near.org';
+const FAILOVER_RPC_SERVER_1 = 'https://rpc.ci-testnet.near.org';
+const FAILOVER_RPC_SERVER_2 = 'https://testnet.rpc.near.dev'; //this one needs API Key
+
+// Provider example
+const provider = new providers.JsonRpcProvider({
+    url: MAIN_RPC_SERVER,
+    /* In case of several unsuccessful calls to the main RPC Server,
+    near-api-js will make an attempt to execute call on failover RPC servers. */
+    failoverUrls: [FAILOVER_RPC_SERVER_1, FAILOVER_RPC_SERVER_2],
+});
+
+async function getNetworkStatus() {
+    const result = await provider.status();
+    console.log(result);
+}
+
+getNetworkStatus();
+
+// Connection example
+//TODO⏎

--- a/examples/cookbook/failover-configuration.js
+++ b/examples/cookbook/failover-configuration.js
@@ -8,10 +8,8 @@ const FAILOVER_RPC_SERVER_2 = 'https://testnet.rpc.near.dev'; //this one needs A
 
 // Provider example
 const provider = new providers.JsonRpcProvider({
-    url: MAIN_RPC_SERVER,
-    /* In case of several unsuccessful calls to the main RPC Server,
-    near-api-js will make an attempt to execute call on failover RPC servers. */
-    failoverUrls: [FAILOVER_RPC_SERVER_1, FAILOVER_RPC_SERVER_2],
+    // TODO: what is happening here
+    url: [MAIN_RPC_SERVER, FAILOVER_RPC_SERVER_1, FAILOVER_RPC_SERVER_2],
 });
 
 async function getNetworkStatus() {

--- a/lib/near.d.ts
+++ b/lib/near.d.ts
@@ -49,6 +49,10 @@ export interface NearConfig {
      */
     nodeUrl: string;
     /**
+     * RPC API Keys. Used to authenticate users on RPC Server.
+     */
+    apiKeys: string;
+    /**
      * NEAR RPC API headers. Can be used to pass API KEY and other parameters.
      * @see {@link JsonRpcProvider.JsonRpcProvider | JsonRpcProvider}
      */

--- a/lib/near.d.ts
+++ b/lib/near.d.ts
@@ -44,10 +44,11 @@ export interface NearConfig {
      */
     networkId: string;
     /**
-     * NEAR RPC API url. used to make JSON RPC calls to interact with NEAR.
+     * NEAR RPC API url. Used to make JSON RPC calls to interact with NEAR.
+     * You can set multiple RPC Server URLs to turn on failover functionality.
      * @see {@link JsonRpcProvider.JsonRpcProvider | JsonRpcProvider}
      */
-    nodeUrl: string;
+    nodeUrl: string | string[];
     /**
      * RPC API Keys. Used to authenticate users on RPC Server.
      */

--- a/lib/near.js
+++ b/lib/near.js
@@ -30,7 +30,13 @@ class Near {
         this.config = config;
         this.connection = connection_1.Connection.fromConfig({
             networkId: config.networkId,
-            provider: { type: 'JsonRpcProvider', args: { url: config.nodeUrl, headers: config.headers } },
+            provider: {
+                type: 'JsonRpcProvider', args: {
+                    url: config.nodeUrl,
+                    apiKeys: config.apiKeys,
+                    headers: config.headers,
+                }
+            },
             signer: config.signer || { type: 'InMemorySigner', keyStore: config.keyStore || (config.deps && config.deps.keyStore) }
         });
         if (config.masterAccount) {

--- a/lib/providers/json-rpc-provider.d.ts
+++ b/lib/providers/json-rpc-provider.d.ts
@@ -156,6 +156,11 @@ export declare class JsonRpcProvider extends Provider {
      */
     gasPrice(blockId: BlockId | null): Promise<GasPrice>;
     /**
+     * Part of the RPC failover design.
+     * Changing current (first) rpc server and moves it to the and of the queue.
+     */
+    private rotateRpcServers;
+    /**
      * Directly call the RPC specifying the method and params
      *
      * @param method RPC method

--- a/lib/providers/json-rpc-provider.js
+++ b/lib/providers/json-rpc-provider.js
@@ -302,7 +302,11 @@ class JsonRpcProvider extends provider_1.Provider {
         if (typeof this.connection.url === 'string') {
             return;
         }
-        this.connection.url.push(this.connection.url.shift());
+        const currentRpcServer = this.connection.url.shift();
+        this.connection.url.push(currentRpcServer);
+        if (!process.env['NEAR_NO_LOGS']) {
+            console.warn(`Switched from ${currentRpcServer} RPC Server to ${this.connection.url[0]}`);
+        }
     }
     /**
      * Directly call the RPC specifying the method and params

--- a/lib/providers/json-rpc-provider.js
+++ b/lib/providers/json-rpc-provider.js
@@ -295,6 +295,16 @@ class JsonRpcProvider extends provider_1.Provider {
         return await this.sendJsonRpc('gas_price', [blockId]);
     }
     /**
+     * Part of the RPC failover design.
+     * Changing current (first) rpc server and moves it to the and of the queue.
+     */
+    rotateRpcServers() {
+        if (typeof this.connection.url === 'string') {
+            return;
+        }
+        this.connection.url.push(this.connection.url.shift());
+    }
+    /**
      * Directly call the RPC specifying the method and params
      *
      * @param method RPC method
@@ -337,6 +347,8 @@ class JsonRpcProvider extends provider_1.Provider {
                     if (!process.env['NEAR_NO_LOGS']) {
                         console.warn(`Retrying request to ${method} as it has timed out`, params);
                     }
+                    // switch  to another server if it's available
+                    this.rotateRpcServers();
                     return null;
                 }
                 throw error;

--- a/lib/utils/web.d.ts
+++ b/lib/utils/web.d.ts
@@ -1,5 +1,5 @@
 export interface ConnectionInfo {
-    url: string;
+    url: string | string[];
     apiKeys?: {
         [url: string]: string;
     };

--- a/lib/utils/web.d.ts
+++ b/lib/utils/web.d.ts
@@ -1,5 +1,8 @@
 export interface ConnectionInfo {
     url: string;
+    apiKeys?: {
+        [url: string]: string;
+    };
     user?: string;
     password?: string;
     allowInsecure?: boolean;

--- a/lib/utils/web.js
+++ b/lib/utils/web.js
@@ -24,7 +24,11 @@ async function fetchJson(connectionInfoOrUrl, json) {
             const response = await fetch(connectionInfo.url, {
                 method: json ? 'POST' : 'GET',
                 body: json ? json : undefined,
-                headers: { ...connectionInfo.headers, 'Content-Type': 'application/json' }
+                headers: {
+                    'Content-Type': 'application/json',
+                    'x-api-key': connectionInfo.apiKeys ? connectionInfo.apiKeys[connectionInfo.url] : undefined,
+                    ...connectionInfo.headers,
+                },
             });
             if (!response.ok) {
                 if (response.status === 503) {

--- a/lib/utils/web.js
+++ b/lib/utils/web.js
@@ -19,20 +19,21 @@ async function fetchJson(connectionInfoOrUrl, json) {
     else {
         connectionInfo = connectionInfoOrUrl;
     }
+    const currentRpcServer = typeof connectionInfo.url === 'string' ? connectionInfo.url : connectionInfo.url[0];
     const response = await exponential_backoff_1.default(START_WAIT_TIME_MS, RETRY_NUMBER, BACKOFF_MULTIPLIER, async () => {
         try {
-            const response = await fetch(connectionInfo.url, {
+            const response = await fetch(currentRpcServer, {
                 method: json ? 'POST' : 'GET',
                 body: json ? json : undefined,
                 headers: {
                     'Content-Type': 'application/json',
-                    'x-api-key': connectionInfo.apiKeys ? connectionInfo.apiKeys[connectionInfo.url] : undefined,
+                    'x-api-key': connectionInfo.apiKeys ? connectionInfo.apiKeys[currentRpcServer] : undefined,
                     ...connectionInfo.headers,
                 },
             });
             if (!response.ok) {
                 if (response.status === 503) {
-                    errors_1.logWarning(`Retrying HTTP request for ${connectionInfo.url} as it's not available now`);
+                    errors_1.logWarning(`Retrying HTTP request for ${currentRpcServer} as it's not available now`);
                     return null;
                 }
                 throw http_errors_1.default(response.status, await response.text());
@@ -41,14 +42,14 @@ async function fetchJson(connectionInfoOrUrl, json) {
         }
         catch (error) {
             if (error.toString().includes('FetchError') || error.toString().includes('Failed to fetch')) {
-                errors_1.logWarning(`Retrying HTTP request for ${connectionInfo.url} because of error: ${error}`);
+                errors_1.logWarning(`Retrying HTTP request for ${currentRpcServer} because of error: ${error}`);
                 return null;
             }
             throw error;
         }
     });
     if (!response) {
-        throw new providers_1.TypedError(`Exceeded ${RETRY_NUMBER} attempts for ${connectionInfo.url}.`, 'RetriesExceeded');
+        throw new providers_1.TypedError(`Exceeded ${RETRY_NUMBER} attempts for ${currentRpcServer}.`, 'RetriesExceeded');
     }
     return await response.json();
 }

--- a/src/near.ts
+++ b/src/near.ts
@@ -54,7 +54,10 @@ export interface NearConfig {
      * @see {@link JsonRpcProvider.JsonRpcProvider | JsonRpcProvider}
      */
     nodeUrl: string;
-
+    /**
+     * RPC API Keys. Used to authenticate users on RPC Server.
+     */
+    apiKeys: string;
     /**
      * NEAR RPC API headers. Can be used to pass API KEY and other parameters.
      * @see {@link JsonRpcProvider.JsonRpcProvider | JsonRpcProvider}
@@ -84,7 +87,13 @@ export class Near {
         this.config = config;
         this.connection = Connection.fromConfig({
             networkId: config.networkId,
-            provider: { type: 'JsonRpcProvider', args: { url: config.nodeUrl, headers: config.headers } },
+            provider: {
+                type: 'JsonRpcProvider', args: {
+                    url: config.nodeUrl,
+                    apiKeys: config.apiKeys,
+                    headers: config.headers,
+                }
+            },
             signer: config.signer || { type: 'InMemorySigner', keyStore: config.keyStore || (config.deps && config.deps.keyStore) }
         });
         if (config.masterAccount) {

--- a/src/near.ts
+++ b/src/near.ts
@@ -50,14 +50,17 @@ export interface NearConfig {
     networkId: string;
 
     /**
-     * NEAR RPC API url. used to make JSON RPC calls to interact with NEAR.
+     * NEAR RPC API url. Used to make JSON RPC calls to interact with NEAR.
+     * You can set multiple RPC Server URLs to turn on failover functionality.
      * @see {@link JsonRpcProvider.JsonRpcProvider | JsonRpcProvider}
      */
-    nodeUrl: string;
+    nodeUrl: string | string[];
+
     /**
      * RPC API Keys. Used to authenticate users on RPC Server.
      */
     apiKeys: string;
+
     /**
      * NEAR RPC API headers. Can be used to pass API KEY and other parameters.
      * @see {@link JsonRpcProvider.JsonRpcProvider | JsonRpcProvider}

--- a/src/providers/json-rpc-provider.ts
+++ b/src/providers/json-rpc-provider.ts
@@ -340,6 +340,15 @@ export class JsonRpcProvider extends Provider {
     }
 
     /**
+     * Part of the RPC failover design.
+     * Changing current (first) rpc server and moves it to the and of the queue.
+     */
+    private rotateRpcServers() {
+        if (typeof this.connection.url === 'string') { return; }
+        this.connection.url.push(this.connection.url.shift());
+    }
+
+    /**
      * Directly call the RPC specifying the method and params
      *
      * @param method RPC method
@@ -382,6 +391,8 @@ export class JsonRpcProvider extends Provider {
                     if (!process.env['NEAR_NO_LOGS']) {
                         console.warn(`Retrying request to ${method} as it has timed out`, params);
                     }
+                    // switch  to another server if it's available
+                    this.rotateRpcServers();
                     return null;
                 }
 

--- a/src/providers/json-rpc-provider.ts
+++ b/src/providers/json-rpc-provider.ts
@@ -379,7 +379,7 @@ export class JsonRpcProvider extends Provider {
                 return response;
             } catch (error) {
                 if (error.type === 'TimeoutError') {
-                    if (!process.env['NEAR_NO_LOGS']){
+                    if (!process.env['NEAR_NO_LOGS']) {
                         console.warn(`Retrying request to ${method} as it has timed out`, params);
                     }
                     return null;

--- a/src/providers/json-rpc-provider.ts
+++ b/src/providers/json-rpc-provider.ts
@@ -345,7 +345,11 @@ export class JsonRpcProvider extends Provider {
      */
     private rotateRpcServers() {
         if (typeof this.connection.url === 'string') { return; }
-        this.connection.url.push(this.connection.url.shift());
+        const currentRpcServer = this.connection.url.shift();
+        this.connection.url.push(currentRpcServer);
+        if (!process.env['NEAR_NO_LOGS']) {
+            console.warn(`Switched from ${currentRpcServer} RPC Server to ${this.connection.url[0]}`);
+        }
     }
 
     /**

--- a/src/utils/web.ts
+++ b/src/utils/web.ts
@@ -11,7 +11,7 @@ const RETRY_NUMBER = 10;
 export interface ConnectionInfo {
     // RPC Server URL or the prioritized array of such URLs
     url: string | string[];
-    apiKeys?: { [url: string]: string }
+    apiKeys?: { [url: string]: string };
     user?: string;
     password?: string;
     allowInsecure?: boolean;

--- a/src/utils/web.ts
+++ b/src/utils/web.ts
@@ -10,6 +10,7 @@ const RETRY_NUMBER = 10;
 
 export interface ConnectionInfo {
     url: string;
+    failoverRpcUrls?: string[],
     apiKeys?: { [url: string]: string }
     user?: string;
     password?: string;

--- a/src/utils/web.ts
+++ b/src/utils/web.ts
@@ -10,6 +10,7 @@ const RETRY_NUMBER = 10;
 
 export interface ConnectionInfo {
     url: string;
+    apiKeys?: { [url: string]: string }
     user?: string;
     password?: string;
     allowInsecure?: boolean;
@@ -30,7 +31,11 @@ export async function fetchJson(connectionInfoOrUrl: string | ConnectionInfo, js
             const response = await fetch(connectionInfo.url, {
                 method: json ? 'POST' : 'GET',
                 body: json ? json : undefined,
-                headers: { ...connectionInfo.headers, 'Content-Type': 'application/json' }
+                headers: {
+                    'Content-Type': 'application/json',
+                    'x-api-key': connectionInfo.apiKeys ? connectionInfo.apiKeys[connectionInfo.url] : undefined,
+                    ...connectionInfo.headers,
+                },
             });
             if (!response.ok) {
                 if (response.status === 503) {

--- a/test/providers.test.js
+++ b/test/providers.test.js
@@ -338,9 +338,9 @@ test('near json rpc fetch node status', async () => {
 });
 
 test('JsonRpc rotateRpcServers', async () => {
-    const SERVER_1 = "server1";
-    const SERVER_2 = "server2";
-    const SERVER_3 = "server3";
+    const SERVER_1 = 'server1';
+    const SERVER_2 = 'server2';
+    const SERVER_3 = 'server3';
     const provider = new nearApi.providers.JsonRpcProvider({ url: [SERVER_1, SERVER_2, SERVER_3] });
     expect(provider.connection.url.length).toEqual(3);
     expect(provider.connection.url[0]).toMatch(SERVER_1);

--- a/test/providers.test.js
+++ b/test/providers.test.js
@@ -1,5 +1,5 @@
 const nearApi = require('../src/index');
-const testUtils  = require('./test-utils');
+const testUtils = require('./test-utils');
 const BN = require('bn.js');
 const base58 = require('bs58');
 
@@ -64,7 +64,7 @@ test('json rpc fetch validators info', withProvider(async (provider) => {
     expect(validators.current_validators.length).toBeGreaterThanOrEqual(1);
 }));
 
-test('txStatus with string hash and buffer hash', withProvider(async(provider) => {
+test('txStatus with string hash and buffer hash', withProvider(async (provider) => {
     const near = await testUtils.setUpTestConnection();
     const sender = await testUtils.createAccount(near);
     const receiver = await testUtils.createAccount(near);
@@ -76,7 +76,7 @@ test('txStatus with string hash and buffer hash', withProvider(async(provider) =
     expect(responseWithUint8Array).toMatchObject(outcome);
 }));
 
-test('json rpc query with block_id', withProvider(async(provider) => {
+test('json rpc query with block_id', withProvider(async (provider) => {
     const stat = await provider.status();
     let block_id = stat.sync_info.latest_block_height - 1;
 
@@ -111,7 +111,7 @@ test('json rpc query view_state', withProvider(async (provider) => {
 
     await contract.setValue({ args: { value: 'hello' } });
 
-    return testUtils.waitFor(async() => {
+    return testUtils.waitFor(async () => {
         const response = await provider.query({
             request_type: 'view_state',
             finality: 'final',
@@ -152,7 +152,7 @@ test('json rpc query view_code', withProvider(async (provider) => {
     const account = await testUtils.createAccount(near);
     const contract = await testUtils.deployContract(account, testUtils.generateUniqueString('test'));
 
-    return testUtils.waitFor(async() => {
+    return testUtils.waitFor(async () => {
         const response = await provider.query({
             request_type: 'view_code',
             finality: 'final',
@@ -175,7 +175,7 @@ test('json rpc query call_function', withProvider(async (provider) => {
 
     await contract.setValue({ args: { value: 'hello' } });
 
-    return testUtils.waitFor(async() => {
+    return testUtils.waitFor(async () => {
         const response = await provider.query({
             request_type: 'call_function',
             finality: 'final',
@@ -200,7 +200,7 @@ test('json rpc query call_function', withProvider(async (provider) => {
     });
 }));
 
-test('final tx result', async() => {
+test('final tx result', async () => {
     const result = {
         status: { SuccessValue: 'e30=' },
         transaction: { id: '11111', outcome: { status: { SuccessReceiptId: '11112' }, logs: [], receipt_ids: ['11112'], gas_burnt: 1 } },
@@ -212,7 +212,7 @@ test('final tx result', async() => {
     expect(nearApi.providers.getTransactionLastResult(result)).toEqual({});
 });
 
-test('final tx result with null', async() => {
+test('final tx result with null', async () => {
     const result = {
         status: 'Failure',
         transaction: { id: '11111', outcome: { status: { SuccessReceiptId: '11112' }, logs: [], receipt_ids: ['11112'], gas_burnt: 1 } },
@@ -224,7 +224,7 @@ test('final tx result with null', async() => {
     expect(nearApi.providers.getTransactionLastResult(result)).toEqual(null);
 });
 
-test('json rpc light client proof', async() => {
+test('json rpc light client proof', async () => {
     const near = await testUtils.setUpTestConnection();
     const workingAccount = await testUtils.createAccount(near);
     const executionOutcome = await workingAccount.sendMoney(workingAccount.accountId, new BN(10000));
@@ -335,4 +335,20 @@ test('near json rpc fetch node status', async () => {
     const near = await nearApi.connect(config);
     let response = await near.connection.provider.status();
     expect(response.chain_id).toBeTruthy();
+});
+
+test('JsonRpc rotateRpcServers', async () => {
+    const SERVER_1 = "server1";
+    const SERVER_2 = "server2";
+    const SERVER_3 = "server3";
+    const provider = new nearApi.providers.JsonRpcProvider({ url: [SERVER_1, SERVER_2, SERVER_3] });
+    expect(provider.connection.url.length).toEqual(3);
+    expect(provider.connection.url[0]).toMatch(SERVER_1);
+    expect(provider.connection.url[1]).toMatch(SERVER_2);
+    expect(provider.connection.url[2]).toMatch(SERVER_3);
+    provider.rotateRpcServers();
+    expect(provider.connection.url.length).toEqual(3);
+    expect(provider.connection.url[0]).toMatch(SERVER_2);
+    expect(provider.connection.url[1]).toMatch(SERVER_3);
+    expect(provider.connection.url[2]).toMatch(SERVER_1);
 });


### PR DESCRIPTION
Closing #733
- Added support for multiple API Keys (since we can have multiple RPC Servers)
- Added basic failover functionality

With this design of failover, we will change (rotate) our server when needed and stick to this new server for our next calls. It will help to avoid long responses when first (or more) servers are down.

For now, server rotation is happening only on `Timeout` error.

Also, check this comment: https://github.com/near/near-api-js/issues/733#issuecomment-998869162
