### PR TITLE
fix: improve typings

### DIFF
--- a/lib/near.d.ts
+++ b/lib/near.d.ts
@@ -52,7 +52,7 @@ export interface NearConfig {
      * NEAR RPC API headers. Can be used to pass API KEY and other parameters.
      * @see {@link JsonRpcProvider.JsonRpcProvider | JsonRpcProvider}
      */
-    headers: {
+    headers?: {
         [key: string]: string | number;
     };
     /**

--- a/lib/wallet-account.d.ts
+++ b/lib/wallet-account.d.ts
@@ -52,7 +52,7 @@ export declare class WalletConnection {
     _near: Near;
     /** @hidden */
     _connectedAccount: ConnectedWalletAccount;
-    constructor(near: Near, appKeyPrefix: string | null);
+    constructor(near: Near, appKeyPrefix?: string);
     /**
      * Returns true, if this WalletAccount is authorized with the wallet.
      * @example

--- a/src/near.ts
+++ b/src/near.ts
@@ -59,7 +59,7 @@ export interface NearConfig {
      * NEAR RPC API headers. Can be used to pass API KEY and other parameters.
      * @see {@link JsonRpcProvider.JsonRpcProvider | JsonRpcProvider}
      */
-    headers: { [key: string]: string | number };
+    headers?: { [key: string]: string | number };
 
     /**
      * NEAR wallet url used to redirect users to their wallet in browser applications.

--- a/src/wallet-account.ts
+++ b/src/wallet-account.ts
@@ -79,7 +79,7 @@ export class WalletConnection {
     /** @hidden */
     _connectedAccount: ConnectedWalletAccount;
 
-    constructor(near: Near, appKeyPrefix: string | null) {
+    constructor(near: Near, appKeyPrefix?: string) {
         this._near = near;
         const authDataKey = appKeyPrefix + LOCAL_STORAGE_KEY_SUFFIX;
         const authData = JSON.parse(window.localStorage.getItem(authDataKey));


### PR DESCRIPTION
* The `headers` attribute for `NearConfig` seems to be optional, but is currently typed as required
* The `appKeyPrefix` for `WalletConnection` doesn't even seem to be used, but its type (`string | null`) makes it required; better to get rid of the `| null` and add the `?` instead