### PR TITLE
Account, WalletConnection and ConnectedWalletAccount interfaces

### DIFF
--- a/lib/account.d.ts
+++ b/lib/account.d.ts
@@ -69,13 +69,46 @@ export interface FunctionCallOptions {
 declare function parseJsonFromRawResponse(response: Uint8Array): any;
 declare function bytesJsonStringify(input: any): Buffer;
 /**
+ * Account interface
+ */
+interface IAccount {
+    state(): Promise<AccountView>;
+    findAccessKey(receiverId: string, actions: Action[]): Promise<{
+        publicKey: PublicKey;
+        accessKey: AccessKeyView;
+    }>;
+    createAndDeployContract(contractId: string, publicKey: string | PublicKey, data: Uint8Array, amount: BN): Promise<Account>;
+    sendMoney(receiverId: string, amount: BN): Promise<FinalExecutionOutcome>;
+    createAccount(newAccountId: string, publicKey: string | PublicKey, amount: BN): Promise<FinalExecutionOutcome>;
+    deleteAccount(beneficiaryId: string): any;
+    deployContract(data: Uint8Array): Promise<FinalExecutionOutcome>;
+    functionCall({ contractId, methodName, args, gas, attachedDeposit, walletMeta, walletCallbackUrl, stringify }: FunctionCallOptions): Promise<FinalExecutionOutcome>;
+    addKey(publicKey: string | PublicKey, contractId?: string, methodNames?: string | string[], amount?: BN): Promise<FinalExecutionOutcome>;
+    deleteKey(publicKey: string | PublicKey): Promise<FinalExecutionOutcome>;
+    stake(publicKey: string | PublicKey, amount: BN): Promise<FinalExecutionOutcome>;
+    viewFunction(contractId: string, methodName: string, args: any): Promise<any>;
+    viewState(prefix: string | Uint8Array, blockQuery: {
+        blockId: BlockId;
+    } | {
+        finality: Finality;
+    }): Promise<Array<{
+        key: Buffer;
+        value: Buffer;
+    }>>;
+    getAccessKeys(): Promise<AccessKeyInfoView[]>;
+    getAccountDetails(): Promise<{
+        authorizedApps: AccountAuthorizedApp[];
+    }>;
+    getAccountBalance(): Promise<AccountBalance>;
+}
+/**
  * This class provides common account related RPC calls including signing transactions with a {@link KeyPair}.
  *
  * @example {@link https://docs.near.org/docs/develop/front-end/naj-quick-reference#account}
  * @hint Use {@link WalletConnection} in the browser to redirect to {@link https://docs.near.org/docs/tools/near-wallet | NEAR Wallet} for Account/key management using the {@link BrowserLocalStorageKeyStore}.
  * @see {@link https://nomicon.io/DataStructures/Account.html | Account Spec}
  */
-export declare class Account {
+export declare class Account implements IAccount {
     readonly connection: Connection;
     readonly accountId: string;
     constructor(connection: Connection, accountId: string);

--- a/lib/account.d.ts
+++ b/lib/account.d.ts
@@ -71,22 +71,32 @@ declare function bytesJsonStringify(input: any): Buffer;
 /**
  * Account interface
  */
-interface IAccount {
-    state(): Promise<AccountView>;
+interface IAccount extends AccountActions, AccountInfo {
     findAccessKey(receiverId: string, actions: Action[]): Promise<{
         publicKey: PublicKey;
         accessKey: AccessKeyView;
     }>;
     createAndDeployContract(contractId: string, publicKey: string | PublicKey, data: Uint8Array, amount: BN): Promise<Account>;
-    sendMoney(receiverId: string, amount: BN): Promise<FinalExecutionOutcome>;
+}
+/**
+ * NEAR Actions interface (requires FullAccess or FunctionCall Key to be executed)
+ */
+interface AccountActions {
     createAccount(newAccountId: string, publicKey: string | PublicKey, amount: BN): Promise<FinalExecutionOutcome>;
     deleteAccount(beneficiaryId: string): any;
-    deployContract(data: Uint8Array): Promise<FinalExecutionOutcome>;
-    functionCall({ contractId, methodName, args, gas, attachedDeposit, walletMeta, walletCallbackUrl, stringify }: FunctionCallOptions): Promise<FinalExecutionOutcome>;
     addKey(publicKey: string | PublicKey, contractId?: string, methodNames?: string | string[], amount?: BN): Promise<FinalExecutionOutcome>;
     deleteKey(publicKey: string | PublicKey): Promise<FinalExecutionOutcome>;
+    sendMoney(receiverId: string, amount: BN): Promise<FinalExecutionOutcome>;
     stake(publicKey: string | PublicKey, amount: BN): Promise<FinalExecutionOutcome>;
+    deployContract(data: Uint8Array): Promise<FinalExecutionOutcome>;
+    functionCall({ contractId, methodName, args, gas, attachedDeposit, walletMeta, walletCallbackUrl, stringify }: FunctionCallOptions): Promise<FinalExecutionOutcome>;
+}
+/**
+ * Account information interface
+ */
+interface AccountInfo {
     viewFunction(contractId: string, methodName: string, args: any): Promise<any>;
+    state(): Promise<AccountView>;
     viewState(prefix: string | Uint8Array, blockQuery: {
         blockId: BlockId;
     } | {

--- a/lib/account.d.ts
+++ b/lib/account.d.ts
@@ -72,10 +72,7 @@ declare function bytesJsonStringify(input: any): Buffer;
  * Account interface
  */
 interface IAccount extends AccountActions, AccountInfo {
-    findAccessKey(receiverId: string, actions: Action[]): Promise<{
-        publicKey: PublicKey;
-        accessKey: AccessKeyView;
-    }>;
+    signAndSendTransaction({ receiverId, actions, returnError }: SignAndSendTransactionOptions): Promise<FinalExecutionOutcome>;
     createAndDeployContract(contractId: string, publicKey: string | PublicKey, data: Uint8Array, amount: BN): Promise<Account>;
 }
 /**
@@ -142,7 +139,7 @@ export declare class Account implements IAccount {
      * Sign a transaction to preform a list of actions and broadcast it using the RPC API.
      * @see {@link JsonRpcProvider.sendTransaction}
      */
-    protected signAndSendTransaction({ receiverId, actions, returnError }: SignAndSendTransactionOptions): Promise<FinalExecutionOutcome>;
+    signAndSendTransaction({ receiverId, actions, returnError }: SignAndSendTransactionOptions): Promise<FinalExecutionOutcome>;
     /** @hidden */
     accessKeyByPublicKeyCache: {
         [key: string]: AccessKeyView;
@@ -156,7 +153,7 @@ export declare class Account implements IAccount {
      * @param actions currently unused (see todo)
      * @returns `{ publicKey PublicKey; accessKey: AccessKeyView }`
      */
-    findAccessKey(receiverId: string, actions: Action[]): Promise<{
+    protected findAccessKey(receiverId: string, actions: Action[]): Promise<{
         publicKey: PublicKey;
         accessKey: AccessKeyView;
     }>;

--- a/lib/account.js
+++ b/lib/account.js
@@ -25,17 +25,6 @@ function parseJsonFromRawResponse(response) {
 function bytesJsonStringify(input) {
     return Buffer.from(JSON.stringify(input));
 }
-/*
-* Account class functionality that in not a part of any interface now:
-*   - signAndSendTransaction
-*       - signTransaction()
-*       - printLogsAndFailures()
-*            - printLogs()
-*   - validateArgs(args: any) (used in viewFunction and functionCall, can be copied)
-*
-* Can it be moved somewhere? Can we use this new entity instead of ConnectedWalletAccount?
-* Can Wallet be an implementation of a Signer?
-*/
 /**
  * This class provides common account related RPC calls including signing transactions with a {@link KeyPair}.
  *

--- a/lib/account.js
+++ b/lib/account.js
@@ -25,6 +25,17 @@ function parseJsonFromRawResponse(response) {
 function bytesJsonStringify(input) {
     return Buffer.from(JSON.stringify(input));
 }
+/*
+* Account class functionality that in not a part of any interface now:
+*   - signAndSendTransaction
+*       - signTransaction()
+*       - printLogsAndFailures()
+*            - printLogs()
+*   - validateArgs(args: any) (used in viewFunction and functionCall, can be copied)
+*
+* Can it be moved somewhere? Can we use this new entity instead of ConnectedWalletAccount?
+* Can Wallet be an implementation of a Signer?
+*/
 /**
  * This class provides common account related RPC calls including signing transactions with a {@link KeyPair}.
  *

--- a/lib/account_multisig.d.ts
+++ b/lib/account_multisig.d.ts
@@ -17,7 +17,7 @@ export declare class AccountMultisig extends Account {
     onAddRequestResult: Function;
     constructor(connection: Connection, accountId: string, options: any);
     signAndSendTransactionWithAccount(receiverId: string, actions: Action[]): Promise<FinalExecutionOutcome>;
-    protected signAndSendTransaction({ receiverId, actions }: SignAndSendTransactionOptions): Promise<FinalExecutionOutcome>;
+    signAndSendTransaction({ receiverId, actions }: SignAndSendTransactionOptions): Promise<FinalExecutionOutcome>;
     deleteUnconfirmedRequests(): Promise<void>;
     getRequestIds(): Promise<string>;
     getRequest(): any;
@@ -40,7 +40,7 @@ export declare class Account2FA extends AccountMultisig {
      * Sign a transaction to preform a list of actions and broadcast it using the RPC API.
      * @see {@link JsonRpcProvider.sendTransaction}
      */
-    protected signAndSendTransaction({ receiverId, actions }: SignAndSendTransactionOptions): Promise<FinalExecutionOutcome>;
+    signAndSendTransaction({ receiverId, actions }: SignAndSendTransactionOptions): Promise<FinalExecutionOutcome>;
     deployMultisig(contractBytes: Uint8Array): Promise<FinalExecutionOutcome>;
     disable(contractBytes: Uint8Array): Promise<FinalExecutionOutcome>;
     sendCodeDefault(): Promise<any>;

--- a/lib/wallet-account.d.ts
+++ b/lib/wallet-account.d.ts
@@ -30,6 +30,17 @@ interface RequestSignTransactionsOptions {
     meta?: string;
 }
 /**
+ * WalletConnection interface
+ */
+interface IWalletConnection {
+    isSignedIn(): any;
+    getAccountId(): any;
+    requestSignIn({ contractId, methodNames, successUrl, failureUrl }: SignInOptions): any;
+    requestSignTransactions({ transactions, meta, callbackUrl }: RequestSignTransactionsOptions): Promise<void>;
+    signOut(): any;
+    account(): any;
+}
+/**
  * This class is used in conjunction with the {@link BrowserLocalStorageKeyStore}.
  * It redirects users to {@link https://docs.near.org/docs/tools/near-wallet | NEAR Wallet} for key management.
  *
@@ -44,7 +55,7 @@ interface RequestSignTransactionsOptions {
  * if(!wallet.isSingnedIn()) return wallet.requestSignIn()
  * ```
  */
-export declare class WalletConnection {
+export declare class WalletConnection implements IWalletConnection {
     /** @hidden */
     _walletBaseUrl: string;
     /** @hidden */

--- a/lib/wallet-account.d.ts
+++ b/lib/wallet-account.d.ts
@@ -140,7 +140,7 @@ export declare class ConnectedWalletAccount extends Account {
      * Sign a transaction by redirecting to the NEAR Wallet
      * @see {@link WalletConnection.requestSignTransactions}
      */
-    protected signAndSendTransaction({ receiverId, actions, walletMeta, walletCallbackUrl }: SignAndSendTransactionOptions): Promise<FinalExecutionOutcome>;
+    signAndSendTransaction({ receiverId, actions, walletMeta, walletCallbackUrl }: SignAndSendTransactionOptions): Promise<FinalExecutionOutcome>;
     /**
      * Check if given access key allows the function call or method attempted in transaction
      * @param accessKey Array of {access_key: AccessKey, public_key: PublicKey} items

--- a/src/account.ts
+++ b/src/account.ts
@@ -116,13 +116,35 @@ function bytesJsonStringify(input: any): Buffer {
 }
 
 /**
+ * Account interface
+ */
+interface IAccount {
+    state(): Promise<AccountView>;
+    findAccessKey(receiverId: string, actions: Action[]): Promise<{ publicKey: PublicKey; accessKey: AccessKeyView }>;
+    createAndDeployContract(contractId: string, publicKey: string | PublicKey, data: Uint8Array, amount: BN): Promise<Account>;
+    sendMoney(receiverId: string, amount: BN): Promise<FinalExecutionOutcome>;
+    createAccount(newAccountId: string, publicKey: string | PublicKey, amount: BN): Promise<FinalExecutionOutcome>;
+    deleteAccount(beneficiaryId: string);
+    deployContract(data: Uint8Array): Promise<FinalExecutionOutcome>;
+    functionCall({ contractId, methodName, args, gas, attachedDeposit, walletMeta, walletCallbackUrl, stringify }: FunctionCallOptions): Promise<FinalExecutionOutcome>;
+    addKey(publicKey: string | PublicKey, contractId?: string, methodNames?: string | string[], amount?: BN): Promise<FinalExecutionOutcome>;
+    deleteKey(publicKey: string | PublicKey): Promise<FinalExecutionOutcome>;
+    stake(publicKey: string | PublicKey, amount: BN): Promise<FinalExecutionOutcome>;
+    viewFunction(contractId: string, methodName: string, args: any): Promise<any>;
+    viewState(prefix: string | Uint8Array, blockQuery: { blockId: BlockId } | { finality: Finality }): Promise<Array<{ key: Buffer; value: Buffer }>>;
+    getAccessKeys(): Promise<AccessKeyInfoView[]>;
+    getAccountDetails(): Promise<{ authorizedApps: AccountAuthorizedApp[] }>;
+    getAccountBalance(): Promise<AccountBalance>;
+}
+
+/**
  * This class provides common account related RPC calls including signing transactions with a {@link KeyPair}.
  *
  * @example {@link https://docs.near.org/docs/develop/front-end/naj-quick-reference#account}
  * @hint Use {@link WalletConnection} in the browser to redirect to {@link https://docs.near.org/docs/tools/near-wallet | NEAR Wallet} for Account/key management using the {@link BrowserLocalStorageKeyStore}.
  * @see {@link https://nomicon.io/DataStructures/Account.html | Account Spec}
  */
-export class Account {
+export class Account implements IAccount {
     readonly connection: Connection;
     readonly accountId: string;
 

--- a/src/account.ts
+++ b/src/account.ts
@@ -163,6 +163,18 @@ interface AccountInfo {
     getAccountBalance(): Promise<AccountBalance>;
 }
 
+/*
+* Account class functionality that in not a part of any interface now:
+*   - signAndSendTransaction
+*       - signTransaction()
+*       - printLogsAndFailures()
+*            - printLogs()
+*   - validateArgs(args: any) (used in viewFunction and functionCall, can be copied)
+*
+* Can it be moved somewhere? Can we use this new entity instead of ConnectedWalletAccount?
+* Can Wallet be an implementation of a Signer?
+*/
+
 /**
  * This class provides common account related RPC calls including signing transactions with a {@link KeyPair}.
  *

--- a/src/account_multisig.ts
+++ b/src/account_multisig.ts
@@ -41,7 +41,7 @@ export class AccountMultisig extends Account {
         return super.signAndSendTransaction({ receiverId, actions });
     }
 
-    protected async signAndSendTransaction({ receiverId, actions }: SignAndSendTransactionOptions): Promise<FinalExecutionOutcome> {
+    async signAndSendTransaction({ receiverId, actions }: SignAndSendTransactionOptions): Promise<FinalExecutionOutcome> {
         const { accountId } = this;
 
         const args = Buffer.from(JSON.stringify({
@@ -162,7 +162,7 @@ export class Account2FA extends AccountMultisig {
      * Sign a transaction to preform a list of actions and broadcast it using the RPC API.
      * @see {@link JsonRpcProvider.sendTransaction}
      */
-    protected async signAndSendTransaction({ receiverId, actions }: SignAndSendTransactionOptions): Promise<FinalExecutionOutcome> {
+    async signAndSendTransaction({ receiverId, actions }: SignAndSendTransactionOptions): Promise<FinalExecutionOutcome> {
         await super.signAndSendTransaction({ receiverId, actions });
         // TODO: Should following override onRequestResult in superclass instead of doing custom signAndSendTransaction?
         await this.sendCode();

--- a/src/wallet-account.ts
+++ b/src/wallet-account.ts
@@ -42,6 +42,18 @@ interface RequestSignTransactionsOptions {
 }
 
 /**
+ * WalletConnection interface
+ */
+ interface IWalletConnection {
+    isSignedIn();
+    getAccountId();
+    requestSignIn({ contractId, methodNames, successUrl, failureUrl }: SignInOptions);
+    requestSignTransactions({ transactions, meta, callbackUrl }: RequestSignTransactionsOptions): Promise<void>;
+    signOut();
+    account();
+}
+
+/**
  * This class is used in conjunction with the {@link BrowserLocalStorageKeyStore}.
  * It redirects users to {@link https://docs.near.org/docs/tools/near-wallet | NEAR Wallet} for key management.
  * 
@@ -56,7 +68,7 @@ interface RequestSignTransactionsOptions {
  * if(!wallet.isSingnedIn()) return wallet.requestSignIn()
  * ```
  */
-export class WalletConnection {
+export class WalletConnection implements IWalletConnection {
     /** @hidden */
     _walletBaseUrl: string;
 

--- a/src/wallet-account.ts
+++ b/src/wallet-account.ts
@@ -263,7 +263,7 @@ export class ConnectedWalletAccount extends Account {
      * Sign a transaction by redirecting to the NEAR Wallet
      * @see {@link WalletConnection.requestSignTransactions}
      */
-    protected async signAndSendTransaction({ receiverId, actions, walletMeta, walletCallbackUrl = window.location.href }: SignAndSendTransactionOptions): Promise<FinalExecutionOutcome> {
+    async signAndSendTransaction({ receiverId, actions, walletMeta, walletCallbackUrl = window.location.href }: SignAndSendTransactionOptions): Promise<FinalExecutionOutcome> {
         const localKey = await this.connection.signer.getPublicKey(this.accountId, this.connection.networkId);
         let accessKey = await this.accessKeyForTransaction(receiverId, actions, localKey);
         if (!accessKey) {

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -65,7 +65,7 @@ async function createAccountMultisig(near, options) {
         accountMultisig.getRecoveryMethods = () => ({ data: [] });
         accountMultisig.postSignedJson = async (path) => {
             switch (path) {
-                case '/2fa/getAccessKey': return { publicKey };
+            case '/2fa/getAccessKey': return { publicKey };
             }
         };
         await accountMultisig.deployMultisig(new Uint8Array([...(await fs.readFile(MULTISIG_WASM_PATH))]));


### PR DESCRIPTION
Playing with separation of Account logic. It should help to be more flexible and pass signing to the wallet/walletSelector.  More info in comments.