### PR TITLE
add: returnRawResult option

### DIFF
--- a/lib/contract.d.ts
+++ b/lib/contract.d.ts
@@ -56,5 +56,6 @@ export declare class Contract {
      * @param options NEAR smart contract methods that your application will use. These will be available as `contract.methodName`
      */
     constructor(account: Account, contractId: string, options: ContractMethods);
+    private _changeMethodRaw;
     private _changeMethod;
 }

--- a/lib/contract.js
+++ b/lib/contract.js
@@ -97,7 +97,7 @@ class Contract {
             });
         });
     }
-    async _changeMethod({ args, methodName, gas, amount, meta, callbackUrl }) {
+    async _changeMethod({ args, methodName, gas, amount, meta, callbackUrl, returnRawResult = false }) {
         validateBNLike({ gas, amount });
         const rawResult = await this.account.functionCall({
             contractId: this.contractId,
@@ -108,7 +108,7 @@ class Contract {
             walletMeta: meta,
             walletCallbackUrl: callbackUrl
         });
-        return providers_1.getTransactionLastResult(rawResult);
+        return returnRawResult ? rawResult : providers_1.getTransactionLastResult(rawResult);
     }
 }
 exports.Contract = Contract;

--- a/lib/contract.js
+++ b/lib/contract.js
@@ -87,14 +87,14 @@ class Contract {
                         if (args.length > 1 || !(args[0] && args[0].args)) {
                             const deprecate = depd_1.default('contract.methodName(args, gas, amount)');
                             deprecate('use `contract.methodName({ args, gas?, amount?, callbackUrl?, meta? })` instead');
-                            return this._changeMethod({
-                                methodName,
+                            return this[resultType === '' ? '_changeMethod' : '_changeMethodRaw']({
+                                methodName: baseMethodName,
                                 args: args[0],
                                 gas: args[1],
                                 amount: args[2]
                             });
                         }
-                        return this._changeMethod({ methodName, ...args[0] });
+                        return this[resultType === '' ? '_changeMethod' : '_changeMethodRaw']({ methodName: baseMethodName, ...args[0] });
                     })
                 });
             });

--- a/lib/contract.js
+++ b/lib/contract.js
@@ -74,32 +74,35 @@ class Contract {
                 })
             });
         });
-        changeMethods.forEach((methodName) => {
-            Object.defineProperty(this, methodName, {
-                writable: false,
-                enumerable: true,
-                value: nameFunction(methodName, async (...args) => {
-                    if (args.length && (args.length > 3 || !(isObject(args[0]) || isUint8Array(args[0])))) {
-                        throw new errors_1.PositionalArgsError();
-                    }
-                    if (args.length > 1 || !(args[0] && args[0].args)) {
-                        const deprecate = depd_1.default('contract.methodName(args, gas, amount)');
-                        deprecate('use `contract.methodName({ args, gas?, amount?, callbackUrl?, meta? })` instead');
-                        return this._changeMethod({
-                            methodName,
-                            args: args[0],
-                            gas: args[1],
-                            amount: args[2]
-                        });
-                    }
-                    return this._changeMethod({ methodName, ...args[0] });
-                })
+        changeMethods.forEach((baseMethodName) => {
+            ['', 'Raw'].forEach((resultType) => {
+                const methodName = `${baseMethodName}${resultType}`;
+                Object.defineProperty(this, methodName, {
+                    writable: false,
+                    enumerable: true,
+                    value: nameFunction(methodName, async (...args) => {
+                        if (args.length && (args.length > 3 || !(isObject(args[0]) || isUint8Array(args[0])))) {
+                            throw new errors_1.PositionalArgsError();
+                        }
+                        if (args.length > 1 || !(args[0] && args[0].args)) {
+                            const deprecate = depd_1.default('contract.methodName(args, gas, amount)');
+                            deprecate('use `contract.methodName({ args, gas?, amount?, callbackUrl?, meta? })` instead');
+                            return this._changeMethod({
+                                methodName,
+                                args: args[0],
+                                gas: args[1],
+                                amount: args[2]
+                            });
+                        }
+                        return this._changeMethod({ methodName, ...args[0] });
+                    })
+                });
             });
         });
     }
-    async _changeMethod({ args, methodName, gas, amount, meta, callbackUrl, returnRawResult = false }) {
+    async _changeMethodRaw({ args, methodName, gas, amount, meta, callbackUrl }) {
         validateBNLike({ gas, amount });
-        const rawResult = await this.account.functionCall({
+        const result = await this.account.functionCall({
             contractId: this.contractId,
             methodName,
             args,
@@ -108,7 +111,11 @@ class Contract {
             walletMeta: meta,
             walletCallbackUrl: callbackUrl
         });
-        return returnRawResult ? rawResult : providers_1.getTransactionLastResult(rawResult);
+        return result;
+    }
+    async _changeMethod({ args, methodName, gas, amount, meta, callbackUrl }) {
+        const result = await this._changeMethodRaw({ args, methodName, gas, amount, meta, callbackUrl });
+        return providers_1.getTransactionLastResult(result);
     }
 }
 exports.Contract = Contract;

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -26,6 +26,7 @@ interface ChangeMethodOptions {
     amount?: BN;
     meta?: string;
     callbackUrl?: string;
+    returnRawResult?: boolean;
 }
 
 export interface ContractMethods {
@@ -129,7 +130,7 @@ export class Contract {
         });
     }
 
-    private async _changeMethod({ args, methodName, gas, amount, meta, callbackUrl }: ChangeMethodOptions) {
+    private async _changeMethod({ args, methodName, gas, amount, meta, callbackUrl, returnRawResult = false }: ChangeMethodOptions) {
         validateBNLike({ gas, amount });
 
         const rawResult = await this.account.functionCall({
@@ -142,7 +143,7 @@ export class Contract {
             walletCallbackUrl: callbackUrl
         });
 
-        return getTransactionLastResult(rawResult);
+        return returnRawResult ? rawResult : getTransactionLastResult(rawResult);
     }
 }
 

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -117,15 +117,15 @@ export class Contract {
                         if(args.length > 1 || !(args[0] && args[0].args)) {
                             const deprecate = depd('contract.methodName(args, gas, amount)');
                             deprecate('use `contract.methodName({ args, gas?, amount?, callbackUrl?, meta? })` instead');
-                            return this._changeMethod({
-                                methodName,
+                            return this[resultType === '' ? '_changeMethod' : '_changeMethodRaw']({
+                                methodName: baseMethodName,
                                 args: args[0],
                                 gas: args[1],
                                 amount: args[2]
                             });
                         }
 
-                        return this._changeMethod({ methodName, ...args[0] });
+                        return this[resultType === '' ? '_changeMethod' : '_changeMethodRaw']({ methodName: baseMethodName, ...args[0] });
                     })
                 });
             });

--- a/src/contract.ts
+++ b/src/contract.ts
@@ -150,7 +150,6 @@ export class Contract {
     
     private async _changeMethod({ args, methodName, gas, amount, meta, callbackUrl }: ChangeMethodOptions) {
         const result = await this._changeMethodRaw({ args, methodName, gas, amount, meta, callbackUrl });
-
         return getTransactionLastResult(result);
     }
 


### PR DESCRIPTION
Currently only the SuccessValue is returned from calling contracts with this api...

https://github.com/near/near-api-js/blob/a05667361ddab208423f5a5c0e3dd0ce182b9880/lib/providers/provider.js#L30

This option provides a means to access the full rawResult object.