### PR TITLE
Remove unused line to set appKeyPrefix default

### DIFF
--- a/lib/wallet-account.js
+++ b/lib/wallet-account.js
@@ -43,7 +43,6 @@ class WalletConnection {
         const authData = JSON.parse(window.localStorage.getItem(authDataKey));
         this._networkId = near.config.networkId;
         this._walletBaseUrl = near.config.walletUrl;
-        appKeyPrefix = appKeyPrefix || near.config.contractName || 'default';
         this._keyStore = near.connection.signer.keyStore;
         this._authData = authData || { allKeys: [] };
         this._authDataKey = authDataKey;

--- a/src/wallet-account.ts
+++ b/src/wallet-account.ts
@@ -85,7 +85,6 @@ export class WalletConnection {
         const authData = JSON.parse(window.localStorage.getItem(authDataKey));
         this._networkId = near.config.networkId;
         this._walletBaseUrl = near.config.walletUrl;
-        appKeyPrefix = appKeyPrefix || near.config.contractName || 'default';
         this._keyStore = (near.connection.signer as InMemorySigner).keyStore;
         this._authData = authData || { allKeys: [] };
         this._authDataKey = authDataKey;


### PR DESCRIPTION
Hi NEAR API JS team 👋

I started learning NEAR by reading the code and found a minor issue.

`WalletConnect` or `WalletAccount` function currently takes `appKeyPrefix` as an optional argument.

There is a line to set the default value for `appKeyPrefix`: `appKeyPrefix = appKeyPrefix || near.config.contractName || 'default';`

However, the line is located a few lines after `appKeyPrefix` is actually used: `const authDataKey = appKeyPrefix + LOCAL_STORAGE_KEY_SUFFIX;`

Because of this, when `appKeyPrefix` is not given, `authDataKey` unfortunately looks something like this: `undefined_wallet_auth_key`

The proper fix is to bring the line to set the default value before we set `authDataKey`, however, that change is not backward compatible, so I chose to simply remove the line that sets the default for `appKeyPrefix`. Another option is to check if the `undefined_wallet_auth_key` key exists in local storage, if not set the proper default value but that seems verbose. Happy to discuss.