### PR TITLE
feat: reexport near-units

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -3,3 +3,4 @@ export * as keyStores from './key_stores/index';
 export * from './common-index';
 export * from './connect';
 export * from './constants';
+export { NEAR, Gas, parse as parseUnits } from 'near-units';

--- a/lib/index.js
+++ b/lib/index.js
@@ -27,3 +27,7 @@ exports.keyStores = __importStar(require("./key_stores/index"));
 __exportStar(require("./common-index"), exports);
 __exportStar(require("./connect"), exports);
 __exportStar(require("./constants"), exports);
+var near_units_1 = require("near-units");
+Object.defineProperty(exports, "NEAR", { enumerable: true, get: function () { return near_units_1.NEAR; } });
+Object.defineProperty(exports, "Gas", { enumerable: true, get: function () { return near_units_1.Gas; } });
+Object.defineProperty(exports, "parseUnits", { enumerable: true, get: function () { return near_units_1.parse; } });

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
         "http-errors": "^1.7.2",
         "js-sha256": "^0.9.0",
         "mustache": "^4.0.0",
+        "near-units": "^0.1.9",
         "node-fetch": "^2.6.1",
         "text-encoding-utf-8": "^1.0.2",
         "tweetnacl": "^1.0.1"

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,4 @@ export * as keyStores from './key_stores/index';
 export * from './common-index';
 export * from './connect';
 export * from './constants';
+export {NEAR, Gas, parse as parseUnits} from 'near-units';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4265,6 +4265,13 @@ near-hello@^0.5.1:
   resolved "https://registry.yarnpkg.com/near-hello/-/near-hello-0.5.1.tgz#68621928857afc21f5a7e0c21a47069a5dc058ef"
   integrity sha512-k7S8VFyESWgkKYDso99B4XbxAdo0VX9b3+GAaO5PvMgQjNr/6o09PHRywg/NkBQpf+ZYj7nNpJcyrNJGQsvA3w==
 
+near-units@^0.1.9:
+  version "0.1.9"
+  resolved "https://registry.yarnpkg.com/near-units/-/near-units-0.1.9.tgz#4bf07da0b046e08e0b8785ad8e32d4df3a944b93"
+  integrity sha512-xiuBjpNsi+ywiu7P6iWRZdgFm7iCr/cfWlVO6+e5uaAqH4mE1rrurElyrL91llNDSnMwogd9XmlZOw5KbbHNsA==
+  dependencies:
+    bn.js "^5.2.0"
+
 neo-async@^2.6.0:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"


### PR DESCRIPTION
Now users can import `near-units` to get access to `NEAR` and `Gas` classes, which have a `parse` method to parse strings with units and has a `toHuman` method to convert the units to a human readable string.

e.g.

```ts
NEAR.parse("10.19 N");
Gas.parse("100 Tgas");
```