### PR TITLE
Multiple nodeUrls configuration

### DIFF
--- a/lib/near.d.ts
+++ b/lib/near.d.ts
@@ -49,6 +49,11 @@ export interface NearConfig {
      */
     nodeUrl: string;
     /**
+     * NEAR RPC API urls. Compatibility with existing nodeUrl, multiple URLs for JSON RPC calls.
+     * @see {@link JsonRpcProvider.JsonRpcProvider | JsonRpcProvider}
+     */
+    nodeUrls: string;
+    /**
      * NEAR RPC API headers. Can be used to pass API KEY and other parameters.
      * @see {@link JsonRpcProvider.JsonRpcProvider | JsonRpcProvider}
      */

--- a/lib/near.js
+++ b/lib/near.js
@@ -40,7 +40,7 @@ class Near {
         }
         this.connection = connection_1.Connection.fromConfig({
             networkId: config.networkId,
-            provider: { type: 'JsonRpcProvider', args: { selectUrlIndex: 0, urls: nodeUrls, headers: config.headers } },
+            provider: { type: 'JsonRpcProvider', args: { urls: nodeUrls, headers: config.headers } },
             signer: config.signer || { type: 'InMemorySigner', keyStore: config.keyStore || (config.deps && config.deps.keyStore) }
         });
         if (config.masterAccount) {

--- a/lib/near.js
+++ b/lib/near.js
@@ -28,9 +28,19 @@ const account_creator_1 = require("./account_creator");
 class Near {
     constructor(config) {
         this.config = config;
+        const nodeUrls = [];
+        if (config.nodeUrl) {
+            nodeUrls.push(config.nodeUrl);
+        }
+        if (config.nodeUrls) {
+            nodeUrls.push(...config.nodeUrls);
+        }
+        if (nodeUrls.length === 0) {
+            throw new Error('Need to pass nodeUrl or nodeUrls.');
+        }
         this.connection = connection_1.Connection.fromConfig({
             networkId: config.networkId,
-            provider: { type: 'JsonRpcProvider', args: { url: config.nodeUrl, headers: config.headers } },
+            provider: { type: 'JsonRpcProvider', args: { selectUrlIndex: 0, urls: nodeUrls, headers: config.headers } },
             signer: config.signer || { type: 'InMemorySigner', keyStore: config.keyStore || (config.deps && config.deps.keyStore) }
         });
         if (config.masterAccount) {

--- a/lib/providers/json-rpc-provider.d.ts
+++ b/lib/providers/json-rpc-provider.d.ts
@@ -14,7 +14,7 @@ export declare class JsonRpcProvider extends Provider {
     /**
      * @param connectionInfoOrUrl ConnectionInfo or RPC API endpoint URL (deprecated)
      */
-    constructor(connectionInfoOrUrl?: string | ConnectionInfo);
+    constructor(connectionInfoOrUrls?: string | ConnectionInfo);
     /**
      * Gets the RPC's status
      * @see {@link https://docs.near.org/docs/develop/front-end/rpc#general-validator-status}

--- a/lib/providers/json-rpc-provider.js
+++ b/lib/providers/json-rpc-provider.js
@@ -34,15 +34,15 @@ class JsonRpcProvider extends provider_1.Provider {
     /**
      * @param connectionInfoOrUrl ConnectionInfo or RPC API endpoint URL (deprecated)
      */
-    constructor(connectionInfoOrUrl) {
+    constructor(connectionInfoOrUrls) {
         super();
-        if (connectionInfoOrUrl != null && typeof connectionInfoOrUrl == 'object') {
-            this.connection = connectionInfoOrUrl;
+        if (connectionInfoOrUrls != null && typeof connectionInfoOrUrls == 'object') {
+            this.connection = connectionInfoOrUrls;
         }
         else {
             const deprecate = depd_1.default('JsonRpcProvider(url?: string)');
             deprecate('use `JsonRpcProvider(connectionInfo: ConnectionInfo)` instead');
-            this.connection = { url: connectionInfoOrUrl };
+            this.connection = { selectUrlIndex: 0, urls: [connectionInfoOrUrls] };
         }
     }
     /**

--- a/lib/utils/web.d.ts
+++ b/lib/utils/web.d.ts
@@ -1,5 +1,6 @@
 export interface ConnectionInfo {
-    url: string;
+    selectUrlIndex: number;
+    urls: string[];
     user?: string;
     password?: string;
     allowInsecure?: boolean;

--- a/lib/utils/web.d.ts
+++ b/lib/utils/web.d.ts
@@ -1,5 +1,5 @@
 export interface ConnectionInfo {
-    selectUrlIndex: number;
+    selectUrlIndex?: number;
     urls: string[];
     user?: string;
     password?: string;

--- a/lib/utils/web.js
+++ b/lib/utils/web.js
@@ -24,15 +24,17 @@ async function fetchJson(connectionInfoOrUrl, json) {
     }
     const response = await exponential_backoff_1.default(START_WAIT_TIME_MS, RETRY_NUMBER, BACKOFF_MULTIPLIER, async () => {
         connectionInfo.selectUrlIndex = (connectionInfo.selectUrlIndex + 1) % connectionInfo.urls.length;
+        const currentUrl = connectionInfo.urls[connectionInfo.selectUrlIndex];
+        const nextUrl = connectionInfo.urls[(connectionInfo.selectUrlIndex + 1) % connectionInfo.urls.length];
         try {
-            const response = await fetch(connectionInfo.urls[connectionInfo.selectUrlIndex], {
+            const response = await fetch(currentUrl, {
                 method: json ? 'POST' : 'GET',
                 body: json ? json : undefined,
                 headers: { ...connectionInfo.headers, 'Content-Type': 'application/json' }
             });
             if (!response.ok) {
                 if (response.status === 503) {
-                    errors_1.logWarning(`Retrying HTTP request for ${connectionInfo.urls[connectionInfo.selectUrlIndex]} as it's not available now`);
+                    errors_1.logWarning(`Retrying HTTP request for ${nextUrl} as ${currentUrl} not available now`);
                     return null;
                 }
                 throw http_errors_1.default(response.status, await response.text());
@@ -41,14 +43,14 @@ async function fetchJson(connectionInfoOrUrl, json) {
         }
         catch (error) {
             if (error.toString().includes('FetchError') || error.toString().includes('Failed to fetch')) {
-                errors_1.logWarning(`Retrying HTTP request for ${connectionInfo.urls[connectionInfo.selectUrlIndex]} because of error: ${error}`);
+                errors_1.logWarning(`Retrying HTTP request for ${nextUrl} because of error: ${error}`);
                 return null;
             }
             throw error;
         }
     });
     if (!response) {
-        throw new providers_1.TypedError(`Exceeded ${RETRY_NUMBER} attempts for ${connectionInfo.urls[connectionInfo.selectUrlIndex]}.`, 'RetriesExceeded');
+        throw new providers_1.TypedError(`Exceeded ${RETRY_NUMBER} attempts.`, 'RetriesExceeded');
     }
     return await response.json();
 }

--- a/lib/utils/web.js
+++ b/lib/utils/web.js
@@ -12,23 +12,28 @@ const START_WAIT_TIME_MS = 1000;
 const BACKOFF_MULTIPLIER = 1.5;
 const RETRY_NUMBER = 10;
 async function fetchJson(connectionInfoOrUrl, json) {
-    let connectionInfo = { url: null };
+    let connectionInfo = { selectUrlIndex: 0, urls: [] };
+    let selectUrlIndex = 0;
     if (typeof (connectionInfoOrUrl) === 'string') {
-        connectionInfo.url = connectionInfoOrUrl;
+        connectionInfo.urls = [connectionInfoOrUrl];
     }
     else {
         connectionInfo = connectionInfoOrUrl;
     }
     const response = await exponential_backoff_1.default(START_WAIT_TIME_MS, RETRY_NUMBER, BACKOFF_MULTIPLIER, async () => {
+        if (connectionInfo.selectUrlIndex) {
+            selectUrlIndex = connectionInfo.selectUrlIndex;
+        }
+        connectionInfo.selectUrlIndex = (selectUrlIndex + 1) % connectionInfo.urls.length;
         try {
-            const response = await fetch(connectionInfo.url, {
+            const response = await fetch(connectionInfo.urls[selectUrlIndex], {
                 method: json ? 'POST' : 'GET',
                 body: json ? json : undefined,
                 headers: { ...connectionInfo.headers, 'Content-Type': 'application/json' }
             });
             if (!response.ok) {
                 if (response.status === 503) {
-                    errors_1.logWarning(`Retrying HTTP request for ${connectionInfo.url} as it's not available now`);
+                    errors_1.logWarning(`Retrying HTTP request for ${connectionInfo.urls[selectUrlIndex]} as it's not available now`);
                     return null;
                 }
                 throw http_errors_1.default(response.status, await response.text());
@@ -37,14 +42,14 @@ async function fetchJson(connectionInfoOrUrl, json) {
         }
         catch (error) {
             if (error.toString().includes('FetchError') || error.toString().includes('Failed to fetch')) {
-                errors_1.logWarning(`Retrying HTTP request for ${connectionInfo.url} because of error: ${error}`);
+                errors_1.logWarning(`Retrying HTTP request for ${connectionInfo.urls[selectUrlIndex]} because of error: ${error}`);
                 return null;
             }
             throw error;
         }
     });
     if (!response) {
-        throw new providers_1.TypedError(`Exceeded ${RETRY_NUMBER} attempts for ${connectionInfo.url}.`, 'RetriesExceeded');
+        throw new providers_1.TypedError(`Exceeded ${RETRY_NUMBER} attempts for ${connectionInfo.urls[selectUrlIndex]}.`, 'RetriesExceeded');
     }
     return await response.json();
 }

--- a/lib/utils/web.js
+++ b/lib/utils/web.js
@@ -12,28 +12,27 @@ const START_WAIT_TIME_MS = 1000;
 const BACKOFF_MULTIPLIER = 1.5;
 const RETRY_NUMBER = 10;
 async function fetchJson(connectionInfoOrUrl, json) {
-    let connectionInfo = { selectUrlIndex: 0, urls: [] };
-    let selectUrlIndex = 0;
+    let connectionInfo = { urls: [] };
     if (typeof (connectionInfoOrUrl) === 'string') {
         connectionInfo.urls = [connectionInfoOrUrl];
     }
     else {
         connectionInfo = connectionInfoOrUrl;
     }
+    if (!connectionInfo.selectUrlIndex) {
+        connectionInfo.selectUrlIndex = -1;
+    }
     const response = await exponential_backoff_1.default(START_WAIT_TIME_MS, RETRY_NUMBER, BACKOFF_MULTIPLIER, async () => {
-        if (connectionInfo.selectUrlIndex) {
-            selectUrlIndex = connectionInfo.selectUrlIndex;
-        }
-        connectionInfo.selectUrlIndex = (selectUrlIndex + 1) % connectionInfo.urls.length;
+        connectionInfo.selectUrlIndex = (connectionInfo.selectUrlIndex + 1) % connectionInfo.urls.length;
         try {
-            const response = await fetch(connectionInfo.urls[selectUrlIndex], {
+            const response = await fetch(connectionInfo.urls[connectionInfo.selectUrlIndex], {
                 method: json ? 'POST' : 'GET',
                 body: json ? json : undefined,
                 headers: { ...connectionInfo.headers, 'Content-Type': 'application/json' }
             });
             if (!response.ok) {
                 if (response.status === 503) {
-                    errors_1.logWarning(`Retrying HTTP request for ${connectionInfo.urls[selectUrlIndex]} as it's not available now`);
+                    errors_1.logWarning(`Retrying HTTP request for ${connectionInfo.urls[connectionInfo.selectUrlIndex]} as it's not available now`);
                     return null;
                 }
                 throw http_errors_1.default(response.status, await response.text());
@@ -42,14 +41,14 @@ async function fetchJson(connectionInfoOrUrl, json) {
         }
         catch (error) {
             if (error.toString().includes('FetchError') || error.toString().includes('Failed to fetch')) {
-                errors_1.logWarning(`Retrying HTTP request for ${connectionInfo.urls[selectUrlIndex]} because of error: ${error}`);
+                errors_1.logWarning(`Retrying HTTP request for ${connectionInfo.urls[connectionInfo.selectUrlIndex]} because of error: ${error}`);
                 return null;
             }
             throw error;
         }
     });
     if (!response) {
-        throw new providers_1.TypedError(`Exceeded ${RETRY_NUMBER} attempts for ${connectionInfo.urls[selectUrlIndex]}.`, 'RetriesExceeded');
+        throw new providers_1.TypedError(`Exceeded ${RETRY_NUMBER} attempts for ${connectionInfo.urls[connectionInfo.selectUrlIndex]}.`, 'RetriesExceeded');
     }
     return await response.json();
 }

--- a/src/near.ts
+++ b/src/near.ts
@@ -102,7 +102,7 @@ export class Near {
 
         this.connection = Connection.fromConfig({
             networkId: config.networkId,
-            provider: { type: 'JsonRpcProvider', args: { selectUrlIndex: 0, urls: nodeUrls, headers: config.headers } },
+            provider: { type: 'JsonRpcProvider', args: { urls: nodeUrls, headers: config.headers } },
             signer: config.signer || { type: 'InMemorySigner', keyStore: config.keyStore || (config.deps && config.deps.keyStore) }
         });
         if (config.masterAccount) {

--- a/src/near.ts
+++ b/src/near.ts
@@ -56,6 +56,12 @@ export interface NearConfig {
     nodeUrl: string;
 
     /**
+     * NEAR RPC API urls. Compatibility with existing nodeUrl, multiple URLs for JSON RPC calls.
+     * @see {@link JsonRpcProvider.JsonRpcProvider | JsonRpcProvider}
+     */
+    nodeUrls: string;
+
+    /**
      * NEAR RPC API headers. Can be used to pass API KEY and other parameters.
      * @see {@link JsonRpcProvider.JsonRpcProvider | JsonRpcProvider}
      */
@@ -82,9 +88,21 @@ export class Near {
 
     constructor(config: NearConfig) {
         this.config = config;
+
+        const nodeUrls = [];
+        if(config.nodeUrl) {
+            nodeUrls.push(config.nodeUrl);
+        }
+        if(config.nodeUrls) {
+            nodeUrls.push(...config.nodeUrls);
+        }
+        if(nodeUrls.length === 0) {
+            throw new Error('Need to pass nodeUrl or nodeUrls.');
+        }
+
         this.connection = Connection.fromConfig({
             networkId: config.networkId,
-            provider: { type: 'JsonRpcProvider', args: { url: config.nodeUrl, headers: config.headers } },
+            provider: { type: 'JsonRpcProvider', args: { selectUrlIndex: 0, urls: nodeUrls, headers: config.headers } },
             signer: config.signer || { type: 'InMemorySigner', keyStore: config.keyStore || (config.deps && config.deps.keyStore) }
         });
         if (config.masterAccount) {

--- a/src/providers/json-rpc-provider.ts
+++ b/src/providers/json-rpc-provider.ts
@@ -56,14 +56,14 @@ export class JsonRpcProvider extends Provider {
     /**
      * @param connectionInfoOrUrl ConnectionInfo or RPC API endpoint URL (deprecated)
      */
-    constructor(connectionInfoOrUrl?: string | ConnectionInfo) {
+    constructor(connectionInfoOrUrls?: string | ConnectionInfo) {
         super();
-        if (connectionInfoOrUrl != null && typeof connectionInfoOrUrl == 'object') {
-            this.connection = connectionInfoOrUrl as ConnectionInfo;
+        if (connectionInfoOrUrls != null && typeof connectionInfoOrUrls == 'object') {
+            this.connection = connectionInfoOrUrls as ConnectionInfo;
         } else {
             const deprecate = depd('JsonRpcProvider(url?: string)');
             deprecate('use `JsonRpcProvider(connectionInfo: ConnectionInfo)` instead');
-            this.connection = { url: connectionInfoOrUrl as string };
+            this.connection = { selectUrlIndex: 0, urls: [connectionInfoOrUrls as string] };
         }
     }
 

--- a/src/utils/web.ts
+++ b/src/utils/web.ts
@@ -9,7 +9,7 @@ const BACKOFF_MULTIPLIER = 1.5;
 const RETRY_NUMBER = 10;
 
 export interface ConnectionInfo {
-    selectUrlIndex: number;
+    selectUrlIndex?: number;
     urls: string[];
     user?: string;
     password?: string;
@@ -19,27 +19,26 @@ export interface ConnectionInfo {
 }
 
 export async function fetchJson(connectionInfoOrUrl: string | ConnectionInfo, json?: string): Promise<any> {
-    let connectionInfo: ConnectionInfo = { selectUrlIndex: 0, urls: [] };
-    let selectUrlIndex = 0;
+    let connectionInfo: ConnectionInfo = { urls: [] };
     if (typeof (connectionInfoOrUrl) === 'string') {
         connectionInfo.urls = [connectionInfoOrUrl];
     } else {
         connectionInfo = connectionInfoOrUrl as ConnectionInfo;
     }
+    if(!connectionInfo.selectUrlIndex) {
+        connectionInfo.selectUrlIndex = -1;
+    }
     const response = await exponentialBackoff(START_WAIT_TIME_MS, RETRY_NUMBER, BACKOFF_MULTIPLIER, async () => {
-        if(connectionInfo.selectUrlIndex) {
-            selectUrlIndex = connectionInfo.selectUrlIndex;
-        }
-        connectionInfo.selectUrlIndex = (selectUrlIndex + 1) % connectionInfo.urls.length;
+        connectionInfo.selectUrlIndex = (connectionInfo.selectUrlIndex + 1) % connectionInfo.urls.length;
         try {
-            const response = await fetch(connectionInfo.urls[selectUrlIndex], {
+            const response = await fetch(connectionInfo.urls[connectionInfo.selectUrlIndex], {
                 method: json ? 'POST' : 'GET',
                 body: json ? json : undefined,
                 headers: { ...connectionInfo.headers, 'Content-Type': 'application/json' }
             });
             if (!response.ok) {
                 if (response.status === 503) {
-                    logWarning(`Retrying HTTP request for ${connectionInfo.urls[selectUrlIndex]} as it's not available now`);
+                    logWarning(`Retrying HTTP request for ${connectionInfo.urls[connectionInfo.selectUrlIndex]} as it's not available now`);
                     return null;
                 }
                 throw createError(response.status, await response.text());
@@ -47,14 +46,14 @@ export async function fetchJson(connectionInfoOrUrl: string | ConnectionInfo, js
             return response;
         } catch (error) {
             if (error.toString().includes('FetchError') || error.toString().includes('Failed to fetch')) {
-                logWarning(`Retrying HTTP request for ${connectionInfo.urls[selectUrlIndex]} because of error: ${error}`);
+                logWarning(`Retrying HTTP request for ${connectionInfo.urls[connectionInfo.selectUrlIndex]} because of error: ${error}`);
                 return null;
             }
             throw error;
         }
     });
     if (!response) {
-        throw new TypedError(`Exceeded ${RETRY_NUMBER} attempts for ${connectionInfo.urls[selectUrlIndex]}.`, 'RetriesExceeded');
+        throw new TypedError(`Exceeded ${RETRY_NUMBER} attempts for ${connectionInfo.urls[connectionInfo.selectUrlIndex]}.`, 'RetriesExceeded');
     }
     return await response.json();
 }

--- a/test/providers.test.js
+++ b/test/providers.test.js
@@ -1,5 +1,5 @@
 const nearApi = require('../src/index');
-const testUtils  = require('./test-utils');
+const testUtils = require('./test-utils');
 const BN = require('bn.js');
 const base58 = require('bs58');
 
@@ -64,7 +64,7 @@ test('json rpc fetch validators info', withProvider(async (provider) => {
     expect(validators.current_validators.length).toBeGreaterThanOrEqual(1);
 }));
 
-test('txStatus with string hash and buffer hash', withProvider(async(provider) => {
+test('txStatus with string hash and buffer hash', withProvider(async (provider) => {
     const near = await testUtils.setUpTestConnection();
     const sender = await testUtils.createAccount(near);
     const receiver = await testUtils.createAccount(near);
@@ -76,7 +76,7 @@ test('txStatus with string hash and buffer hash', withProvider(async(provider) =
     expect(responseWithUint8Array).toMatchObject(outcome);
 }));
 
-test('json rpc query with block_id', withProvider(async(provider) => {
+test('json rpc query with block_id', withProvider(async (provider) => {
     const stat = await provider.status();
     let block_id = stat.sync_info.latest_block_height - 1;
 
@@ -111,7 +111,7 @@ test('json rpc query view_state', withProvider(async (provider) => {
 
     await contract.setValue({ args: { value: 'hello' } });
 
-    return testUtils.waitFor(async() => {
+    return testUtils.waitFor(async () => {
         const response = await provider.query({
             request_type: 'view_state',
             finality: 'final',
@@ -152,7 +152,7 @@ test('json rpc query view_code', withProvider(async (provider) => {
     const account = await testUtils.createAccount(near);
     const contract = await testUtils.deployContract(account, testUtils.generateUniqueString('test'));
 
-    return testUtils.waitFor(async() => {
+    return testUtils.waitFor(async () => {
         const response = await provider.query({
             request_type: 'view_code',
             finality: 'final',
@@ -175,7 +175,7 @@ test('json rpc query call_function', withProvider(async (provider) => {
 
     await contract.setValue({ args: { value: 'hello' } });
 
-    return testUtils.waitFor(async() => {
+    return testUtils.waitFor(async () => {
         const response = await provider.query({
             request_type: 'call_function',
             finality: 'final',
@@ -200,7 +200,7 @@ test('json rpc query call_function', withProvider(async (provider) => {
     });
 }));
 
-test('final tx result', async() => {
+test('final tx result', async () => {
     const result = {
         status: { SuccessValue: 'e30=' },
         transaction: { id: '11111', outcome: { status: { SuccessReceiptId: '11112' }, logs: [], receipt_ids: ['11112'], gas_burnt: 1 } },
@@ -212,7 +212,7 @@ test('final tx result', async() => {
     expect(nearApi.providers.getTransactionLastResult(result)).toEqual({});
 });
 
-test('final tx result with null', async() => {
+test('final tx result with null', async () => {
     const result = {
         status: 'Failure',
         transaction: { id: '11111', outcome: { status: { SuccessReceiptId: '11112' }, logs: [], receipt_ids: ['11112'], gas_burnt: 1 } },
@@ -224,7 +224,7 @@ test('final tx result with null', async() => {
     expect(nearApi.providers.getTransactionLastResult(result)).toEqual(null);
 });
 
-test('json rpc light client proof', async() => {
+test('json rpc light client proof', async () => {
     const near = await testUtils.setUpTestConnection();
     const workingAccount = await testUtils.createAccount(near);
     const executionOutcome = await workingAccount.sendMoney(workingAccount.accountId, new BN(10000));
@@ -322,12 +322,12 @@ test('json rpc gas price', withProvider(async (provider) => {
 
 test('JsonRpc connection object exist without url provided', async () => {
     const provider = new nearApi.providers.JsonRpcProvider();
-    expect(provider.connection).toStrictEqual({ url: undefined });
+    expect(provider.connection).toStrictEqual({ selectUrlIndex: 0, urls: [undefined] });
 });
 
 test('JsonRpc connection url is not null on empty string', async () => {
     const provider = new nearApi.providers.JsonRpcProvider('');
-    expect(provider.connection).toStrictEqual({ url: '' });
+    expect(provider.connection).toStrictEqual({ selectUrlIndex: 0, urls: [''] });
 });
 
 test('near json rpc fetch node status', async () => {

--- a/test/utils/web.test.js
+++ b/test/utils/web.test.js
@@ -14,7 +14,7 @@ describe('web', () => {
         expect(result.result.chain_id).toBe('testnet');
     });
     test('object parameter in fetchJson', async () => {
-        const connection = { urls: ['https://rpc.testnet.near.org'], selectUrlIndex: 0 };
+        const connection = { urls: ['https://rpc.testnet.near.org'] };
         const statusRequest = {
             'jsonrpc': '2.0',
             'id': 'dontcare',

--- a/test/utils/web.test.js
+++ b/test/utils/web.test.js
@@ -14,7 +14,7 @@ describe('web', () => {
         expect(result.result.chain_id).toBe('testnet');
     });
     test('object parameter in fetchJson', async () => {
-        const connection = { url: 'https://rpc.testnet.near.org' };
+        const connection = { urls: ['https://rpc.testnet.near.org'], selectUrlIndex: 0 };
         const statusRequest = {
             'jsonrpc': '2.0',
             'id': 'dontcare',


### PR DESCRIPTION
Multiple nodeUrls configuration #733 
- Support multiple `nodeUrls` & compatible with `nodeUrl`
- Failover node when `fetchJson` error

Based on the retry mechanism, the program only needs to switch the next node when fetch error. The user had configured `n` nodes. When the `kth` node fetch error, failover to `( k + 1 ) % n` nodes.

Same as #769. Recreate a new pr. @TrevorJTClarke 