### PR TITLE
fix: make PR stale after 14 days of no activity

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/stale@v3
         with:
-          stale-pr-message: 'This PR is stale because it has been open for 7 days with no activity. Remove stale label or comment or this will be closed in another 7 days.'
-          days-before-pr-stale: 7
+          stale-pr-message: 'This PR is stale because it has been open for 14 days with no activity. Remove stale label or comment or this will be closed in another 7 days.'
+          days-before-pr-stale: 14
           days-before-pr-close: 7
 


### PR DESCRIPTION
Many contributors have noted that 7 days of no activity is too short for marking a PR as stale.  

See 
#792 
#793 
#788
#800 
#801 

I know that @volovyk-s is doing his best to keep up with the demands of making things compatible with the new Dev Console and other "frontier" tools, but it is sad that community contributions are languishing.
