### PR TITLE
Add secp256k1 support

### DIFF
--- a/lib/signer.d.ts
+++ b/lib/signer.d.ts
@@ -1,4 +1,4 @@
-import { Signature, KeyPair, PublicKey } from './utils/key_pair';
+import { Signature, KeyType, KeyPair, PublicKey } from './utils/key_pair';
 import { KeyStore } from './key_stores/keystore';
 /**
  * General signing interface, can be used for in memory signing, RPC singing, external wallet, HSM, etc.
@@ -7,7 +7,7 @@ export declare abstract class Signer {
     /**
      * Creates new key and returns public key.
      */
-    abstract createKey(accountId: string, networkId?: string): Promise<PublicKey>;
+    abstract createKey(accountId: string, networkId?: string, keyType?: KeyType): Promise<PublicKey>;
     /**
      * Returns public key for given account / network.
      * @param accountId accountId to retrieve from.
@@ -44,7 +44,7 @@ export declare class InMemorySigner extends Signer {
      * @param networkId The targeted network. (ex. default, betanet, etc…)
      * @returns {Promise<PublicKey>}
      */
-    createKey(accountId: string, networkId: string): Promise<PublicKey>;
+    createKey(accountId: string, networkId: string, keyType?: KeyType): Promise<PublicKey>;
     /**
      * Gets the existing public key for a given account
      * @param accountId The NEAR account to assign a public key to

--- a/lib/signer.js
+++ b/lib/signer.js
@@ -41,8 +41,8 @@ class InMemorySigner extends Signer {
      * @param networkId The targeted network. (ex. default, betanet, etc…)
      * @returns {Promise<PublicKey>}
      */
-    async createKey(accountId, networkId) {
-        const keyPair = key_pair_1.KeyPair.fromRandom('ed25519');
+    async createKey(accountId, networkId, keyType) {
+        const keyPair = keyType === key_pair_1.KeyType.SECP256K1 ? key_pair_1.KeyPair.fromRandom('secp256k1') : key_pair_1.KeyPair.fromRandom('ed25519');
         await this.keyStore.setKey(networkId, accountId, keyPair);
         return keyPair.getPublicKey();
     }

--- a/lib/transaction.d.ts
+++ b/lib/transaction.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="node" />
 import BN from 'bn.js';
 import { Enum, Assignable } from './utils/enums';
+import { BinaryReader, BinaryWriter } from 'borsh';
 import { KeyType, PublicKey } from './utils/key_pair';
 import { Signer } from './signer';
 export declare class FunctionCallPermission extends Assignable {
@@ -72,6 +73,8 @@ export declare function deleteAccount(beneficiaryId: string): Action;
 export declare class Signature extends Assignable {
     keyType: KeyType;
     data: Uint8Array;
+    static borshDeserialize(reader: BinaryReader): Signature;
+    borshSerialize(writer: BinaryWriter): void;
 }
 export declare class Transaction extends Assignable {
     signerId: string;

--- a/lib/transaction.js
+++ b/lib/transaction.js
@@ -104,6 +104,24 @@ function deleteAccount(beneficiaryId) {
 }
 exports.deleteAccount = deleteAccount;
 class Signature extends enums_1.Assignable {
+    static borshDeserialize(reader) {
+        const keyType = reader.readU8();
+        let data;
+        switch (keyType) {
+            case key_pair_1.KeyType.ED25519:
+                data = reader.readFixedArray(64);
+                break;
+            case key_pair_1.KeyType.SECP256K1:
+                data = reader.readFixedArray(65);
+                break;
+            default: throw new Error(`Unknown key type ${keyType}`);
+        }
+        return new Signature({ keyType, data });
+    }
+    borshSerialize(writer) {
+        writer.writeU8(this.keyType);
+        writer.writeFixedArray(this.data);
+    }
 }
 exports.Signature = Signature;
 class Transaction extends enums_1.Assignable {
@@ -132,10 +150,7 @@ class Action extends enums_1.Enum {
 }
 exports.Action = Action;
 exports.SCHEMA = new Map([
-    [Signature, { kind: 'struct', fields: [
-                ['keyType', 'u8'],
-                ['data', [64]]
-            ] }],
+    [Signature, { kind: 'function' }],
     [SignedTransaction, { kind: 'struct', fields: [
                 ['transaction', Transaction],
                 ['signature', Signature]
@@ -148,10 +163,7 @@ exports.SCHEMA = new Map([
                 ['blockHash', [32]],
                 ['actions', [Action]]
             ] }],
-    [key_pair_1.PublicKey, { kind: 'struct', fields: [
-                ['keyType', 'u8'],
-                ['data', [32]]
-            ] }],
+    [key_pair_1.PublicKey, { kind: 'function' }],
     [AccessKey, { kind: 'struct', fields: [
                 ['nonce', 'u64'],
                 ['permission', AccessKeyPermission],

--- a/lib/utils/key_pair.d.ts
+++ b/lib/utils/key_pair.d.ts
@@ -1,4 +1,5 @@
 import { Assignable } from './enums';
+import { BinaryReader, BinaryWriter } from 'borsh';
 export declare type Arrayish = string | ArrayLike<number>;
 export interface Signature {
     signature: Uint8Array;
@@ -6,7 +7,8 @@ export interface Signature {
 }
 /** All supported key types */
 export declare enum KeyType {
-    ED25519 = 0
+    ED25519 = 0,
+    SECP256K1 = 1
 }
 /**
  * PublicKey representation that has type and bytes of the key.
@@ -18,6 +20,8 @@ export declare class PublicKey extends Assignable {
     static fromString(encodedKey: string): PublicKey;
     toString(): string;
     verify(message: Uint8Array, signature: Uint8Array): boolean;
+    static borshDeserialize(reader: BinaryReader): PublicKey;
+    borshSerialize(writer: BinaryWriter): void;
 }
 export declare abstract class KeyPair {
     abstract sign(message: Uint8Array): Signature;
@@ -55,6 +59,41 @@ export declare class KeyPairEd25519 extends KeyPair {
      * // returns [SECRET_KEY]
      */
     static fromRandom(): KeyPairEd25519;
+    sign(message: Uint8Array): Signature;
+    verify(message: Uint8Array, signature: Uint8Array): boolean;
+    toString(): string;
+    getPublicKey(): PublicKey;
+}
+/**
+ * This class provides key pair functionality for secp256k1 curve:
+ * generating key pairs, encoding key pairs, signing and verifying.
+ * nearcore expects secp256k1 public keys to be 64 bytes at all times,
+ * even when string encoded the secp256k1 library returns 65 byte keys
+ * (including a 1 byte header that indicates how the pubkey was encoded).
+ * We'll force the secp256k1 library to always encode uncompressed
+ * keys with the corresponding 0x04 header byte, then manually
+ * insert/remove that byte as needed.
+ */
+export declare class KeyPairSecp256k1 extends KeyPair {
+    readonly publicKey: PublicKey;
+    readonly secretKey: string;
+    /**
+     * Construct an instance of key pair given a secret key.
+     * It's generally assumed that these are encoded in base58.
+     * @param {string} secretKey
+     */
+    constructor(secretKey: string);
+    /**
+     * Generate a new random keypair.
+     * @example
+     * const keyRandom = KeyPair.fromRandom();
+     * keyRandom.publicKey
+     * // returns [PUBLIC_KEY]
+     *
+     * keyRandom.secretKey
+     * // returns [SECRET_KEY]
+     */
+    static fromRandom(): KeyPairSecp256k1;
     sign(message: Uint8Array): Signature;
     verify(message: Uint8Array, signature: Uint8Array): boolean;
     toString(): string;

--- a/lib/utils/key_pair.js
+++ b/lib/utils/key_pair.js
@@ -3,24 +3,29 @@ var __importDefault = (this && this.__importDefault) || function (mod) {
     return (mod && mod.__esModule) ? mod : { "default": mod };
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.KeyPairEd25519 = exports.KeyPair = exports.PublicKey = exports.KeyType = void 0;
+exports.KeyPairSecp256k1 = exports.KeyPairEd25519 = exports.KeyPair = exports.PublicKey = exports.KeyType = void 0;
 const tweetnacl_1 = __importDefault(require("tweetnacl"));
 const serialize_1 = require("./serialize");
 const enums_1 = require("./enums");
+const crypto_1 = require("crypto");
+const secp256k1_1 = __importDefault(require("secp256k1"));
 /** All supported key types */
 var KeyType;
 (function (KeyType) {
     KeyType[KeyType["ED25519"] = 0] = "ED25519";
+    KeyType[KeyType["SECP256K1"] = 1] = "SECP256K1";
 })(KeyType = exports.KeyType || (exports.KeyType = {}));
 function key_type_to_str(keyType) {
     switch (keyType) {
         case KeyType.ED25519: return 'ed25519';
+        case KeyType.SECP256K1: return 'secp256k1';
         default: throw new Error(`Unknown key type ${keyType}`);
     }
 }
 function str_to_key_type(keyType) {
     switch (keyType.toLowerCase()) {
         case 'ed25519': return KeyType.ED25519;
+        case 'secp256k1': return KeyType.SECP256K1;
         default: throw new Error(`Unknown key type ${keyType}`);
     }
 }
@@ -52,8 +57,30 @@ class PublicKey extends enums_1.Assignable {
     verify(message, signature) {
         switch (this.keyType) {
             case KeyType.ED25519: return tweetnacl_1.default.sign.detached.verify(message, signature, this.data);
+            // we don't need the recovery id to verify secp25k61 signatures locally, so drop  it here
+            // also inject the 0x04 header back into the pubkey before trying to interact with it in
+            // the secp256k1 library
+            case KeyType.SECP256K1: return secp256k1_1.default.ecdsaVerify(signature.subarray(0, 64), message, new Uint8Array([0x04, ...this.data]));
             default: throw new Error(`Unknown key type ${this.keyType}`);
         }
+    }
+    static borshDeserialize(reader) {
+        const keyType = reader.readU8();
+        let data;
+        switch (keyType) {
+            case KeyType.ED25519:
+                data = reader.readFixedArray(32);
+                break;
+            case KeyType.SECP256K1:
+                data = reader.readFixedArray(64);
+                break;
+            default: throw new Error(`Unknown key type ${keyType}`);
+        }
+        return new PublicKey({ keyType, data });
+    }
+    borshSerialize(writer) {
+        writer.writeU8(this.keyType);
+        writer.writeFixedArray(this.data);
     }
 }
 exports.PublicKey = PublicKey;
@@ -65,17 +92,20 @@ class KeyPair {
     static fromRandom(curve) {
         switch (curve.toUpperCase()) {
             case 'ED25519': return KeyPairEd25519.fromRandom();
+            case 'SECP256K1': return KeyPairSecp256k1.fromRandom();
             default: throw new Error(`Unknown curve ${curve}`);
         }
     }
     static fromString(encodedKey) {
         const parts = encodedKey.split(':');
+        //TODO: clarify what we must do here
         if (parts.length === 1) {
             return new KeyPairEd25519(parts[0]);
         }
         else if (parts.length === 2) {
             switch (parts[0].toUpperCase()) {
                 case 'ED25519': return new KeyPairEd25519(parts[1]);
+                case 'SECP256K1': return new KeyPairSecp256k1(parts[1]);
                 default: throw new Error(`Unknown curve: ${parts[0]}`);
             }
         }
@@ -130,3 +160,60 @@ class KeyPairEd25519 extends KeyPair {
     }
 }
 exports.KeyPairEd25519 = KeyPairEd25519;
+/**
+ * This class provides key pair functionality for secp256k1 curve:
+ * generating key pairs, encoding key pairs, signing and verifying.
+ * nearcore expects secp256k1 public keys to be 64 bytes at all times,
+ * even when string encoded the secp256k1 library returns 65 byte keys
+ * (including a 1 byte header that indicates how the pubkey was encoded).
+ * We'll force the secp256k1 library to always encode uncompressed
+ * keys with the corresponding 0x04 header byte, then manually
+ * insert/remove that byte as needed.
+ */
+class KeyPairSecp256k1 extends KeyPair {
+    /**
+     * Construct an instance of key pair given a secret key.
+     * It's generally assumed that these are encoded in base58.
+     * @param {string} secretKey
+     */
+    constructor(secretKey) {
+        super();
+        const withHeader = secp256k1_1.default.publicKeyCreate(serialize_1.base_decode(secretKey), false);
+        const data = withHeader.subarray(1, withHeader.length); // remove the 0x04 header byte
+        this.publicKey = new PublicKey({
+            keyType: KeyType.SECP256K1,
+            data
+        });
+        this.secretKey = secretKey;
+    }
+    /**
+     * Generate a new random keypair.
+     * @example
+     * const keyRandom = KeyPair.fromRandom();
+     * keyRandom.publicKey
+     * // returns [PUBLIC_KEY]
+     *
+     * keyRandom.secretKey
+     * // returns [SECRET_KEY]
+     */
+    static fromRandom() {
+        // TODO: find better way to generate PK
+        const secretKey = crypto_1.randomBytes(32);
+        return new KeyPairSecp256k1(serialize_1.base_encode(secretKey));
+    }
+    sign(message) {
+        // nearcore expects 65 byte signatures formed by appending the recovery id to the 64 byte signature
+        const { signature, recid } = secp256k1_1.default.ecdsaSign(message, serialize_1.base_decode(this.secretKey));
+        return { signature: new Uint8Array([...signature, recid]), publicKey: this.publicKey };
+    }
+    verify(message, signature) {
+        return this.publicKey.verify(message, signature);
+    }
+    toString() {
+        return `secp256k1:${this.secretKey}`;
+    }
+    getPublicKey() {
+        return this.publicKey;
+    }
+}
+exports.KeyPairSecp256k1 = KeyPairSecp256k1;

--- a/lib/wallet-account.d.ts
+++ b/lib/wallet-account.d.ts
@@ -85,7 +85,7 @@ export declare class WalletConnection {
      * wallet.requestSignIn({ contractId: 'account-with-deploy-contract.near' });
      * ```
      */
-    requestSignIn(contractIdOrOptions?: string | SignInOptions, title?: string, successUrl?: string, failureUrl?: string): Promise<void>;
+    requestSignIn(contractIdOrOptions?: string | SignInOptions, title?: string, successUrl?: string, failureUrl?: string, keyType?: 'ed25519' | 'secp256k1'): Promise<void>;
     /**
      * Requests the user to quickly sign for a transaction or batch of transactions by redirecting to the NEAR wallet.
      */

--- a/lib/wallet-account.js
+++ b/lib/wallet-account.js
@@ -87,7 +87,7 @@ class WalletConnection {
      * wallet.requestSignIn({ contractId: 'account-with-deploy-contract.near' });
      * ```
      */
-    async requestSignIn(contractIdOrOptions = {}, title, successUrl, failureUrl) {
+    async requestSignIn(contractIdOrOptions = {}, title, successUrl, failureUrl, keyType = 'ed25519') {
         let options;
         if (typeof contractIdOrOptions === 'string') {
             const deprecate = depd_1.default('requestSignIn(contractId, title)');
@@ -106,7 +106,7 @@ class WalletConnection {
             const contractAccount = await this._near.account(options.contractId);
             await contractAccount.state();
             newUrl.searchParams.set('contract_id', options.contractId);
-            const accessKey = utils_1.KeyPair.fromRandom('ed25519');
+            const accessKey = utils_1.KeyPair.fromRandom(keyType);
             newUrl.searchParams.set('public_key', accessKey.getPublicKey().toString());
             await this._keyStore.setKey(this._networkId, PENDING_ACCESS_KEY_PREFIX + accessKey.getPublicKey(), accessKey);
         }

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
         "files": [
             {
                 "path": "dist/near-api-js.min.js",
-                "maxSize": "105kB"
+                "maxSize": "250kB"
             }
         ]
     },

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
         "js-sha256": "^0.9.0",
         "mustache": "^4.0.0",
         "node-fetch": "^2.6.1",
+        "secp256k1": "^4.0.3",
         "text-encoding-utf-8": "^1.0.2",
         "tweetnacl": "^1.0.1"
     },

--- a/src/signer.ts
+++ b/src/signer.ts
@@ -1,5 +1,5 @@
 import sha256 from 'js-sha256';
-import { Signature, KeyPair, PublicKey } from './utils/key_pair';
+import { Signature, KeyType, KeyPair, PublicKey } from './utils/key_pair';
 import { KeyStore } from './key_stores/keystore';
 import { InMemoryKeyStore } from './key_stores/in_memory_key_store';
 
@@ -11,7 +11,7 @@ export abstract class Signer {
     /**
      * Creates new key and returns public key.
      */
-    abstract async createKey(accountId: string, networkId?: string): Promise<PublicKey>;
+    abstract async createKey(accountId: string, networkId?: string, keyType?: KeyType): Promise<PublicKey>;
 
     /**
      * Returns public key for given account / network.
@@ -61,8 +61,8 @@ export class InMemorySigner extends Signer {
      * @param networkId The targeted network. (ex. default, betanet, etc…)
      * @returns {Promise<PublicKey>}
      */
-    async createKey(accountId: string, networkId: string): Promise<PublicKey> {
-        const keyPair = KeyPair.fromRandom('ed25519');
+    async createKey(accountId: string, networkId: string, keyType?: KeyType): Promise<PublicKey> {
+        const keyPair = keyType === KeyType.SECP256K1 ? KeyPair.fromRandom('secp256k1') : KeyPair.fromRandom('ed25519');
         await this.keyStore.setKey(networkId, accountId, keyPair);
         return keyPair.getPublicKey();
     }

--- a/src/transaction.ts
+++ b/src/transaction.ts
@@ -2,7 +2,7 @@ import sha256 from 'js-sha256';
 import BN from 'bn.js';
 
 import { Enum, Assignable } from './utils/enums';
-import { serialize, deserialize } from 'borsh';
+import { serialize, deserialize, BinaryReader, BinaryWriter } from 'borsh';
 import { KeyType, PublicKey } from './utils/key_pair';
 import { Signer } from './signer';
 
@@ -94,6 +94,26 @@ export function deleteAccount(beneficiaryId: string): Action {
 export class Signature extends Assignable {
     keyType: KeyType;
     data: Uint8Array;
+    
+    static borshDeserialize(reader: BinaryReader) {
+        const keyType = reader.readU8();
+        let data: Uint8Array
+        switch (keyType) {
+            case KeyType.ED25519: 
+            data = reader.readFixedArray(64)
+            break
+            case KeyType.SECP256K1: 
+            data = reader.readFixedArray(65)
+            break
+            default: throw new Error(`Unknown key type ${keyType}`);
+        }
+        return new Signature({keyType, data})
+     }
+    
+    borshSerialize(writer: BinaryWriter) {
+        writer.writeU8(this.keyType);
+        writer.writeFixedArray(this.data)
+    }
 }
 
 export class Transaction extends Assignable {
@@ -142,10 +162,7 @@ export class Action extends Enum {
 }
 
 export const SCHEMA = new Map<Function, any>([
-    [Signature, {kind: 'struct', fields: [
-        ['keyType', 'u8'],
-        ['data', [64]]
-    ]}],
+    [Signature, {kind: 'function'}],
     [SignedTransaction, {kind: 'struct', fields: [
         ['transaction', Transaction],
         ['signature', Signature]
@@ -158,10 +175,7 @@ export const SCHEMA = new Map<Function, any>([
         ['blockHash', [32]],
         ['actions', [Action]]
     ]}],
-    [PublicKey, { kind: 'struct', fields: [
-        ['keyType', 'u8'],
-        ['data', [32]]
-    ]}],
+    [PublicKey, { kind: 'function'}],
     [AccessKey, { kind: 'struct', fields: [
         ['nonce', 'u64'],
         ['permission', AccessKeyPermission],

--- a/src/utils/key_pair.ts
+++ b/src/utils/key_pair.ts
@@ -2,7 +2,7 @@ import nacl from 'tweetnacl';
 import { base_encode, base_decode } from './serialize';
 import { Assignable } from './enums';
 import { randomBytes } from 'crypto';
-import {BinaryReader, BinaryWriter} from 'borsh'
+import {BinaryReader, BinaryWriter} from 'borsh';
 import secp256k1 from 'secp256k1';
 
 export type Arrayish = string | ArrayLike<number>;
@@ -76,22 +76,22 @@ export class PublicKey extends Assignable {
     
     static borshDeserialize(reader: BinaryReader) {
         const keyType = reader.readU8();
-        let data: Uint8Array
+        let data: Uint8Array;
         switch (keyType) {
         case KeyType.ED25519: 
-            data = reader.readFixedArray(32)
-            break
+            data = reader.readFixedArray(32);
+            break;
         case KeyType.SECP256K1: 
-            data = reader.readFixedArray(64)
-            break
+            data = reader.readFixedArray(64);
+            break;
         default: throw new Error(`Unknown key type ${keyType}`);
         }
-        return new PublicKey({keyType, data})
-     }
+        return new PublicKey({keyType, data});
+    }
     
     borshSerialize(writer: BinaryWriter) {
         writer.writeU8(this.keyType);
-        writer.writeFixedArray(this.data)
+        writer.writeFixedArray(this.data);
     }
 }
 
@@ -203,8 +203,8 @@ export class KeyPairSecp256k1 extends KeyPair {
      */
     constructor(secretKey: string) {
         super();
-        const withHeader = secp256k1.publicKeyCreate(base_decode(secretKey), false)
-        const data = withHeader.subarray(1, withHeader.length) // remove the 0x04 header byte
+        const withHeader = secp256k1.publicKeyCreate(base_decode(secretKey), false);
+        const data = withHeader.subarray(1, withHeader.length); // remove the 0x04 header byte
         this.publicKey = new PublicKey({
             keyType: KeyType.SECP256K1,
             data

--- a/src/utils/key_pair.ts
+++ b/src/utils/key_pair.ts
@@ -1,6 +1,9 @@
 import nacl from 'tweetnacl';
 import { base_encode, base_decode } from './serialize';
 import { Assignable } from './enums';
+import { randomBytes } from 'crypto';
+import {BinaryReader, BinaryWriter} from 'borsh'
+import secp256k1 from 'secp256k1';
 
 export type Arrayish = string | ArrayLike<number>;
 
@@ -12,11 +15,13 @@ export interface Signature {
 /** All supported key types */
 export enum KeyType {
     ED25519 = 0,
+    SECP256K1 = 1, 
 }
 
 function key_type_to_str(keyType: KeyType): string {
     switch (keyType) {
     case KeyType.ED25519: return 'ed25519';
+    case KeyType.SECP256K1: return 'secp256k1';
     default: throw new Error(`Unknown key type ${keyType}`);
     }
 }
@@ -24,6 +29,7 @@ function key_type_to_str(keyType: KeyType): string {
 function str_to_key_type(keyType: string): KeyType {
     switch (keyType.toLowerCase()) {
     case 'ed25519': return KeyType.ED25519;
+    case 'secp256k1': return KeyType.SECP256K1;
     default: throw new Error(`Unknown key type ${keyType}`);
     }
 }
@@ -41,7 +47,7 @@ export class PublicKey extends Assignable {
         }
         return value;
     }
-
+    
     static fromString(encodedKey: string): PublicKey {
         const parts = encodedKey.split(':');
         if (parts.length === 1) {
@@ -52,7 +58,7 @@ export class PublicKey extends Assignable {
             throw new Error('Invalid encoded key format, must be <curve>:<encoded key>');
         }
     }
-
+    
     toString(): string {
         return `${key_type_to_str(this.keyType)}:${base_encode(this.data)}`;
     }
@@ -60,8 +66,32 @@ export class PublicKey extends Assignable {
     verify(message: Uint8Array, signature: Uint8Array): boolean {
         switch (this.keyType) {
         case KeyType.ED25519: return nacl.sign.detached.verify(message, signature, this.data);
+        // we don't need the recovery id to verify secp25k61 signatures locally, so drop  it here
+        // also inject the 0x04 header back into the pubkey before trying to interact with it in
+        // the secp256k1 library
+        case KeyType.SECP256K1: return secp256k1.ecdsaVerify(signature.subarray(0, 64), message, new Uint8Array([0x04, ...this.data]));
         default: throw new Error(`Unknown key type ${this.keyType}`);
         }
+    }
+    
+    static borshDeserialize(reader: BinaryReader) {
+        const keyType = reader.readU8();
+        let data: Uint8Array
+        switch (keyType) {
+        case KeyType.ED25519: 
+            data = reader.readFixedArray(32)
+            break
+        case KeyType.SECP256K1: 
+            data = reader.readFixedArray(64)
+            break
+        default: throw new Error(`Unknown key type ${keyType}`);
+        }
+        return new PublicKey({keyType, data})
+     }
+    
+    borshSerialize(writer: BinaryWriter) {
+        writer.writeU8(this.keyType);
+        writer.writeFixedArray(this.data)
     }
 }
 
@@ -78,17 +108,20 @@ export abstract class KeyPair {
     static fromRandom(curve: string): KeyPair {
         switch (curve.toUpperCase()) {
         case 'ED25519': return KeyPairEd25519.fromRandom();
+        case 'SECP256K1': return KeyPairSecp256k1.fromRandom();
         default: throw new Error(`Unknown curve ${curve}`);
         }
     }
 
     static fromString(encodedKey: string): KeyPair {
         const parts = encodedKey.split(':');
+        //TODO: clarify what we must do here
         if (parts.length === 1) {
             return new KeyPairEd25519(parts[0]);
         } else if (parts.length === 2) {
             switch (parts[0].toUpperCase()) {
             case 'ED25519': return new KeyPairEd25519(parts[1]);
+            case 'SECP256K1': return new KeyPairSecp256k1(parts[1]);
             default: throw new Error(`Unknown curve: ${parts[0]}`);
             }
         } else {
@@ -143,6 +176,70 @@ export class KeyPairEd25519 extends KeyPair {
 
     toString(): string {
         return `ed25519:${this.secretKey}`;
+    }
+
+    getPublicKey(): PublicKey {
+        return this.publicKey;
+    }
+}
+/**
+ * This class provides key pair functionality for secp256k1 curve:
+ * generating key pairs, encoding key pairs, signing and verifying.
+ * nearcore expects secp256k1 public keys to be 64 bytes at all times, 
+ * even when string encoded the secp256k1 library returns 65 byte keys 
+ * (including a 1 byte header that indicates how the pubkey was encoded).
+ * We'll force the secp256k1 library to always encode uncompressed
+ * keys with the corresponding 0x04 header byte, then manually 
+ * insert/remove that byte as needed.
+ */
+export class KeyPairSecp256k1 extends KeyPair {
+    readonly publicKey: PublicKey;
+    readonly secretKey: string;
+
+    /**
+     * Construct an instance of key pair given a secret key.
+     * It's generally assumed that these are encoded in base58.
+     * @param {string} secretKey
+     */
+    constructor(secretKey: string) {
+        super();
+        const withHeader = secp256k1.publicKeyCreate(base_decode(secretKey), false)
+        const data = withHeader.subarray(1, withHeader.length) // remove the 0x04 header byte
+        this.publicKey = new PublicKey({
+            keyType: KeyType.SECP256K1,
+            data
+        });
+        this.secretKey = secretKey;
+    }
+
+    /**
+     * Generate a new random keypair.
+     * @example
+     * const keyRandom = KeyPair.fromRandom();
+     * keyRandom.publicKey
+     * // returns [PUBLIC_KEY]
+     *
+     * keyRandom.secretKey
+     * // returns [SECRET_KEY]
+     */
+    static fromRandom() {
+        // TODO: find better way to generate PK
+        const secretKey = randomBytes(32);
+        return new KeyPairSecp256k1(base_encode(secretKey));
+    }
+
+    sign(message: Uint8Array): Signature {
+        // nearcore expects 65 byte signatures formed by appending the recovery id to the 64 byte signature
+        const { signature, recid } = secp256k1.ecdsaSign(message, base_decode(this.secretKey)); 
+        return { signature: new Uint8Array([...signature, recid]), publicKey: this.publicKey };
+    }
+
+    verify(message: Uint8Array, signature: Uint8Array): boolean {
+        return this.publicKey.verify(message, signature);
+    }
+
+    toString(): string {
+        return `secp256k1:${this.secretKey}`;
     }
 
     getPublicKey(): PublicKey {

--- a/src/wallet-account.ts
+++ b/src/wallet-account.ts
@@ -136,7 +136,8 @@ export class WalletConnection {
         contractIdOrOptions: string | SignInOptions = {},
         title?: string,
         successUrl?: string,
-        failureUrl?: string
+        failureUrl?: string,
+        keyType: 'ed25519' | 'secp256k1' = 'ed25519'
     ) {
         let options: SignInOptions;
         if (typeof contractIdOrOptions === 'string') {
@@ -157,7 +158,7 @@ export class WalletConnection {
             await contractAccount.state();
 
             newUrl.searchParams.set('contract_id', options.contractId);
-            const accessKey = KeyPair.fromRandom('ed25519');
+            const accessKey = KeyPair.fromRandom(keyType);
             newUrl.searchParams.set('public_key', accessKey.getPublicKey().toString());
             await this._keyStore.setKey(this._networkId, PENDING_ACCESS_KEY_PREFIX + accessKey.getPublicKey(), accessKey);
         }

--- a/test/account.access_key.test.js
+++ b/test/account.access_key.test.js
@@ -29,6 +29,16 @@ test('make function call using access key', async() => {
     expect(await contract.getValue()).toEqual(setCallValue);
 });
 
+test('make function call using secp256k1 access key', async() => {
+    const keyPair = nearApi.utils.KeyPair.fromRandom('secp256k1');
+    await workingAccount.addKey(keyPair.getPublicKey(), contractId, '', '2000000000000000000000000');
+    // Override in the key store the workingAccount key to the given access key.
+    await nearjs.connection.signer.keyStore.setKey(testUtils.networkId, workingAccount.accountId, keyPair);
+    const setCallValue = testUtils.generateUniqueString('setCallPrefix');
+    await contract.setValue({ args: { value: setCallValue } });
+    expect(await contract.getValue()).toEqual(setCallValue);
+});
+
 test('remove access key no longer works', async() => {
     const keyPair = nearApi.utils.KeyPair.fromRandom('ed25519');
     let publicKey = keyPair.getPublicKey();

--- a/test/account.test.js
+++ b/test/account.test.js
@@ -36,6 +36,17 @@ test('create account and then view account returns the created account', async (
     expect(state.amount).toEqual(newAmount.toString());
 });
 
+test('create account with a secp256k1 key and then view account returns the created account', async () => {
+    const newAccountName = testUtils.generateUniqueString('test');
+    const newAccountPublicKey = 'secp256k1:45KcWwYt6MYRnnWFSxyQVkuu9suAzxoSkUMEnFNBi9kDayTo5YPUaqMWUrf7YHUDNMMj3w75vKuvfAMgfiFXBy28';
+    const { amount } = await workingAccount.state();
+    const newAmount = new BN(amount).div(new BN(10));
+    await workingAccount.createAccount(newAccountName, newAccountPublicKey, newAmount);
+    const newAccount = new Account(nearjs.connection, newAccountName);
+    const state = await newAccount.state();
+    expect(state.amount).toEqual(newAmount.toString());
+});
+
 test('send money', async() => {
     const sender = await testUtils.createAccount(nearjs);
     const receiver = await testUtils.createAccount(nearjs);

--- a/test/key_pair.test.js
+++ b/test/key_pair.test.js
@@ -1,41 +1,82 @@
 
 const nearApi = require('../src/index');
 const { sha256 } = require('js-sha256');
+describe('Using Ed25519 Curve', () => {
+    test('test sign and verify', async () => {
+        const keyPair = new nearApi.utils.key_pair.KeyPairEd25519('26x56YPzPDro5t2smQfGcYAPy3j7R2jB2NUb7xKbAGK23B6x4WNQPh3twb6oDksFov5X8ts5CtntUNbpQpAKFdbR');
+        expect(keyPair.publicKey.toString()).toEqual('ed25519:AYWv9RAN1hpSQA4p1DLhCNnpnNXwxhfH9qeHN8B4nJ59');
+        const message = new Uint8Array(sha256.array('message'));
+        const signature = keyPair.sign(message);
+        expect(nearApi.utils.serialize.base_encode(signature.signature)).toEqual('26gFr4xth7W9K7HPWAxq3BLsua8oTy378mC1MYFiEXHBBpeBjP8WmJEJo8XTBowetvqbRshcQEtBUdwQcAqDyP8T');
+    });
 
-test('test sign and verify', async () => {
-    const keyPair = new nearApi.utils.key_pair.KeyPairEd25519('26x56YPzPDro5t2smQfGcYAPy3j7R2jB2NUb7xKbAGK23B6x4WNQPh3twb6oDksFov5X8ts5CtntUNbpQpAKFdbR');
-    expect(keyPair.publicKey.toString()).toEqual('ed25519:AYWv9RAN1hpSQA4p1DLhCNnpnNXwxhfH9qeHN8B4nJ59');
-    const message = new Uint8Array(sha256.array('message'));
-    const signature = keyPair.sign(message);
-    expect(nearApi.utils.serialize.base_encode(signature.signature)).toEqual('26gFr4xth7W9K7HPWAxq3BLsua8oTy378mC1MYFiEXHBBpeBjP8WmJEJo8XTBowetvqbRshcQEtBUdwQcAqDyP8T');
+    test('test sign and verify with random', async () => {
+        const keyPair = nearApi.utils.key_pair.KeyPairEd25519.fromRandom();
+        const message = new Uint8Array(sha256.array('message'));
+        const signature = keyPair.sign(message);
+        expect(keyPair.verify(message, signature.signature)).toBeTruthy();
+    });
+
+    test('test sign and verify with public key', async () => {
+        const keyPair = new nearApi.utils.key_pair.KeyPairEd25519('5JueXZhEEVqGVT5powZ5twyPP8wrap2K7RdAYGGdjBwiBdd7Hh6aQxMP1u3Ma9Yanq1nEv32EW7u8kUJsZ6f315C');
+        const message = new Uint8Array(sha256.array('message'));
+        const signature = keyPair.sign(message);
+        const publicKey = nearApi.utils.key_pair.PublicKey.from('ed25519:EWrekY1deMND7N3Q7Dixxj12wD7AVjFRt2H9q21QHUSW');
+        expect(publicKey.verify(message, signature.signature)).toBeTruthy();
+    });
+
+    test('test from secret', async () => {
+        const keyPair = new nearApi.utils.key_pair.KeyPairEd25519('5JueXZhEEVqGVT5powZ5twyPP8wrap2K7RdAYGGdjBwiBdd7Hh6aQxMP1u3Ma9Yanq1nEv32EW7u8kUJsZ6f315C');
+        expect(keyPair.publicKey.toString()).toEqual('ed25519:EWrekY1deMND7N3Q7Dixxj12wD7AVjFRt2H9q21QHUSW');
+    });
+
+    test('convert to string', async () => {
+        const keyPair = nearApi.utils.key_pair.KeyPairEd25519.fromRandom();
+        const newKeyPair = nearApi.utils.key_pair.KeyPair.fromString(keyPair.toString());
+        expect(newKeyPair.secretKey).toEqual(keyPair.secretKey);
+
+        const keyString = 'ed25519:2wyRcSwSuHtRVmkMCGjPwnzZmQLeXLzLLyED1NDMt4BjnKgQL6tF85yBx6Jr26D2dUNeC716RBoTxntVHsegogYw';
+        const keyPair2 = nearApi.utils.key_pair.KeyPair.fromString(keyString);
+        expect(keyPair2.toString()).toEqual(keyString);
+    });
 });
 
-test('test sign and verify with random', async () => {
-    const keyPair = nearApi.utils.key_pair.KeyPairEd25519.fromRandom();
-    const message = new Uint8Array(sha256.array('message'));
-    const signature = keyPair.sign(message);
-    expect(keyPair.verify(message, signature.signature)).toBeTruthy();
-});
+describe('Using Secp256k1 Curve', () => {
+    test('Should sign and verify with Secp256k1', async () => {
+        const keyPair = new nearApi.utils.key_pair.KeyPairSecp256k1('Cqmi5vHc59U1MHhq7JCxTSJentvVBYMcKGUA7s7kwnKn');
+        expect(keyPair.publicKey.toString()).toEqual('secp256k1:45KcWwYt6MYRnnWFSxyQVkuu9suAzxoSkUMEnFNBi9kDayTo5YPUaqMWUrf7YHUDNMMj3w75vKuvfAMgfiFXBy28');
+        const message = new Uint8Array(sha256.array('message'));
+        const signature = keyPair.sign(message);
+        expect(nearApi.utils.serialize.base_encode(signature.signature)).toEqual('3xamkuNXQr4HHLXygRdp42Q19BRs6X5vENHbVtj7duaphZpdaRR2dZD7NvxWHw2twFiUxCvYXue6ZDsWg77DWBxNb');
+    });
 
-test('test sign and verify with public key', async () => {
-    const keyPair = new nearApi.utils.key_pair.KeyPairEd25519('5JueXZhEEVqGVT5powZ5twyPP8wrap2K7RdAYGGdjBwiBdd7Hh6aQxMP1u3Ma9Yanq1nEv32EW7u8kUJsZ6f315C');
-    const message = new Uint8Array(sha256.array('message'));
-    const signature = keyPair.sign(message);
-    const publicKey = nearApi.utils.key_pair.PublicKey.from('ed25519:EWrekY1deMND7N3Q7Dixxj12wD7AVjFRt2H9q21QHUSW');
-    expect(publicKey.verify(message, signature.signature)).toBeTruthy();
-});
+    test('Should sign and verify random message using Secp256k1 curve', async () => {
+        const keyPair = nearApi.utils.key_pair.KeyPairSecp256k1.fromRandom();
+        const message = new Uint8Array(sha256.array('message'));
+        const signature = keyPair.sign(message);
+        expect(keyPair.verify(message, signature.signature)).toBeTruthy();
+    });
 
-test('test from secret', async () => {
-    const keyPair = new nearApi.utils.key_pair.KeyPairEd25519('5JueXZhEEVqGVT5powZ5twyPP8wrap2K7RdAYGGdjBwiBdd7Hh6aQxMP1u3Ma9Yanq1nEv32EW7u8kUJsZ6f315C');
-    expect(keyPair.publicKey.toString()).toEqual('ed25519:EWrekY1deMND7N3Q7Dixxj12wD7AVjFRt2H9q21QHUSW');
-});
+    test('Should sign and verify public key created using Secp256k1', async () => {
+        const keyPair = new nearApi.utils.key_pair.KeyPairSecp256k1('Cqmi5vHc59U1MHhq7JCxTSJentvVBYMcKGUA7s7kwnKn');
+        const message = new Uint8Array(sha256.array('message'));
+        const signature = keyPair.sign(message);
+        const publicKey = nearApi.utils.key_pair.PublicKey.from('secp256k1:45KcWwYt6MYRnnWFSxyQVkuu9suAzxoSkUMEnFNBi9kDayTo5YPUaqMWUrf7YHUDNMMj3w75vKuvfAMgfiFXBy28');
+        expect(publicKey.verify(message, signature.signature)).toBeTruthy();
+    });
 
-test('convert to string', async () => {
-    const keyPair = nearApi.utils.key_pair.KeyPairEd25519.fromRandom();
-    const newKeyPair = nearApi.utils.key_pair.KeyPair.fromString(keyPair.toString());
-    expect(newKeyPair.secretKey).toEqual(keyPair.secretKey);
+    test('Should create proper publicKey from secret using Secp256k1', async () => {
+        const keyPair = new nearApi.utils.key_pair.KeyPairSecp256k1('Cqmi5vHc59U1MHhq7JCxTSJentvVBYMcKGUA7s7kwnKn');
+        expect(keyPair.publicKey.toString()).toEqual('secp256k1:45KcWwYt6MYRnnWFSxyQVkuu9suAzxoSkUMEnFNBi9kDayTo5YPUaqMWUrf7YHUDNMMj3w75vKuvfAMgfiFXBy28');
+    });
 
-    const keyString = 'ed25519:2wyRcSwSuHtRVmkMCGjPwnzZmQLeXLzLLyED1NDMt4BjnKgQL6tF85yBx6Jr26D2dUNeC716RBoTxntVHsegogYw';
-    const keyPair2 = nearApi.utils.key_pair.KeyPair.fromString(keyString);
-    expect(keyPair2.toString()).toEqual(keyString);
+    test('Should return proper key converted to string using Secp256k1', async () => {
+        const keyPair = nearApi.utils.key_pair.KeyPairSecp256k1.fromRandom();
+        const newKeyPair = nearApi.utils.key_pair.KeyPair.fromString(keyPair.toString());
+        expect(newKeyPair.secretKey).toEqual(keyPair.secretKey);
+
+        const keyString = 'secp256k1:7s1Jno8tbqFHBMqLh3epaFBbk194zAuMqo8yPbxvTbXn';
+        const keyPair2 = nearApi.utils.key_pair.KeyPair.fromString(keyString);
+        expect(keyPair2.toString()).toEqual(keyString);
+    });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2054,7 +2054,7 @@ electron-to-chromium@^1.3.846:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.853.tgz#f3ed1d31f092cb3a17af188bca6c6a3ec91c3e82"
   integrity sha512-W4U8n+U8I5/SUaFcqZgbKRmYZwcyEIQVBDf+j5QQK6xChjXnQD+wj248eGR9X4u+dDmDR//8vIfbu4PrdBBIoQ==
 
-elliptic@^6.5.3:
+elliptic@^6.5.3, elliptic@^6.5.4:
   version "6.5.4"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.4.tgz#da37cebd31e79a1367e941b592ed1fbebd58abbb"
   integrity sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==
@@ -4275,6 +4275,11 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
+node-addon-api@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-2.0.2.tgz#432cfa82962ce494b132e9d72a15b29f71ff5d32"
+  integrity sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==
+
 node-cleanup@^2.1.2:
   version "2.1.2"
   resolved "https://registry.npmjs.org/node-cleanup/-/node-cleanup-2.1.2.tgz#7ac19abd297e09a7f72a71545d951b517e4dde2c"
@@ -4292,6 +4297,11 @@ node-fetch@^1.7.1:
   dependencies:
     encoding "^0.1.11"
     is-stream "^1.0.1"
+
+node-gyp-build@^4.2.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/node-gyp-build/-/node-gyp-build-4.3.0.tgz#9f256b03e5826150be39c764bf51e993946d71a3"
+  integrity sha512-iWjXZvmboq0ja1pUGULQBexmxq8CV4xBhX7VDOTbL7ZR4FOowwY/VOtRxBN/yKxmdGoIp4j5ysNT4u3S2pDQ3Q==
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -5095,6 +5105,15 @@ saxes@^5.0.1:
   integrity sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==
   dependencies:
     xmlchars "^2.2.0"
+
+secp256k1@^4.0.3:
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/secp256k1/-/secp256k1-4.0.3.tgz#c4559ecd1b8d3c1827ed2d1b94190d69ce267303"
+  integrity sha512-NLZVf+ROMxwtEj3Xa562qgv2BK5e2WNmXPiOdVIPLgs6lyTzMvBq0aWTYMI5XCP9jZMVKOcqZLw/Wc4vDkuxhA==
+  dependencies:
+    elliptic "^6.5.4"
+    node-addon-api "^2.0.0"
+    node-gyp-build "^4.2.0"
 
 "semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5.0, semver@^5.6.0:
   version "5.7.1"


### PR DESCRIPTION
This PR adds support for the secp256k1 curve. It's based off #780, which gets pretty close. @mikedotexe asked us to take a look at the js implementation after adding secp support in the swift library  [here](https://github.com/near/near-api-swift/pull/3).