### PR TITLE
feat: add method to disable 2FA with FAK

### DIFF
--- a/lib/account_multisig.d.ts
+++ b/lib/account_multisig.d.ts
@@ -77,6 +77,12 @@ export declare class Account2FA extends AccountMultisig {
     signAndSendTransaction(receiverId: string, actions: Action[]): Promise<FinalExecutionOutcome>;
     private __signAndSendTransaction;
     deployMultisig(contractBytes: Uint8Array): Promise<FinalExecutionOutcome>;
+    disableWithFAK({ contractBytes, cleanupContractBytes }: {
+        contractBytes: Uint8Array;
+        cleanupContractBytes?: Uint8Array;
+    }): Promise<FinalExecutionOutcome>;
+    get2faDisableCleanupActions(cleanupContractBytes: Uint8Array): Promise<Action[]>;
+    get2faDisableKeyConversionActions(): Promise<Action[]>;
     /**
      * This method converts LAKs back to FAKs, clears state and deploys an 'empty' contract (contractBytes param)
      * @param [contractBytes]{@link https://github.com/near/near-wallet/blob/master/packages/frontend/src/wasm/main.wasm?raw=true}

--- a/lib/account_multisig.js
+++ b/lib/account_multisig.js
@@ -12,6 +12,7 @@ const key_pair_1 = require("./utils/key_pair");
 const transaction_1 = require("./transaction");
 const providers_1 = require("./providers");
 const web_1 = require("./utils/web");
+const borsh_1 = require("borsh");
 exports.MULTISIG_STORAGE_KEY = '__multisigRequest';
 exports.MULTISIG_ALLOWANCE = new bn_js_1.default(format_1.parseNearAmount('1'));
 // TODO: Different gas value for different requests (can reduce gas usage dramatically)
@@ -258,12 +259,45 @@ class Account2FA extends AccountMultisig {
                 throw new providers_1.TypedError(`Can not deploy a contract to account ${this.accountId} on network ${this.connection.networkId}, the account state could not be verified.`, 'ContractStateUnknown');
         }
     }
-    /**
-     * This method converts LAKs back to FAKs, clears state and deploys an 'empty' contract (contractBytes param)
-     * @param [contractBytes]{@link https://github.com/near/near-wallet/blob/master/packages/frontend/src/wasm/main.wasm?raw=true}
-     * @param [cleanupContractBytes]{@link https://github.com/near/core-contracts/blob/master/state-cleanup/res/state_cleanup.wasm?raw=true}
-     */
-    async disable(contractBytes, cleanupContractBytes) {
+    async disableWithFAK({ contractBytes, cleanupContractBytes }) {
+        const publicKey = await this.connection.signer.getPublicKey(this.accountId, this.connection.networkId);
+        const accessKey = await this.connection.provider.query({
+            request_type: 'view_access_key',
+            account_id: this.accountId,
+            public_key: publicKey.toString(),
+            finality: 'optimistic'
+        });
+        const block = await this.connection.provider.block({ finality: 'final' });
+        const blockHash = block.header.hash;
+        if (accessKey.permission !== 'FullAccess') {
+            throw new providers_1.TypedError(`No full access key found in keystore. Unable to bypass multisig`, 'NoFAKFound');
+        }
+        const nonce = ++accessKey.nonce;
+        const actions = [
+            ...(cleanupContractBytes ? await this.get2faDisableCleanupActions(cleanupContractBytes) : []),
+            ...(await this.get2faDisableKeyConversionActions()),
+            transaction_1.deployContract(contractBytes),
+        ];
+        const [, signedTx] = await transaction_1.signTransaction(this.accountId, nonce, actions, borsh_1.baseDecode(blockHash), this.connection.signer, this.accountId, this.connection.networkId);
+        return this.connection.provider.sendTransaction(signedTx);
+    }
+    async get2faDisableCleanupActions(cleanupContractBytes) {
+        const currentAccountState = await this.viewState('').catch(error => {
+            const cause = error.cause && error.cause.name;
+            if (cause == 'NO_CONTRACT_CODE') {
+                return [];
+            }
+            throw cause == 'TOO_LARGE_CONTRACT_STATE' ?
+                new providers_1.TypedError(`Can not deploy a contract to account ${this.accountId} on network ${this.connection.networkId}, the account has existing state.`, 'ContractHasExistingState') :
+                error;
+        });
+        const currentAccountStateKeys = currentAccountState.map(({ key }) => key.toString('base64'));
+        return currentAccountState.length ? [
+            transaction_1.deployContract(cleanupContractBytes),
+            transaction_1.functionCall('clean', { keys: currentAccountStateKeys }, exports.MULTISIG_GAS, new bn_js_1.default('0'))
+        ] : [];
+    }
+    async get2faDisableKeyConversionActions() {
         const { accountId } = this;
         const accessKeys = await this.getAccessKeys();
         const lak2fak = accessKeys
@@ -275,36 +309,38 @@ class Account2FA extends AccountMultisig {
                 perm.method_names.includes('add_request_and_confirm');
         });
         const confirmOnlyKey = key_pair_1.PublicKey.from((await this.postSignedJson('/2fa/getAccessKey', { accountId })).publicKey);
+        return [
+            transaction_1.deleteKey(confirmOnlyKey),
+            ...lak2fak.map(({ public_key }) => transaction_1.deleteKey(key_pair_1.PublicKey.from(public_key))),
+            ...lak2fak.map(({ public_key }) => transaction_1.addKey(key_pair_1.PublicKey.from(public_key), transaction_1.fullAccessKey()))
+        ];
+    }
+    /**
+     * This method converts LAKs back to FAKs, clears state and deploys an 'empty' contract (contractBytes param)
+     * @param [contractBytes]{@link https://github.com/near/near-wallet/blob/master/packages/frontend/src/wasm/main.wasm?raw=true}
+     * @param [cleanupContractBytes]{@link https://github.com/near/core-contracts/blob/master/state-cleanup/res/state_cleanup.wasm?raw=true}
+     */
+    async disable(contractBytes, cleanupContractBytes) {
         const { stateStatus } = await this.checkMultisigCodeAndStateStatus();
         if (stateStatus !== MultisigStateStatus.VALID_STATE && stateStatus !== MultisigStateStatus.STATE_NOT_INITIALIZED) {
             throw new providers_1.TypedError(`Can not deploy a contract to account ${this.accountId} on network ${this.connection.networkId}, the account state could not be verified.`, 'ContractStateUnknown');
         }
         let deleteAllRequestsError;
         await this.deleteAllRequests().catch(e => deleteAllRequestsError = e);
-        const currentAccountState = await this.viewState('').catch(error => {
-            const cause = error.cause && error.cause.name;
-            if (cause == 'NO_CONTRACT_CODE') {
-                return [];
+        const cleanupActions = await this.get2faDisableCleanupActions(cleanupContractBytes).catch(e => {
+            if (e.type === 'ContractHasExistingState') {
+                throw deleteAllRequestsError || e;
             }
-            throw cause == 'TOO_LARGE_CONTRACT_STATE' ?
-                deleteAllRequestsError || new providers_1.TypedError(`Can not deploy a contract to account ${this.accountId} on network ${this.connection.networkId}, the account has existing state.`, 'ContractHasExistingState') :
-                error;
+            throw e;
         });
-        const currentAccountStateKeys = currentAccountState.map(({ key }) => key.toString('base64'));
-        const cleanupActions = currentAccountState.length ? [
-            transaction_1.deployContract(cleanupContractBytes),
-            transaction_1.functionCall('clean', { keys: currentAccountStateKeys }, exports.MULTISIG_GAS, new bn_js_1.default('0'))
-        ] : [];
         const actions = [
             ...cleanupActions,
-            transaction_1.deleteKey(confirmOnlyKey),
-            ...lak2fak.map(({ public_key }) => transaction_1.deleteKey(key_pair_1.PublicKey.from(public_key))),
-            ...lak2fak.map(({ public_key }) => transaction_1.addKey(key_pair_1.PublicKey.from(public_key), null)),
+            ...(await this.get2faDisableKeyConversionActions()),
             transaction_1.deployContract(contractBytes),
         ];
-        console.log('disabling 2fa for', accountId);
+        console.log('disabling 2fa for', this.accountId);
         return await this.signAndSendTransaction({
-            receiverId: accountId,
+            receiverId: this.accountId,
             actions
         });
     }

--- a/lib/account_multisig.js
+++ b/lib/account_multisig.js
@@ -260,17 +260,11 @@ class Account2FA extends AccountMultisig {
     }
     async disableWithFAK({ contractBytes, cleanupContractBytes }) {
         let cleanupActions = [];
-        const keyConversionActions = await this.get2faDisableKeyConversionActions();
         if (cleanupContractBytes) {
-            let deleteAllRequestsError;
-            await this.deleteAllRequests().catch(e => deleteAllRequestsError = e);
-            cleanupActions = await this.get2faDisableCleanupActions(cleanupContractBytes).catch(e => {
-                if (e.type === 'ContractHasExistingState') {
-                    throw deleteAllRequestsError || e;
-                }
-                throw e;
-            });
+            await this.deleteAllRequests().catch(e => e);
+            cleanupActions = await this.get2faDisableCleanupActions(cleanupContractBytes);
         }
+        const keyConversionActions = await this.get2faDisableKeyConversionActions();
         const actions = [
             ...cleanupActions,
             ...keyConversionActions,
@@ -288,9 +282,9 @@ class Account2FA extends AccountMultisig {
             if (cause == 'NO_CONTRACT_CODE') {
                 return [];
             }
-            throw cause == 'TOO_LARGE_CONTRACT_STATE' ?
-                new providers_1.TypedError(`Can not deploy a contract to account ${this.accountId} on network ${this.connection.networkId}, the account has existing state.`, 'ContractHasExistingState') :
-                error;
+            throw cause == 'TOO_LARGE_CONTRACT_STATE'
+                ? new providers_1.TypedError(`Can not deploy a contract to account ${this.accountId} on network ${this.connection.networkId}, the account has existing state.`, 'ContractHasExistingState')
+                : error;
         });
         const currentAccountStateKeys = currentAccountState.map(({ key }) => key.toString('base64'));
         return currentAccountState.length ? [

--- a/lib/account_multisig.js
+++ b/lib/account_multisig.js
@@ -12,7 +12,6 @@ const key_pair_1 = require("./utils/key_pair");
 const transaction_1 = require("./transaction");
 const providers_1 = require("./providers");
 const web_1 = require("./utils/web");
-const borsh_1 = require("borsh");
 exports.MULTISIG_STORAGE_KEY = '__multisigRequest';
 exports.MULTISIG_ALLOWANCE = new bn_js_1.default(format_1.parseNearAmount('1'));
 // TODO: Different gas value for different requests (can reduce gas usage dramatically)
@@ -260,26 +259,28 @@ class Account2FA extends AccountMultisig {
         }
     }
     async disableWithFAK({ contractBytes, cleanupContractBytes }) {
-        const publicKey = await this.connection.signer.getPublicKey(this.accountId, this.connection.networkId);
-        const accessKey = await this.connection.provider.query({
-            request_type: 'view_access_key',
-            account_id: this.accountId,
-            public_key: publicKey.toString(),
-            finality: 'optimistic'
-        });
-        const block = await this.connection.provider.block({ finality: 'final' });
-        const blockHash = block.header.hash;
-        if (accessKey.permission !== 'FullAccess') {
+        let cleanupActions = [];
+        const keyConversionActions = await this.get2faDisableKeyConversionActions();
+        if (cleanupContractBytes) {
+            let deleteAllRequestsError;
+            await this.deleteAllRequests().catch(e => deleteAllRequestsError = e);
+            cleanupActions = await this.get2faDisableCleanupActions(cleanupContractBytes).catch(e => {
+                if (e.type === 'ContractHasExistingState') {
+                    throw deleteAllRequestsError || e;
+                }
+                throw e;
+            });
+        }
+        const actions = [
+            ...cleanupActions,
+            ...keyConversionActions,
+            transaction_1.deployContract(contractBytes)
+        ];
+        const accessKeyInfo = await this.findAccessKey(this.accountId, actions);
+        if (accessKeyInfo?.accessKey?.permission !== 'FullAccess') {
             throw new providers_1.TypedError(`No full access key found in keystore. Unable to bypass multisig`, 'NoFAKFound');
         }
-        const nonce = ++accessKey.nonce;
-        const actions = [
-            ...(cleanupContractBytes ? await this.get2faDisableCleanupActions(cleanupContractBytes) : []),
-            ...(await this.get2faDisableKeyConversionActions()),
-            transaction_1.deployContract(contractBytes),
-        ];
-        const [, signedTx] = await transaction_1.signTransaction(this.accountId, nonce, actions, borsh_1.baseDecode(blockHash), this.connection.signer, this.accountId, this.connection.networkId);
-        return this.connection.provider.sendTransaction(signedTx);
+        return this.signAndSendTransactionWithAccount(this.accountId, actions);
     }
     async get2faDisableCleanupActions(cleanupContractBytes) {
         const currentAccountState = await this.viewState('').catch(error => {

--- a/lib/account_multisig.js
+++ b/lib/account_multisig.js
@@ -271,7 +271,7 @@ class Account2FA extends AccountMultisig {
             transaction_1.deployContract(contractBytes)
         ];
         const accessKeyInfo = await this.findAccessKey(this.accountId, actions);
-        if (accessKeyInfo?.accessKey?.permission !== 'FullAccess') {
+        if (accessKeyInfo && accessKeyInfo.accessKey && accessKeyInfo.accessKey.permission !== 'FullAccess') {
             throw new providers_1.TypedError(`No full access key found in keystore. Unable to bypass multisig`, 'NoFAKFound');
         }
         return this.signAndSendTransactionWithAccount(this.accountId, actions);

--- a/src/account_multisig.ts
+++ b/src/account_multisig.ts
@@ -6,11 +6,10 @@ import { Account, SignAndSendTransactionOptions } from './account';
 import { Connection } from './connection';
 import { parseNearAmount } from './utils/format';
 import { PublicKey } from './utils/key_pair';
-import { Action, addKey, deleteKey, deployContract, fullAccessKey, functionCall, functionCallAccessKey, signTransaction } from './transaction';
+import { Action, addKey, deleteKey, deployContract, fullAccessKey, functionCall, functionCallAccessKey } from './transaction';
 import { FinalExecutionOutcome, TypedError } from './providers';
 import { fetchJson } from './utils/web';
-import { AccessKeyView, FunctionCallPermissionView } from './providers/provider';
-import { baseDecode } from 'borsh';
+import { FunctionCallPermissionView } from './providers/provider';
 
 export const MULTISIG_STORAGE_KEY = '__multisigRequest';
 export const MULTISIG_ALLOWANCE = new BN(parseNearAmount('1'));
@@ -316,30 +315,32 @@ export class Account2FA extends AccountMultisig {
     }
 
     async disableWithFAK({ contractBytes, cleanupContractBytes }: { contractBytes: Uint8Array, cleanupContractBytes?: Uint8Array }) {
-        const publicKey = await this.connection.signer.getPublicKey(this.accountId, this.connection.networkId);
-        const accessKey = await this.connection.provider.query<AccessKeyView>({
-            request_type: 'view_access_key',
-            account_id: this.accountId,
-            public_key: publicKey.toString(),
-            finality: 'optimistic'
-        });
-        const block = await this.connection.provider.block({ finality: 'final' });
-        const blockHash = block.header.hash;
+        let cleanupActions = [];
+        const keyConversionActions = await this.get2faDisableKeyConversionActions();
+        if(cleanupContractBytes) {
+            let deleteAllRequestsError;
+            await this.deleteAllRequests().catch(e => deleteAllRequestsError = e);
+            cleanupActions = await this.get2faDisableCleanupActions(cleanupContractBytes).catch(e => {
+                if(e.type === 'ContractHasExistingState') {
+                    throw deleteAllRequestsError || e;
+                }
+                throw e;
+            });
+        }
 
-        if(accessKey.permission !== 'FullAccess') {
+        const actions = [
+            ...cleanupActions,
+            ...keyConversionActions,
+            deployContract(contractBytes)
+        ];
+
+        const accessKeyInfo = await this.findAccessKey(this.accountId, actions);
+
+        if(accessKeyInfo?.accessKey?.permission !== 'FullAccess') {
             throw new TypedError(`No full access key found in keystore. Unable to bypass multisig`, 'NoFAKFound');
         }
 
-        const nonce = ++accessKey.nonce;
-        const actions = [
-            ...(cleanupContractBytes ? await this.get2faDisableCleanupActions(cleanupContractBytes) : []),
-            ...(await this.get2faDisableKeyConversionActions()),
-            deployContract(contractBytes),
-        ]
-        const [, signedTx] = await signTransaction(
-            this.accountId, nonce, actions, baseDecode(blockHash), this.connection.signer, this.accountId, this.connection.networkId
-        );
-        return this.connection.provider.sendTransaction(signedTx)
+        return this.signAndSendTransactionWithAccount(this.accountId, actions);
     }
 
     async get2faDisableCleanupActions(cleanupContractBytes: Uint8Array) {

--- a/src/account_multisig.ts
+++ b/src/account_multisig.ts
@@ -349,9 +349,9 @@ export class Account2FA extends AccountMultisig {
             if (cause == 'NO_CONTRACT_CODE') {
                 return [];
             }
-            throw cause == 'TOO_LARGE_CONTRACT_STATE' ?
-                new TypedError(`Can not deploy a contract to account ${this.accountId} on network ${this.connection.networkId}, the account has existing state.`, 'ContractHasExistingState') :
-                error;
+            throw cause == 'TOO_LARGE_CONTRACT_STATE'
+                ? new TypedError(`Can not deploy a contract to account ${this.accountId} on network ${this.connection.networkId}, the account has existing state.`, 'ContractHasExistingState')
+                : error;
         });
 
         const currentAccountStateKeys = currentAccountState.map(({ key }) => key.toString('base64'))

--- a/src/account_multisig.ts
+++ b/src/account_multisig.ts
@@ -316,17 +316,11 @@ export class Account2FA extends AccountMultisig {
 
     async disableWithFAK({ contractBytes, cleanupContractBytes }: { contractBytes: Uint8Array, cleanupContractBytes?: Uint8Array }) {
         let cleanupActions = [];
-        const keyConversionActions = await this.get2faDisableKeyConversionActions();
         if(cleanupContractBytes) {
-            let deleteAllRequestsError;
-            await this.deleteAllRequests().catch(e => deleteAllRequestsError = e);
-            cleanupActions = await this.get2faDisableCleanupActions(cleanupContractBytes).catch(e => {
-                if(e.type === 'ContractHasExistingState') {
-                    throw deleteAllRequestsError || e;
-                }
-                throw e;
-            });
+            await this.deleteAllRequests().catch(e => e);
+            cleanupActions = await this.get2faDisableCleanupActions(cleanupContractBytes);
         }
+        const keyConversionActions = await this.get2faDisableKeyConversionActions();
 
         const actions = [
             ...cleanupActions,

--- a/src/account_multisig.ts
+++ b/src/account_multisig.ts
@@ -330,7 +330,7 @@ export class Account2FA extends AccountMultisig {
 
         const accessKeyInfo = await this.findAccessKey(this.accountId, actions);
 
-        if(accessKeyInfo?.accessKey?.permission !== 'FullAccess') {
+        if(accessKeyInfo && accessKeyInfo.accessKey && accessKeyInfo.accessKey.permission !== 'FullAccess') {
             throw new TypedError(`No full access key found in keystore. Unable to bypass multisig`, 'NoFAKFound');
         }
 

--- a/src/account_multisig.ts
+++ b/src/account_multisig.ts
@@ -6,10 +6,11 @@ import { Account, SignAndSendTransactionOptions } from './account';
 import { Connection } from './connection';
 import { parseNearAmount } from './utils/format';
 import { PublicKey } from './utils/key_pair';
-import { Action, addKey, deleteKey, deployContract, functionCall, functionCallAccessKey } from './transaction';
+import { Action, addKey, deleteKey, deployContract, fullAccessKey, functionCall, functionCallAccessKey, signTransaction } from './transaction';
 import { FinalExecutionOutcome, TypedError } from './providers';
 import { fetchJson } from './utils/web';
-import { FunctionCallPermissionView } from './providers/provider';
+import { AccessKeyView, FunctionCallPermissionView } from './providers/provider';
+import { baseDecode } from 'borsh';
 
 export const MULTISIG_STORAGE_KEY = '__multisigRequest';
 export const MULTISIG_ALLOWANCE = new BN(parseNearAmount('1'));
@@ -314,12 +315,52 @@ export class Account2FA extends AccountMultisig {
         }
     }
 
-    /**
-     * This method converts LAKs back to FAKs, clears state and deploys an 'empty' contract (contractBytes param)
-     * @param [contractBytes]{@link https://github.com/near/near-wallet/blob/master/packages/frontend/src/wasm/main.wasm?raw=true}
-     * @param [cleanupContractBytes]{@link https://github.com/near/core-contracts/blob/master/state-cleanup/res/state_cleanup.wasm?raw=true}
-     */
-    async disable(contractBytes: Uint8Array, cleanupContractBytes: Uint8Array) {
+    async disableWithFAK({ contractBytes, cleanupContractBytes }: { contractBytes: Uint8Array, cleanupContractBytes?: Uint8Array }) {
+        const publicKey = await this.connection.signer.getPublicKey(this.accountId, this.connection.networkId);
+        const accessKey = await this.connection.provider.query<AccessKeyView>({
+            request_type: 'view_access_key',
+            account_id: this.accountId,
+            public_key: publicKey.toString(),
+            finality: 'optimistic'
+        });
+        const block = await this.connection.provider.block({ finality: 'final' });
+        const blockHash = block.header.hash;
+
+        if(accessKey.permission !== 'FullAccess') {
+            throw new TypedError(`No full access key found in keystore. Unable to bypass multisig`, 'NoFAKFound');
+        }
+
+        const nonce = ++accessKey.nonce;
+        const actions = [
+            ...(cleanupContractBytes ? await this.get2faDisableCleanupActions(cleanupContractBytes) : []),
+            ...(await this.get2faDisableKeyConversionActions()),
+            deployContract(contractBytes),
+        ]
+        const [, signedTx] = await signTransaction(
+            this.accountId, nonce, actions, baseDecode(blockHash), this.connection.signer, this.accountId, this.connection.networkId
+        );
+        return this.connection.provider.sendTransaction(signedTx)
+    }
+
+    async get2faDisableCleanupActions(cleanupContractBytes: Uint8Array) {
+        const currentAccountState: { key: Buffer, value: Buffer }[] = await this.viewState('').catch(error => {
+            const cause = error.cause && error.cause.name;
+            if (cause == 'NO_CONTRACT_CODE') {
+                return [];
+            }
+            throw cause == 'TOO_LARGE_CONTRACT_STATE' ?
+                new TypedError(`Can not deploy a contract to account ${this.accountId} on network ${this.connection.networkId}, the account has existing state.`, 'ContractHasExistingState') :
+                error;
+        });
+
+        const currentAccountStateKeys = currentAccountState.map(({ key }) => key.toString('base64'))
+        return currentAccountState.length ? [
+            deployContract(cleanupContractBytes),
+            functionCall('clean', { keys: currentAccountStateKeys }, MULTISIG_GAS, new BN('0'))
+        ] : [];
+    }
+
+    async get2faDisableKeyConversionActions() {
         const { accountId } = this;
         const accessKeys = await this.getAccessKeys();
         const lak2fak = accessKeys
@@ -331,7 +372,19 @@ export class Account2FA extends AccountMultisig {
                     perm.method_names.includes('add_request_and_confirm');
             });
         const confirmOnlyKey = PublicKey.from((await this.postSignedJson('/2fa/getAccessKey', { accountId })).publicKey);
+        return [
+            deleteKey(confirmOnlyKey),
+            ...lak2fak.map(({ public_key }) => deleteKey(PublicKey.from(public_key))),
+            ...lak2fak.map(({ public_key }) => addKey(PublicKey.from(public_key), fullAccessKey()))
+        ];
+    }
 
+    /**
+     * This method converts LAKs back to FAKs, clears state and deploys an 'empty' contract (contractBytes param)
+     * @param [contractBytes]{@link https://github.com/near/near-wallet/blob/master/packages/frontend/src/wasm/main.wasm?raw=true}
+     * @param [cleanupContractBytes]{@link https://github.com/near/core-contracts/blob/master/state-cleanup/res/state_cleanup.wasm?raw=true}
+     */
+    async disable(contractBytes: Uint8Array, cleanupContractBytes: Uint8Array) {
         const { stateStatus } = await this.checkMultisigCodeAndStateStatus();
         if(stateStatus !== MultisigStateStatus.VALID_STATE && stateStatus !== MultisigStateStatus.STATE_NOT_INITIALIZED) {
             throw new TypedError(`Can not deploy a contract to account ${this.accountId} on network ${this.connection.networkId}, the account state could not be verified.`, 'ContractStateUnknown');
@@ -339,31 +392,22 @@ export class Account2FA extends AccountMultisig {
 
         let deleteAllRequestsError;
         await this.deleteAllRequests().catch(e => deleteAllRequestsError = e);
-        const currentAccountState: { key: Buffer, value: Buffer }[] = await this.viewState('').catch(error => {
-            const cause = error.cause && error.cause.name;
-            if (cause == 'NO_CONTRACT_CODE') {
-                return [];
-            }
-            throw cause == 'TOO_LARGE_CONTRACT_STATE' ?
-                deleteAllRequestsError || new TypedError(`Can not deploy a contract to account ${this.accountId} on network ${this.connection.networkId}, the account has existing state.`, 'ContractHasExistingState') :
-                error;
-        });
 
-        const currentAccountStateKeys = currentAccountState.map(({ key }) => key.toString('base64'))
-        const cleanupActions = currentAccountState.length ? [
-            deployContract(cleanupContractBytes),
-            functionCall('clean', { keys: currentAccountStateKeys }, MULTISIG_GAS, new BN('0'))
-        ] : [];
+        const cleanupActions = await this.get2faDisableCleanupActions(cleanupContractBytes).catch(e => {
+            if(e.type === 'ContractHasExistingState') {
+                throw deleteAllRequestsError || e;
+            }
+            throw e;
+        })
+
         const actions = [
             ...cleanupActions,
-            deleteKey(confirmOnlyKey),
-            ...lak2fak.map(({ public_key }) => deleteKey(PublicKey.from(public_key))),
-            ...lak2fak.map(({ public_key }) => addKey(PublicKey.from(public_key), null)),
+            ...(await this.get2faDisableKeyConversionActions()),
             deployContract(contractBytes),
         ];
-        console.log('disabling 2fa for', accountId);
+        console.log('disabling 2fa for', this.accountId);
         return await this.signAndSendTransaction({
-            receiverId: accountId,
+            receiverId: this.accountId,
             actions
         });
     }


### PR DESCRIPTION
This PR adds a `disableWithFAK` method to the `Account2FA` class. This method will allow 2fa disable to be performed without calling the multisig contract if a FAK is loaded into the keystore. It will optionally clear the account state using the [state cleanup contract](https://github.com/near/core-contracts/tree/master/state-cleanup) if the bytes are provided.

If no FAK is loaded into the keystore, the method will throw a `NoFAKFound` error.

`disableWithFAK` will be used on a script that is intended to restore accounts with bricked multisig with a seedphrase.