### PR TITLE
fix: types for block_id in query provider

### DIFF
--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -32,7 +32,13 @@ export type BlockId = BlockHash | BlockHeight;
 
 export type Finality = 'optimistic' | 'near-final' | 'final'
 
-export type BlockReference = { blockId: BlockId } | { finality: Finality } | { sync_checkpoint: 'genesis' | 'earliest_available' }
+export type SyncCheckpoint = 'genesis' | 'earliest_available'
+
+export type BlockFinallyOrCheckpoint = { finality: Finality } | { sync_checkpoint: SyncCheckpoint }
+
+export type BlockReference = { blockId: BlockId } | BlockFinallyOrCheckpoint
+
+export type BlockRpcQueryReference = { block_id: BlockId } | BlockFinallyOrCheckpoint
 
 export enum ExecutionStatusBasic {
     Unknown = 'Unknown',
@@ -402,7 +408,7 @@ export type RpcQueryRequest = (ViewAccountRequest |
     ViewAccountRequest |
     ViewAccessKeyRequest |
     ViewAccessKeyListRequest |
-    CallFunctionRequest) & BlockReference
+    CallFunctionRequest) & BlockRpcQueryReference
 
 
 /** @hidden */


### PR DESCRIPTION
I spent some time to figure out why my code was not working until I realized that the interface `BlockReference`  was not correct for RPC calls...

https://docs.near.org/docs/api/rpc#using-block_id-param