### PR TITLE
Be able to await until sign in process done completely

### DIFF
--- a/lib/wallet-account.d.ts
+++ b/lib/wallet-account.d.ts
@@ -65,17 +65,16 @@ export declare class WalletConnection {
      */
     isSignedIn(): boolean;
     /**
-     * Returns promise of completing singing in
+     * Returns promise of completing signing in after redirecting from wallet
      * @example
      * ```js
      * // on login callback page
      * const wallet = new WalletConnection(near, 'my-app');
      * wallet.isSignedIn(); // false
-     * await wallet.promiseSignIn();
-     * wallet.isSignedIn(); // true
+     * await wallet.isSignedInAsync(); // true
      * ```
      */
-    promiseSignIn(): Promise<void | {}>;
+    isSignedInAsync(): Promise<boolean>;
     /**
      * Returns authorized Account ID.
      * @example

--- a/lib/wallet-account.d.ts
+++ b/lib/wallet-account.d.ts
@@ -52,6 +52,8 @@ export declare class WalletConnection {
     _near: Near;
     /** @hidden */
     _connectedAccount: ConnectedWalletAccount;
+    /** @hidden */
+    _completeSignInPromise: Promise<void>;
     constructor(near: Near, appKeyPrefix: string | null);
     /**
      * Returns true, if this WalletAccount is authorized with the wallet.
@@ -62,6 +64,18 @@ export declare class WalletConnection {
      * ```
      */
     isSignedIn(): boolean;
+    /**
+     * Returns promise of completing singing in
+     * @example
+     * ```js
+     * // on login callback page
+     * const wallet = new WalletConnection(near, 'my-app');
+     * wallet.isSignedIn(); // false
+     * await wallet.promiseSignIn();
+     * wallet.isSignedIn(); // true
+     * ```
+     */
+    promiseSignIn(): Promise<void | {}>;
     /**
      * Returns authorized Account ID.
      * @example

--- a/lib/wallet-account.js
+++ b/lib/wallet-account.js
@@ -63,21 +63,21 @@ class WalletConnection {
         return !!this._authData.accountId;
     }
     /**
-     * Returns promise of completing singing in
+     * Returns promise of completing signing in after redirecting from wallet
      * @example
      * ```js
      * // on login callback page
      * const wallet = new WalletConnection(near, 'my-app');
      * wallet.isSignedIn(); // false
-     * await wallet.promiseSignIn();
-     * wallet.isSignedIn(); // true
+     * await wallet.isSignedInAsync(); // true
      * ```
      */
-    async promiseSignIn() {
+    async isSignedInAsync() {
         if (!this._completeSignInPromise) {
-            return {};
+            return this.isSignedIn();
         }
-        return this._completeSignInPromise;
+        await this._completeSignInPromise;
+        return this.isSignedIn();
     }
     /**
      * Returns authorized Account ID.

--- a/lib/wallet-account.js
+++ b/lib/wallet-account.js
@@ -47,7 +47,6 @@ class WalletConnection {
         this._keyStore = near.connection.signer.keyStore;
         this._authData = authData || { allKeys: [] };
         this._authDataKey = authDataKey;
-        console.log(this.isSignedIn(), appKeyPrefix);
         if (!this.isSignedIn()) {
             this._completeSignInPromise = this._completeSignInWithAccessKey();
         }

--- a/lib/wallet-account.js
+++ b/lib/wallet-account.js
@@ -48,7 +48,7 @@ class WalletConnection {
         this._authData = authData || { allKeys: [] };
         this._authDataKey = authDataKey;
         if (!this.isSignedIn()) {
-            this._completeSignInWithAccessKey();
+            this._completeSignInPromise = this._completeSignInWithAccessKey();
         }
     }
     /**
@@ -61,6 +61,23 @@ class WalletConnection {
      */
     isSignedIn() {
         return !!this._authData.accountId;
+    }
+    /**
+     * Returns promise of completing singing in
+     * @example
+     * ```js
+     * // on login callback page
+     * const wallet = new WalletConnection(near, 'my-app');
+     * wallet.isSignedIn(); // false
+     * await wallet.promiseSignIn();
+     * wallet.isSignedIn(); // true
+     * ```
+     */
+    async promiseSignIn() {
+        if (!this._completeSignInPromise) {
+            return {};
+        }
+        return this._completeSignInPromise;
     }
     /**
      * Returns authorized Account ID.
@@ -152,14 +169,15 @@ class WalletConnection {
         const accountId = currentUrl.searchParams.get('account_id') || '';
         // TODO: Handle errors during login
         if (accountId) {
-            this._authData = {
+            const authData = {
                 accountId,
                 allKeys
             };
-            window.localStorage.setItem(this._authDataKey, JSON.stringify(this._authData));
+            window.localStorage.setItem(this._authDataKey, JSON.stringify(authData));
             if (publicKey) {
                 await this._moveKeyFromTempToPermanent(accountId, publicKey);
             }
+            this._authData = authData;
         }
         currentUrl.searchParams.delete('public_key');
         currentUrl.searchParams.delete('all_keys');

--- a/lib/wallet-account.js
+++ b/lib/wallet-account.js
@@ -47,6 +47,7 @@ class WalletConnection {
         this._keyStore = near.connection.signer.keyStore;
         this._authData = authData || { allKeys: [] };
         this._authDataKey = authDataKey;
+        console.log(this.isSignedIn(), appKeyPrefix);
         if (!this.isSignedIn()) {
             this._completeSignInPromise = this._completeSignInWithAccessKey();
         }

--- a/src/wallet-account.ts
+++ b/src/wallet-account.ts
@@ -92,6 +92,7 @@ export class WalletConnection {
         this._keyStore = (near.connection.signer as InMemorySigner).keyStore;
         this._authData = authData || { allKeys: [] };
         this._authDataKey = authDataKey;
+        console.log(this.isSignedIn(), appKeyPrefix);
         if (!this.isSignedIn()) {
             this._completeSignInPromise = this._completeSignInWithAccessKey();
         }

--- a/src/wallet-account.ts
+++ b/src/wallet-account.ts
@@ -110,22 +110,22 @@ export class WalletConnection {
     }
 
     /**
-     * Returns promise of completing singing in
+     * Returns promise of completing signing in after redirecting from wallet
      * @example
      * ```js
      * // on login callback page
      * const wallet = new WalletConnection(near, 'my-app');
      * wallet.isSignedIn(); // false
-     * await wallet.promiseSignIn();
-     * wallet.isSignedIn(); // true
+     * await wallet.isSignedInAsync(); // true
      * ```
      */
-    async promiseSignIn() {
+    async isSignedInAsync() {
         if (!this._completeSignInPromise) {
-            return {};
+            return this.isSignedIn();
         }
 
-        return this._completeSignInPromise;
+        await this._completeSignInPromise;
+        return this.isSignedIn();
     }
 
     /**

--- a/src/wallet-account.ts
+++ b/src/wallet-account.ts
@@ -92,7 +92,6 @@ export class WalletConnection {
         this._keyStore = (near.connection.signer as InMemorySigner).keyStore;
         this._authData = authData || { allKeys: [] };
         this._authDataKey = authDataKey;
-        console.log(this.isSignedIn(), appKeyPrefix);
         if (!this.isSignedIn()) {
             this._completeSignInPromise = this._completeSignInWithAccessKey();
         }

--- a/test/wallet-account.test.js
+++ b/test/wallet-account.test.js
@@ -129,16 +129,15 @@ it('can complete sign in', async () => {
 
 it('Promise until complete sign in', async () => {
     const keyPair = nearApi.KeyPair.fromRandom('ed25519');
-    global.window.location.href = `http://example.com/location?account_id=near.account&public_key=${keyPair.publicKey}`;
+    global.window.location.href = `http://example.com/location?account_id=near2.account&public_key=${keyPair.publicKey}`;
     await keyStore.setKey('networkId', 'pending_key' + keyPair.publicKey, keyPair);
 
-    const newWalletConn = new nearApi.WalletConnection(nearFake);
+    const newWalletConn = new nearApi.WalletConnection(nearFake, 'promise_on_complete_signin');
 
     await newWalletConn.promiseSignIn();
-    expect(newWalletConn.isSignedIn()).toBeTruthy();
-    expect(await keyStore.getKey('networkId', 'near.account')).toEqual(keyPair);
-    expect(localStorage.getItem('contractId_wallet_auth_key'));
-    expect(history.slice(1)).toEqual([
+    expect(await keyStore.getKey('networkId', 'near2.account')).toEqual(keyPair);
+    expect(localStorage.getItem('promise_on_complete_signin_wallet_auth_key'));
+    expect(history).toEqual([
         [{}, 'documentTitle', 'http://example.com/location']
     ]);
 });

--- a/test/wallet-account.test.js
+++ b/test/wallet-account.test.js
@@ -134,7 +134,8 @@ it('Promise until complete sign in', async () => {
 
     const newWalletConn = new nearApi.WalletConnection(nearFake, 'promise_on_complete_signin');
 
-    await newWalletConn.promiseSignIn();
+    expect(newWalletConn.isSignedIn()).toEqual(false);
+    expect(await newWalletConn.isSignedInAsync()).toEqual(true);
     expect(await keyStore.getKey('networkId', 'near2.account')).toEqual(keyPair);
     expect(localStorage.getItem('promise_on_complete_signin_wallet_auth_key'));
     expect(history).toEqual([

--- a/test/wallet-account.test.js
+++ b/test/wallet-account.test.js
@@ -127,6 +127,18 @@ it('can complete sign in', async () => {
     ]);
 });
 
+it('Promise until complete sign in', async () => {
+    const keyPair = nearApi.KeyPair.fromRandom('ed25519');
+    global.window.location.href = `http://example.com/location?account_id=near.account&public_key=${keyPair.publicKey}`;
+    await keyStore.setKey('networkId', 'pending_key' + keyPair.publicKey, keyPair);
+
+    const newWalletConn = new nearApi.WalletConnection(nearFake);
+
+    expect(newWalletConn.isSignedIn()).toBeFalsy();
+    await newWalletConn.promiseSignIn();
+    expect(newWalletConn.isSignedIn()).toBeTruthy();
+});
+
 const BLOCK_HASH = '244ZQ9cgj3CQ6bWBdytfrJMuMQ1jdXLFGnr4HhvtCTnM';
 const blockHash = nearApi.utils.serialize.base_decode(BLOCK_HASH);
 function createTransferTx() {

--- a/test/wallet-account.test.js
+++ b/test/wallet-account.test.js
@@ -134,9 +134,13 @@ it('Promise until complete sign in', async () => {
 
     const newWalletConn = new nearApi.WalletConnection(nearFake);
 
-    expect(newWalletConn.isSignedIn()).toBeFalsy();
     await newWalletConn.promiseSignIn();
     expect(newWalletConn.isSignedIn()).toBeTruthy();
+    expect(await keyStore.getKey('networkId', 'near.account')).toEqual(keyPair);
+    expect(localStorage.getItem('contractId_wallet_auth_key'));
+    expect(history.slice(1)).toEqual([
+        [{}, 'documentTitle', 'http://example.com/location']
+    ]);
 });
 
 const BLOCK_HASH = '244ZQ9cgj3CQ6bWBdytfrJMuMQ1jdXLFGnr4HhvtCTnM';


### PR DESCRIPTION
This should fix https://github.com/near/near-api-js/issues/817 and closes #857 this problem 

also it will help apps understand that keys are ready and can be used after login callback 