### PR TITLE
Support blockId in account viewFunction and fix viewState

### DIFF
--- a/lib/account.d.ts
+++ b/lib/account.d.ts
@@ -2,7 +2,7 @@
 import BN from 'bn.js';
 import { Action, SignedTransaction } from './transaction';
 import { FinalExecutionOutcome } from './providers';
-import { Finality, BlockId, AccountView, AccessKeyView, AccessKeyInfoView } from './providers/provider';
+import { AccountView, AccessKeyView, AccessKeyInfoView, BlockReference } from './providers/provider';
 import { Connection } from './connection';
 import { PublicKey } from './utils/key_pair';
 export interface AccountBalance {
@@ -66,8 +66,6 @@ export interface FunctionCallOptions {
      */
     stringify?: (input: any) => Buffer;
 }
-declare function parseJsonFromRawResponse(response: Uint8Array): any;
-declare function bytesJsonStringify(input: any): Buffer;
 /**
  * This class provides common account related RPC calls including signing transactions with a {@link KeyPair}.
  *
@@ -205,11 +203,13 @@ export declare class Account {
      * @param args Any arguments to the view contract method, wrapped in JSON
      * @param options.parse Parse the result of the call. Receives a Buffer (bytes array) and converts it to any object. By default result will be treated as json.
      * @param options.stringify Convert input arguments into a bytes array. By default the input is treated as a JSON.
+     * @param options.blockQuery specifies which block to query state at. By default returns last "optimistic" block (i.e. not necessarily finalized).
      * @returns {Promise<any>}
      */
-    viewFunction(contractId: string, methodName: string, args?: any, { parse, stringify }?: {
-        parse?: typeof parseJsonFromRawResponse;
-        stringify?: typeof bytesJsonStringify;
+    viewFunction(contractId: string, methodName: string, args?: any, { parse, stringify, blockQuery }?: {
+        parse?: (response: Uint8Array) => any;
+        stringify?: (input: any) => Buffer;
+        blockQuery?: BlockReference;
     }): Promise<any>;
     /**
      * Returns the state (key value pairs) of this account's contract based on the key prefix.
@@ -219,11 +219,7 @@ export declare class Account {
      * @param prefix allows to filter which keys should be returned. Empty prefix means all keys. String prefix is utf-8 encoded.
      * @param blockQuery specifies which block to query state at. By default returns last "optimistic" block (i.e. not necessarily finalized).
      */
-    viewState(prefix: string | Uint8Array, blockQuery?: {
-        blockId: BlockId;
-    } | {
-        finality: Finality;
-    }): Promise<Array<{
+    viewState(prefix: string | Uint8Array, blockQuery?: BlockReference): Promise<Array<{
         key: Buffer;
         value: Buffer;
     }>>;
@@ -244,4 +240,3 @@ export declare class Account {
      */
     getAccountBalance(): Promise<AccountBalance>;
 }
-export {};

--- a/lib/account.js
+++ b/lib/account.js
@@ -358,17 +358,18 @@ class Account {
      * @param args Any arguments to the view contract method, wrapped in JSON
      * @param options.parse Parse the result of the call. Receives a Buffer (bytes array) and converts it to any object. By default result will be treated as json.
      * @param options.stringify Convert input arguments into a bytes array. By default the input is treated as a JSON.
+     * @param options.blockQuery specifies which block to query state at. By default returns last "optimistic" block (i.e. not necessarily finalized).
      * @returns {Promise<any>}
      */
-    async viewFunction(contractId, methodName, args = {}, { parse = parseJsonFromRawResponse, stringify = bytesJsonStringify } = {}) {
+    async viewFunction(contractId, methodName, args = {}, { parse = parseJsonFromRawResponse, stringify = bytesJsonStringify, blockQuery = { finality: 'optimistic' } } = {}) {
         this.validateArgs(args);
         const serializedArgs = stringify(args).toString('base64');
         const result = await this.connection.provider.query({
             request_type: 'call_function',
+            ...blockQuery,
             account_id: contractId,
             method_name: methodName,
             args_base64: serializedArgs,
-            finality: 'optimistic'
         });
         if (result.logs) {
             this.printLogs(contractId, result.logs);

--- a/lib/providers/json-rpc-provider.js
+++ b/lib/providers/json-rpc-provider.js
@@ -303,6 +303,10 @@ class JsonRpcProvider extends provider_1.Provider {
     async sendJsonRpc(method, params) {
         const response = await exponential_backoff_1.default(REQUEST_RETRY_WAIT, REQUEST_RETRY_NUMBER, REQUEST_RETRY_WAIT_BACKOFF, async () => {
             try {
+                if ('blockId' in params) {
+                    params['block_id'] = params['blockId'];
+                    delete params['blockId'];
+                }
                 const request = {
                     method,
                     params,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "near-api-js",
     "description": "JavaScript library to interact with NEAR Protocol via RPC API",
-    "version": "0.44.2",
+    "version": "0.45.0",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/near/near-api-js.git"

--- a/src/providers/json-rpc-provider.ts
+++ b/src/providers/json-rpc-provider.ts
@@ -348,6 +348,10 @@ export class JsonRpcProvider extends Provider {
     async sendJsonRpc<T>(method: string, params: object): Promise<T> {
         const response = await exponentialBackoff(REQUEST_RETRY_WAIT, REQUEST_RETRY_NUMBER, REQUEST_RETRY_WAIT_BACKOFF, async () => {
             try {
+                if ('blockId' in params) {
+                    params['block_id'] = params['blockId'];
+                    delete params['blockId'];
+                }
                 const request = {
                     method,
                     params,


### PR DESCRIPTION
- Bump to version `0.45.0`
- Support passing `blockQuery` to `viewFunction` in account, so you can make view calls at different height. This is pre-work for near-cli to support passing `--blockId=123` for `near view`. Added test
- Fix `viewState` method to parse `blockQuery` correctly when `blockId` is given.