### PR TITLE
Fix for json-rpc method EXPERIMENTAL_tx_status

### DIFF
--- a/lib/providers/json-rpc-provider.d.ts
+++ b/lib/providers/json-rpc-provider.d.ts
@@ -51,7 +51,7 @@ export declare class JsonRpcProvider extends Provider {
      * @param accountId The NEAR account that signed the transaction
      * @returns {Promise<FinalExecutionOutcome>}
      */
-    txStatusReceipts(txHash: Uint8Array, accountId: string): Promise<FinalExecutionOutcome>;
+    txStatusReceipts(txHash: Uint8Array | string, accountId: string): Promise<FinalExecutionOutcome>;
     /**
      * Query the RPC as [shown in the docs](https://docs.near.org/docs/develop/front-end/rpc#accounts--contracts)
      * Query the RPC by passing an {@link RpcQueryRequest}

--- a/lib/providers/json-rpc-provider.js
+++ b/lib/providers/json-rpc-provider.js
@@ -101,7 +101,12 @@ class JsonRpcProvider extends provider_1.Provider {
      * @returns {Promise<FinalExecutionOutcome>}
      */
     async txStatusReceipts(txHash, accountId) {
-        return this.sendJsonRpc('EXPERIMENTAL_tx_status', [borsh_1.baseEncode(txHash), accountId]);
+        if (typeof txHash === 'string') {
+            return this.sendJsonRpc('EXPERIMENTAL_tx_status', [txHash, accountId]);
+        }
+        else {
+            return this.sendJsonRpc('EXPERIMENTAL_tx_status', [borsh_1.baseEncode(txHash), accountId]);
+        }
     }
     /**
      * Query the RPC as [shown in the docs](https://docs.near.org/docs/develop/front-end/rpc#accounts--contracts)

--- a/lib/providers/provider.d.ts
+++ b/lib/providers/provider.d.ts
@@ -344,7 +344,7 @@ export declare abstract class Provider {
     abstract sendTransaction(signedTransaction: SignedTransaction): Promise<FinalExecutionOutcome>;
     abstract sendTransactionAsync(signedTransaction: SignedTransaction): Promise<FinalExecutionOutcome>;
     abstract txStatus(txHash: Uint8Array | string, accountId: string): Promise<FinalExecutionOutcome>;
-    abstract txStatusReceipts(txHash: Uint8Array, accountId: string): Promise<FinalExecutionOutcome>;
+    abstract txStatusReceipts(txHash: Uint8Array | string, accountId: string): Promise<FinalExecutionOutcome>;
     abstract query<T extends QueryResponseKind>(params: RpcQueryRequest): Promise<T>;
     abstract query<T extends QueryResponseKind>(path: string, data: string): Promise<T>;
     abstract block(blockQuery: BlockId | BlockReference): Promise<BlockResult>;

--- a/src/providers/json-rpc-provider.ts
+++ b/src/providers/json-rpc-provider.ts
@@ -127,8 +127,13 @@ export class JsonRpcProvider extends Provider {
      * @param accountId The NEAR account that signed the transaction
      * @returns {Promise<FinalExecutionOutcome>}
      */
-    async txStatusReceipts(txHash: Uint8Array, accountId: string): Promise<FinalExecutionOutcome> {
-        return this.sendJsonRpc('EXPERIMENTAL_tx_status', [baseEncode(txHash), accountId]);
+    async txStatusReceipts(txHash: Uint8Array | string, accountId: string): Promise<FinalExecutionOutcome> {
+        if (typeof txHash === 'string') {
+            return this.sendJsonRpc('EXPERIMENTAL_tx_status', [txHash, accountId]);
+        }
+        else {
+            return this.sendJsonRpc('EXPERIMENTAL_tx_status', [baseEncode(txHash), accountId]);
+        }
     }
 
     /**

--- a/src/providers/provider.ts
+++ b/src/providers/provider.ts
@@ -412,7 +412,7 @@ export abstract class Provider {
     abstract sendTransaction(signedTransaction: SignedTransaction): Promise<FinalExecutionOutcome>;
     abstract sendTransactionAsync(signedTransaction: SignedTransaction): Promise<FinalExecutionOutcome>;
     abstract txStatus(txHash: Uint8Array | string, accountId: string): Promise<FinalExecutionOutcome>;
-    abstract txStatusReceipts(txHash: Uint8Array, accountId: string): Promise<FinalExecutionOutcome>;
+    abstract txStatusReceipts(txHash: Uint8Array | string, accountId: string): Promise<FinalExecutionOutcome>;
     abstract query<T extends QueryResponseKind>(params: RpcQueryRequest): Promise<T>;
     abstract query<T extends QueryResponseKind>(path: string, data: string): Promise<T>;
     // TODO: BlockQuery type?

--- a/test/providers.test.js
+++ b/test/providers.test.js
@@ -76,6 +76,19 @@ test('txStatus with string hash and buffer hash', withProvider(async(provider) =
     expect(responseWithUint8Array).toMatchObject(outcome);
 }));
 
+test('txStatusReciept with string hash and buffer hash', withProvider(async(provider) => {
+    const near = await testUtils.setUpTestConnection();
+    const sender = await testUtils.createAccount(near);
+    const receiver = await testUtils.createAccount(near);
+    const outcome = await sender.sendMoney(receiver.accountId, new BN('1'));
+    const reciepts = await provider.sendJsonRpc('EXPERIMENTAL_tx_status', [outcome.transaction.hash, sender.accountId]);
+
+    const responseWithString = await provider.txStatusReceipts(outcome.transaction.hash, sender.accountId);
+    const responseWithUint8Array = await provider.txStatusReceipts(base58.decode(outcome.transaction.hash), sender.accountId);
+    expect(responseWithString).toMatchObject(reciepts);
+    expect(responseWithUint8Array).toMatchObject(reciepts);
+}));
+
 test('json rpc query with block_id', withProvider(async(provider) => {
     const stat = await provider.status();
     let block_id = stat.sync_info.latest_block_height - 1;


### PR DESCRIPTION
This MR is fixing a fundamental error in the TS wrapper fro txStatusReceipts which should accept both Uint8Array or string and accordingly execute the EXPERIMENTAL_tx_status JSON rpc request.