### PR TITLE
v0.45.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "near-api-js",
     "description": "JavaScript library to interact with NEAR Protocol via RPC API",
-    "version": "0.45.0",
+    "version": "0.45.1",
     "repository": {
         "type": "git",
         "url": "git+https://github.com/near/near-api-js.git"


### PR DESCRIPTION
Bump version for latest release. NP failed to do it as part of publishing flow.
https://github.com/near/near-api-js/releases/tag/v0.45.1