### PR TITLE
Validate account ID

### DIFF
--- a/lib/utils/account.d.ts
+++ b/lib/utils/account.d.ts
@@ -1,0 +1,2 @@
+export declare const isValidId: (address: string) => boolean;
+export declare const isImplicitAccount: (address: string) => boolean;

--- a/lib/utils/account.js
+++ b/lib/utils/account.js
@@ -1,0 +1,17 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.isImplicitAccount = exports.isValidId = void 0;
+const NAMED_ACCOUNT_ID_REGEX = /^(([a-z\d]+[-_])*[a-z\d]+\.)*([a-z\d]+[-_])*[a-z\d]+$/;
+const IMPLICIT_ACCOUNT_ID_REGEX = /^[a-f0-9]{64}$/;
+/*
+ * Validate a NEAR account ID.
+ */
+exports.isValidId = (address) => {
+    if (exports.isImplicitAccount(address)) {
+        return IMPLICIT_ACCOUNT_ID_REGEX.test(address);
+    }
+    return NAMED_ACCOUNT_ID_REGEX.test(address);
+};
+exports.isImplicitAccount = (address) => {
+    return !address.includes('.');
+};

--- a/lib/utils/index.d.ts
+++ b/lib/utils/index.d.ts
@@ -4,6 +4,7 @@ import * as web from './web';
 import * as enums from './enums';
 import * as format from './format';
 import * as rpc_errors from './rpc_errors';
+import * as account from './account';
 import { PublicKey, KeyPair, KeyPairEd25519 } from './key_pair';
 import { logWarning } from './errors';
-export { key_pair, serialize, web, enums, format, PublicKey, KeyPair, KeyPairEd25519, rpc_errors, logWarning, };
+export { key_pair, serialize, web, enums, format, PublicKey, KeyPair, KeyPairEd25519, rpc_errors, logWarning, account };

--- a/lib/utils/index.js
+++ b/lib/utils/index.js
@@ -19,7 +19,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.logWarning = exports.rpc_errors = exports.KeyPairEd25519 = exports.KeyPair = exports.PublicKey = exports.format = exports.enums = exports.web = exports.serialize = exports.key_pair = void 0;
+exports.account = exports.logWarning = exports.rpc_errors = exports.KeyPairEd25519 = exports.KeyPair = exports.PublicKey = exports.format = exports.enums = exports.web = exports.serialize = exports.key_pair = void 0;
 const key_pair = __importStar(require("./key_pair"));
 exports.key_pair = key_pair;
 const serialize = __importStar(require("./serialize"));
@@ -32,6 +32,8 @@ const format = __importStar(require("./format"));
 exports.format = format;
 const rpc_errors = __importStar(require("./rpc_errors"));
 exports.rpc_errors = rpc_errors;
+const account = __importStar(require("./account"));
+exports.account = account;
 const key_pair_1 = require("./key_pair");
 Object.defineProperty(exports, "PublicKey", { enumerable: true, get: function () { return key_pair_1.PublicKey; } });
 Object.defineProperty(exports, "KeyPair", { enumerable: true, get: function () { return key_pair_1.KeyPair; } });

--- a/src/utils/account.ts
+++ b/src/utils/account.ts
@@ -1,0 +1,17 @@
+const NAMED_ACCOUNT_ID_REGEX =  /^(([a-z\d]+[-_])*[a-z\d]+\.)*([a-z\d]+[-_])*[a-z\d]+$/;
+const IMPLICIT_ACCOUNT_ID_REGEX = /^[a-f0-9]{64}$/;
+
+/*
+ * Validate a NEAR account ID.
+ */
+export const isValidId = (address: string): boolean => {
+    if (isImplicitAccount(address)) {
+        return IMPLICIT_ACCOUNT_ID_REGEX.test(address);
+    }
+
+    return NAMED_ACCOUNT_ID_REGEX.test(address);
+};
+
+export const isImplicitAccount = (address: string): boolean => {
+    return !address.includes('.');
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -5,6 +5,7 @@ import * as web from './web';
 import * as enums from './enums';
 import * as format from './format';
 import * as rpc_errors from './rpc_errors';
+import * as account from './account';
 
 import { PublicKey, KeyPair, KeyPairEd25519 } from './key_pair';
 import { logWarning } from './errors';
@@ -20,4 +21,5 @@ export {
     KeyPairEd25519,
     rpc_errors,
     logWarning,
+    account
 };

--- a/test/utils/account.test.js
+++ b/test/utils/account.test.js
@@ -1,0 +1,15 @@
+const nearApi = require('../../src/index');
+const { account } = nearApi.utils;
+
+describe('account', () => {
+    test('named account', async () => {
+        const accountId = 'test.near';
+        const result = account.isValidId(accountId);
+        expect(result).toBe(true);
+    });
+    test('implicit account', async () => {
+        const accountId = '46abe81b0ef0ff938f95d1347c93e3cfdd4eab5baa773b634d90f510581fc085';
+        const result = account.isValidId(accountId);
+        expect(result).toBe(true);
+    });
+});


### PR DESCRIPTION
While working on a NEAR integration, couldn't find any re-usable account ID validator. This will handle validating both implicit and named accounts, and the named account regex was re-used from the NEAR wallet: https://github.com/near/near-wallet/blob/565b9e05471098c27134caa1d26f671cf9bc60e8/packages/frontend/src/utils/wallet.js#L69

Please let me know if there's a better place for this or if I've missed anything, thanks!