### PR TITLE
refactor(near-api-js): getAccountId() returns a string.

### DIFF
--- a/packages/near-api-js/src/wallet-account.ts
+++ b/packages/near-api-js/src/wallet-account.ts
@@ -154,7 +154,7 @@ export class WalletConnection {
      * wallet.getAccountId();
      * ```
      */
-    getAccountId() {
+    getAccountId() : string {
         return this._authData.accountId || '';
     }
 

--- a/packages/near-api-js/src/wallet-account.ts
+++ b/packages/near-api-js/src/wallet-account.ts
@@ -68,7 +68,7 @@ export class WalletConnection {
     _keyStore: KeyStore;
 
     /** @hidden */
-    _authData: any;
+    _authData: { accountId?: string; allKeys?: string[] };
 
     /** @hidden */
     _networkId: string;
@@ -154,7 +154,7 @@ export class WalletConnection {
      * wallet.getAccountId();
      * ```
      */
-    getAccountId() : string {
+    getAccountId() {
         return this._authData.accountId || '';
     }
 


### PR DESCRIPTION
According to this (https://docs.near.org/docs/tutorials/front-end/naj-examples#the-wallet-interface) getAccountId() should return a string.