### PR TITLE
feat: explicit walletconnection errors on server

### DIFF
--- a/packages/near-api-js/src/wallet-account.ts
+++ b/packages/near-api-js/src/wallet-account.ts
@@ -44,6 +44,7 @@ interface RequestSignTransactionsOptions {
 /**
  * This class is used in conjunction with the {@link BrowserLocalStorageKeyStore}.
  * It redirects users to {@link https://docs.near.org/docs/tools/near-wallet | NEAR Wallet} for key management.
+ * This class is not intended for use outside the browser. Without `window` (i.e. in server contexts), it will instantiate but will throw a clear error when used.
  * 
  * @example {@link https://docs.near.org/docs/develop/front-end/naj-quick-reference#wallet}
  * @example

--- a/packages/near-api-js/src/wallet-account.ts
+++ b/packages/near-api-js/src/wallet-account.ts
@@ -82,6 +82,24 @@ export class WalletConnection {
     _completeSignInPromise: Promise<void>;
 
     constructor(near: Near, appKeyPrefix: string | null) {
+        if(typeof window === 'undefined') {
+            return new Proxy(this, {
+                get(target, property) {
+                    if(property === 'isSignedIn') {
+                        return () => false;
+                    }
+                    if(property === 'getAccountId') {
+                        return () => '';
+                    }
+                    if(target[property] && typeof target[property] === 'function') {
+                        return () => {
+                            throw new Error('No window found in context, please ensure you are using WalletConnection on the browser');
+                        };
+                    }
+                    return target[property];
+                }
+            });
+        }
         this._near = near;
         const authDataKey = appKeyPrefix + LOCAL_STORAGE_KEY_SUFFIX;
         const authData = JSON.parse(window.localStorage.getItem(authDataKey));

--- a/packages/near-api-js/test/wallet-account.test.js
+++ b/packages/near-api-js/test/wallet-account.test.js
@@ -57,6 +57,43 @@ it('not signed in by default', () => {
     expect(walletConnection.isSignedIn()).not.toBeTruthy();
 });
 
+describe('fails gracefully on the server side (without window)', () => {
+    const windowValueBefore = global.window;
+
+    beforeEach(() => {
+        global.window = undefined;
+        keyStore.clear();
+    });
+
+    afterEach(() => {
+        global.window = windowValueBefore;
+    });
+
+    it('does not throw on instantiation', () => {
+        expect(() => new nearApi.WalletConnection(nearFake)).not.toThrowError();
+    });
+
+    it('returns an empty string as accountId', () => {
+        const serverWalletConnection = new nearApi.WalletConnection(nearFake);
+        expect(serverWalletConnection.getAccountId()).toEqual('');
+    });
+
+    it('returns false as isSignedIn', () => {
+        const serverWalletConnection = new nearApi.WalletConnection(nearFake);
+        expect(serverWalletConnection.isSignedIn()).toEqual(false);
+    });
+
+    it('throws explicit error when calling other methods on the instance', () => {
+        const serverWalletConnection = new nearApi.WalletConnection(nearFake);
+        expect(() => serverWalletConnection.requestSignIn('signInContract', 'signInTitle', 'http://example.com/success',  'http://example.com/fail')).toThrow(/please ensure you are using WalletConnection on the browser/);
+    });
+
+    it('can access other props on the instance', () => {
+        const serverWalletConnection = new nearApi.WalletConnection(nearFake);
+        expect(serverWalletConnection['randomValue']).toEqual(undefined);
+    });
+});
+
 describe('can request sign in', () => {
     beforeEach(() => keyStore.clear());
     


### PR DESCRIPTION
This PR attempts to address server side devX for the `WalletConnection` class per #801 by returning a proxy that intercepts gets on the instance and throws an explicit error if it's a function call or returns predictable values preventing unpredictable errors and behaviors on SSR stacks and Node.js.