### PR TITLE
ci: Publish lerna packages on push to `master`

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,17 @@
+name: Code checks
+
+on:
+  workflow_call:
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+          cache: 'yarn'
+      - run: yarn install --frozen-lockfile
+      - run: yarn lint
+      - run: yarn test

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
 
 jobs:
-  checks:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -14,4 +14,14 @@ jobs:
           cache: 'yarn'
       - run: yarn install --frozen-lockfile
       - run: yarn lint
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16.x
+          cache: 'yarn'
+      - run: yarn install --frozen-lockfile
       - run: yarn test

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -1,0 +1,34 @@
+name: Publish Packages
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Setup Node
+      uses: actions/setup-node@v3
+      with:
+        node-version: 16.x
+        cache: yarn
+        registry-url: https://registry.npmjs.org
+
+    - name: Install dependencies
+      run: lerna bootstrap
+
+    - name: Publish packages
+      run: |
+        git config user.email "wallet@near.org"
+        git config user.name "CI"
+        lerna publish
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -6,7 +6,11 @@ on:
       - master
 
 jobs:
+  checks:
+    uses: ./.github/workflows/checks.yml
+
   publish:
+    needs: checks
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -35,6 +35,9 @@ jobs:
     - name: Install dependencies
       run: yarn --frozen-lockfile
 
+    - name: Build packages
+      run: lerna build
+
     - name: Publish packages
       run: lerna publish
       env:

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -12,6 +12,7 @@ jobs:
   publish:
     needs: checks
     runs-on: ubuntu-latest
+    environment: NPM
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -22,13 +22,15 @@ jobs:
         cache: yarn
         registry-url: https://registry.npmjs.org
 
+    - name: Configure Git user
+      run: |
+        git config user.email "<>"
+        git config user.name "Github Actions Bot"
+
     - name: Install dependencies
       run: lerna bootstrap
 
     - name: Publish packages
-      run: |
-        git config user.email "wallet@near.org"
-        git config user.name "CI"
-        lerna publish
+      run: lerna publish
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -28,7 +28,7 @@ jobs:
         git config user.name "Github Actions Bot"
 
     - name: Install dependencies
-      run: lerna bootstrap
+      run: yarn --frozen-lockfile
 
     - name: Publish packages
       run: lerna publish

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -11,23 +11,4 @@ concurrency:
 
 jobs:
   checks:
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
-
-    - name: Setup Node
-      uses: actions/setup-node@v3
-      with:
-        node-version: 16.x
-        cache: 'yarn'
-
-    - name: Install dependencies
-      run: yarn --frozen-lockfile
-
-    - name: Run lint
-      run: yarn lint
-
-    - name: Run tests
-      run: yarn test
+    uses: ./.github/workflows/checks.yml

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,6 +1,5 @@
 module.exports = {
     extends: [
-        '@commitlint/config-conventional',
-        '@commitlint/config-lerna-scopes',
+        '@commitlint/config-conventional'
     ],
 };

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,16 @@
 {
   "npmClient": "yarn",
   "version": "independent",
-  "useWorkspaces": true
+  "useWorkspaces": true,
+  "changelogPreset": "conventionalcommits",
+  "command": {
+    "version": {
+      "conventionalCommits": true,
+      "message": "chore(release): publish packages",
+      "allowBranch": "master"
+    },
+    "publish": {
+      "yes": true
+    }
+  }
 }

--- a/lerna.json
+++ b/lerna.json
@@ -3,6 +3,7 @@
   "version": "independent",
   "useWorkspaces": true,
   "changelogPreset": "conventionalcommits",
+  "ignoreChanges": ["**/test/**"],
   "command": {
     "version": {
       "conventionalCommits": true,

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "clean": "yarn lerna run clean",
     "lint": "yarn lerna run lint --stream",
     "test": "yarn lerna run test --stream --concurrency 1",
-    "browserify": "yarn lerna run browserify",
     "bundlewatch": "yarn lerna exec yarn run bundlewatch",
     "release": "yarn lerna version --conventional-commits",
     "prepare": "yarn husky install && yarn lerna run prepare"

--- a/packages/near-api-js/package.json
+++ b/packages/near-api-js/package.json
@@ -50,11 +50,10 @@
     "scripts": {
         "dist": "yarn browserify && yarn doc",
         "browserify": "browserify browser-exports.js -i node-fetch -i http -i https -o dist/near-api-js.js && browserify browser-exports.js -i node-fetch -g uglifyify -o dist/near-api-js.min.js",
-        "prebrowserify": "yarn build",
         "compile": "tsc -p ./tsconfig.json",
         "dev": "yarn compile -w",
         "doc": "typedoc src && touch docs/.nojekyll",
-        "build": "yarn compile",
+        "build": "yarn compile && yarn browserify",
         "test": "jest test",
         "lint": "concurrently \"yarn:lint:*(!fix)\"",
         "lint:src": "eslint --ext .ts src",
@@ -65,7 +64,7 @@
         "prefuzz": "yarn build",
         "fuzz": "jsfuzz test/fuzz/borsh-roundtrip.js test/fuzz/corpus/",
         "clean": "yarn rimraf lib",
-        "prepare": "yarn build && yarn browserify"
+        "prepare": "yarn build"
     },
     "bundlewatch": {
         "files": [


### PR DESCRIPTION
This PR adds a Github Action for publishing Lerna packages to NPM. With the proposed Lerna configuration the publishing pipeline will determine version bumps and generate `CHANGELOG.md` files per package using the [conventionalcommits](https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-conventionalcommits) specification.

Note that this pipeline only supports publishing packages to a **single** account. With the intention to split `near-api-js` in to multiple scoped packages, which will need to published to a different account, we'll need to update this pipeline to support publishing to multiple accounts.

Closes: #753