### PR TITLE
Update error throws on signTransaction

### DIFF
--- a/lib/account.js
+++ b/lib/account.js
@@ -176,7 +176,7 @@ class Account {
         // TODO: Find matching access key based on transaction (i.e. receiverId and actions)
         const publicKey = await this.connection.signer.getPublicKey(this.accountId, this.connection.networkId);
         if (!publicKey) {
-            throw new providers_1.TypedError('Could not find public key in keystore for this accountId.', 'KeyNotFound');
+            throw new providers_1.TypedError(`Can not sign transactions. Could not find public key in keystore for this accountId ${this.accountId}`, 'PublicKeyNotFound');
         }
         const cachedAccessKey = this.accessKeyByPublicKeyCache[publicKey.toString()];
         if (cachedAccessKey !== undefined) {
@@ -195,9 +195,6 @@ class Account {
             // the cached access key.
             if (this.accessKeyByPublicKeyCache[publicKey.toString()]) {
                 return { publicKey, accessKey: this.accessKeyByPublicKeyCache[publicKey.toString()] };
-            }
-            if (!accessKey) {
-                throw new providers_1.TypedError('Could not find access key, check keystore entries or account id access keys', 'KeyNotFound');
             }
             this.accessKeyByPublicKeyCache[publicKey.toString()] = accessKey;
             return { publicKey, accessKey };

--- a/lib/account.js
+++ b/lib/account.js
@@ -90,7 +90,7 @@ class Account {
     async signTransaction(receiverId, actions) {
         const accessKeyInfo = await this.findAccessKey(receiverId, actions);
         if (!accessKeyInfo) {
-            throw new providers_1.TypedError(`Can not sign transactions for account ${this.accountId} on network ${this.connection.networkId}, no matching key pair found in ${this.connection.signer}.`, 'KeyNotFound');
+            throw new providers_1.TypedError(`Can not sign transactions for account ${this.accountId} on network ${this.connection.networkId}, no matching key pair exists for this account`, 'KeyNotFound');
         }
         const { accessKey } = accessKeyInfo;
         const block = await this.connection.provider.block({ finality: 'final' });
@@ -176,7 +176,7 @@ class Account {
         // TODO: Find matching access key based on transaction (i.e. receiverId and actions)
         const publicKey = await this.connection.signer.getPublicKey(this.accountId, this.connection.networkId);
         if (!publicKey) {
-            throw new providers_1.TypedError(`Can not sign transactions. Could not find public key in keystore for this accountId ${this.accountId}`, 'PublicKeyNotFound');
+            throw new providers_1.TypedError(`no matching key pair found in ${this.connection.signer}`, 'PublicKeyNotFound');
         }
         const cachedAccessKey = this.accessKeyByPublicKeyCache[publicKey.toString()];
         if (cachedAccessKey !== undefined) {

--- a/lib/account.js
+++ b/lib/account.js
@@ -176,7 +176,7 @@ class Account {
         // TODO: Find matching access key based on transaction (i.e. receiverId and actions)
         const publicKey = await this.connection.signer.getPublicKey(this.accountId, this.connection.networkId);
         if (!publicKey) {
-            return null;
+            throw new providers_1.TypedError('Could not find public key in keystore for this accountId.', 'KeyNotFound');
         }
         const cachedAccessKey = this.accessKeyByPublicKeyCache[publicKey.toString()];
         if (cachedAccessKey !== undefined) {
@@ -195,6 +195,9 @@ class Account {
             // the cached access key.
             if (this.accessKeyByPublicKeyCache[publicKey.toString()]) {
                 return { publicKey, accessKey: this.accessKeyByPublicKeyCache[publicKey.toString()] };
+            }
+            if (!accessKey) {
+                throw new providers_1.TypedError('Could not find access key, check keystore entries or account id access keys', 'KeyNotFound');
             }
             this.accessKeyByPublicKeyCache[publicKey.toString()] = accessKey;
             return { publicKey, accessKey };

--- a/src/account.ts
+++ b/src/account.ts
@@ -313,7 +313,7 @@ export class Account {
         // TODO: Find matching access key based on transaction (i.e. receiverId and actions)
         const publicKey = await this.connection.signer.getPublicKey(this.accountId, this.connection.networkId);
         if (!publicKey) {
-            throw new TypedError('Could not find public key in keystore for this accountId.', 'KeyNotFound');
+            throw new TypedError(`Can not sign transactions. Could not find public key in keystore for this accountId ${this.accountId}`, 'PublicKeyNotFound');
         }
 
         const cachedAccessKey = this.accessKeyByPublicKeyCache[publicKey.toString()];
@@ -335,10 +335,6 @@ export class Account {
             // the cached access key.
             if(this.accessKeyByPublicKeyCache[publicKey.toString()]) {
                 return { publicKey, accessKey: this.accessKeyByPublicKeyCache[publicKey.toString()] };
-            }
-
-            if (!accessKey) {
-                throw new TypedError('Could not find access key, check keystore entries or account id access keys', 'KeyNotFound');
             }
 
             this.accessKeyByPublicKeyCache[publicKey.toString()] = accessKey;

--- a/src/account.ts
+++ b/src/account.ts
@@ -201,7 +201,7 @@ export class Account {
     protected async signTransaction(receiverId: string, actions: Action[]): Promise<[Uint8Array, SignedTransaction]> {
         const accessKeyInfo = await this.findAccessKey(receiverId, actions);
         if (!accessKeyInfo) {
-            throw new TypedError(`Can not sign transactions for account ${this.accountId} on network ${this.connection.networkId}, no matching key pair found in ${this.connection.signer}.`, 'KeyNotFound');
+            throw new TypedError(`Can not sign transactions for account ${this.accountId} on network ${this.connection.networkId}, no matching key pair exists for this account`, 'KeyNotFound');
         }
         const { accessKey } = accessKeyInfo;
 
@@ -313,7 +313,7 @@ export class Account {
         // TODO: Find matching access key based on transaction (i.e. receiverId and actions)
         const publicKey = await this.connection.signer.getPublicKey(this.accountId, this.connection.networkId);
         if (!publicKey) {
-            throw new TypedError(`Can not sign transactions. Could not find public key in keystore for this accountId ${this.accountId}`, 'PublicKeyNotFound');
+            throw new TypedError(`no matching key pair found in ${this.connection.signer}`, 'PublicKeyNotFound');
         }
 
         const cachedAccessKey = this.accessKeyByPublicKeyCache[publicKey.toString()];

--- a/src/account.ts
+++ b/src/account.ts
@@ -313,7 +313,7 @@ export class Account {
         // TODO: Find matching access key based on transaction (i.e. receiverId and actions)
         const publicKey = await this.connection.signer.getPublicKey(this.accountId, this.connection.networkId);
         if (!publicKey) {
-            return null;
+            throw new TypedError('Could not find public key in keystore for this accountId.', 'KeyNotFound');
         }
 
         const cachedAccessKey = this.accessKeyByPublicKeyCache[publicKey.toString()];
@@ -335,6 +335,10 @@ export class Account {
             // the cached access key.
             if(this.accessKeyByPublicKeyCache[publicKey.toString()]) {
                 return { publicKey, accessKey: this.accessKeyByPublicKeyCache[publicKey.toString()] };
+            }
+
+            if (!accessKey) {
+                throw new TypedError('Could not find access key, check keystore entries or account id access keys', 'KeyNotFound');
             }
 
             this.accessKeyByPublicKeyCache[publicKey.toString()] = accessKey;

--- a/test/account.access_key.test.js
+++ b/test/account.access_key.test.js
@@ -86,3 +86,15 @@ test('loading account after adding a full key', async() => {
     expect(addedKey).toBeTruthy();
     expect(addedKey.access_key.permission).toEqual('FullAccess');
 });
+
+test('load invalid key pair', async() => {
+    // Override in the key store with invalid key pair
+    await nearjs.connection.signer.keyStore.setKey(testUtils.networkId, workingAccount.accountId, '');
+    try {
+        await contract.setValue({ args: { value: 'test' } });
+        fail('should throw an error');
+    } catch (e) {
+        expect(e.message).toEqual(`Can not sign transactions. Could not find public key in keystore for this accountId ${workingAccount.accountId}`);
+        expect(e.type).toEqual('PublicKeyNotFound');
+    }
+});

--- a/test/account.access_key.test.js
+++ b/test/account.access_key.test.js
@@ -40,11 +40,7 @@ test('remove access key no longer works', async() => {
         await contract.setValue({ args: { value: 'test' } });
         fail('should throw an error');
     } catch (e) {
-        if (process.env.NODE_ENV == 'local') {
-            expect(e.message).toEqual(`Can not sign transactions for account ${workingAccount.accountId} on network unittest, no matching key pair found in InMemorySigner(MergeKeyStore(InMemoryKeyStore, InMemoryKeyStore)).`);
-        } else {
-            expect(e.message).toEqual(`Can not sign transactions for account ${workingAccount.accountId} on network unittest, no matching key pair found in InMemorySigner(InMemoryKeyStore).`);
-        }
+        expect(e.message).toEqual(`Can not sign transactions for account ${workingAccount.accountId} on network ${testUtils.networkId}, no matching key pair exists for this account`);
         expect(e.type).toEqual('KeyNotFound');
     }
 });
@@ -94,7 +90,7 @@ test('load invalid key pair', async() => {
         await contract.setValue({ args: { value: 'test' } });
         fail('should throw an error');
     } catch (e) {
-        expect(e.message).toEqual(`Can not sign transactions. Could not find public key in keystore for this accountId ${workingAccount.accountId}`);
+        expect(e.message).toEqual(`no matching key pair found in ${nearjs.connection.signer}`);
         expect(e.type).toEqual('PublicKeyNotFound');
     }
 });


### PR DESCRIPTION
## Motivation
[Issue-618](https://github.com/near/near-api-js/issues/618)

## Description
Added more tailored error throws on `signTransaction`  where if depends on either `publicKey` or `accessKey` is missing, throw error with mentioning which one is missing.

## Reproduce
1. Make sure that near-cli is installed but logged out state.
2. Change `require("near-api-js");` to `require("../../../lib/index");` on `examples/cookbook/transactions/batch-transactions.js`
3. Run this commend from root:

```
yarn run build
cd examples/cookbook/transactions
node batch-transactions.js
```

## Checklist
- [x] Read the [contributing](https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md) guidelines
- [x] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [ ] Performed a self-review of the PR
- [x] Added automated tests
- [x] Manually tested the change
