### PR TITLE
Applied engines property on package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@near-api-js/monorepo",
   "private": true,
+  "engines": {
+    "node": ">=16.16.0"
+  },
   "workspaces": {
     "packages": [
       "packages/*"


### PR DESCRIPTION
## Motivation
Provide transparency for the users, which version of node runtime you support

## Description
Updated `engines` property inside package.json with node version greater or equal to 16.16.0 to be enforced. 

## Checklist
- [x] Read the [contributing](https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md) guidelines
- [x] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [ ] Performed a self-review of the PR
- [ ] Added automated tests
- [x] Manually tested the change
