### PR TITLE
refactor!: Make `walletUrl` required for `Near`

### DIFF
--- a/packages/near-api-js/src/near.ts
+++ b/packages/near-api-js/src/near.ts
@@ -61,7 +61,7 @@ export interface NearConfig {
      * NEAR wallet url used to redirect users to their wallet in browser applications.
      * @see {@link https://docs.near.org/docs/tools/near-wallet}
      */
-    walletUrl?: string;
+    walletUrl: string;
 
     /**
      * JVSM account ID for NEAR JS SDK
@@ -82,6 +82,10 @@ export class Near {
     readonly accountCreator: AccountCreator;
 
     constructor(config: NearConfig) {
+        if (!config.walletUrl) {
+            throw new Error('walletUrl is required but was not supplied');
+        }
+
         this.config = config;
         this.connection = Connection.fromConfig({
             networkId: config.networkId,

--- a/packages/near-api-js/test/config.js
+++ b/packages/near-api-js/test/config.js
@@ -37,6 +37,7 @@ module.exports = function getConfig(env) {
             networkId: 'shared-test',
             nodeUrl: 'https://rpc.ci-testnet.near.org',
             masterAccount: 'test.near',
+            walletUrl: 'https://wallet.testnet.near.org',
         };
     default:
         throw Error(`Unconfigured environment '${env}'. Can be configured in src/config.js.`);

--- a/packages/near-api-js/test/near.test.js
+++ b/packages/near-api-js/test/near.test.js
@@ -1,0 +1,13 @@
+const { Near } = require('../src/index');
+const getConfig = require('./config');
+
+describe('Near', () => {
+    test('throws if walletUrl is not defined', async() => {
+        expect(() => new Near({})).toThrow('walletUrl is required but was not supplied');
+    });
+
+    test('instantiates successfully', () => {
+        const near = new Near(getConfig('test'));
+        expect(near).toBeDefined();
+    });
+});


### PR DESCRIPTION
## Motivation
`walletUrl` is currently optional and can cause failures when not defined.

## Description
This PR updates the TS types to make `walletUrl` required.

## Checklist
- [x] Read the [contributing](https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md) guidelines
- [x] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [x] Performed a self-review of the PR
- [ ] Added automated tests
- [x] Manually tested the change
