### PR TITLE
feat: changed viewFuction to support both POJO and existing arguments

### DIFF
--- a/packages/near-api-js/src/account.ts
+++ b/packages/near-api-js/src/account.ts
@@ -482,7 +482,26 @@ export class Account {
      * @param options.blockQuery specifies which block to query state at. By default returns last "optimistic" block (i.e. not necessarily finalized).
      * @returns {Promise<any>}
      */
-    async viewFunction(
+
+    async viewFunction(obj : any, ...restArgs: any[]) {
+        if (restArgs.length === 0) {
+            const {
+                contractId,
+                methodName,
+                args,
+                options,
+            } = obj;
+            return await this.viewFunctionCall(contractId, methodName, args, options);
+        } else {
+            const contractId = obj;
+            const methodName = restArgs[0];
+            const args = restArgs[1];
+            const options = restArgs[2];
+            return await this.viewFunctionCall(contractId, methodName, args, options);
+        }
+    }
+
+    async viewFunctionCall(
         contractId: string,
         methodName: string,
         args: any = {},

--- a/packages/near-api-js/test/account.test.js
+++ b/packages/near-api-js/test/account.test.js
@@ -298,4 +298,13 @@ describe('with deploy contract', () => {
             args: { name: 'world' }
         })).toEqual('hello world');
     });
+
+    test('make viewFunction call with object format', async() => {
+        const result = await workingAccount.viewFunction({
+            contractId,
+            methodName: 'hello', // this is the function defined in hello.wasm file that we are calling
+            args: {name: 'trex'},
+        });
+        expect(result).toEqual('hello trex');
+    });
 });

--- a/packages/near-api-js/test/account.test.js
+++ b/packages/near-api-js/test/account.test.js
@@ -303,7 +303,7 @@ describe('with deploy contract', () => {
         const result = await workingAccount.viewFunction({
             contractId,
             methodName: 'hello', // this is the function defined in hello.wasm file that we are calling
-            args: {name: 'trex'},
+            args: { name: 'trex' },
         });
         expect(result).toEqual('hello trex');
     });


### PR DESCRIPTION
## Motivation
[Issue-627](https://github.com/near/near-api-js/issues/627)
Users wanting to use `viewFunction` call as if they are using `functionCall`.
By passing single object that contains all arguments as props. This is actually standard practice compared to passing multiple props in specific order. 

## Description
Created adapter layer where depends on the format of given arguments, it either deconstruct from object (new approach) or passing given arguments as it is (existing approach)


## Checklist
- [x] Read the [contributing](https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md) guidelines
- [x] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [ ] Performed a self-review of the PR
- [x] Added automated tests
- [ ] Manually tested the change
