### PR TITLE
feat: signAndSendBundledActions method added to expose the signAndSen…

### DIFF
--- a/packages/near-api-js/src/account.ts
+++ b/packages/near-api-js/src/account.ts
@@ -209,6 +209,14 @@ export class Account {
     }
 
     /**
+     * Sign a transaction to perform a list of actions and broadcast it using the RPC API.
+     * @see {@link JsonRpcProvider.sendTransaction}
+     */
+    signAndSendBundledActions(options: SignAndSendTransactionOptions): Promise<FinalExecutionOutcome> {
+        return this.signAndSendTransaction(options);
+    }
+
+    /**
      * Sign a transaction to preform a list of actions and broadcast it using the RPC API.
      * @see {@link JsonRpcProvider.sendTransaction}
      */

--- a/packages/near-api-js/src/account_multisig.ts
+++ b/packages/near-api-js/src/account_multisig.ts
@@ -62,6 +62,14 @@ export class AccountMultisig extends Account {
         return super.signAndSendTransaction({ receiverId, actions });
     }
 
+    /**
+     * Sign a transaction to perform a list of actions and broadcast it using the RPC API.
+     * @see {@link JsonRpcProvider.sendTransaction}
+     */
+    signAndSendBundledActions(options: SignAndSendTransactionOptions): Promise<FinalExecutionOutcome> {
+        return this.signAndSendTransaction(options);
+    }
+
     protected async signAndSendTransaction({ receiverId, actions }: SignAndSendTransactionOptions): Promise<FinalExecutionOutcome> {
         const { accountId } = this;
 
@@ -228,6 +236,14 @@ export class Account2FA extends AccountMultisig {
         this.getCode = options.getCode || this.getCodeDefault;
         this.verifyCode = options.verifyCode || this.verifyCodeDefault;
         this.onConfirmResult = options.onConfirmResult;
+    }
+
+    /**
+     * Sign a transaction to perform a list of actions and broadcast it using the RPC API.
+     * @see {@link JsonRpcProvider.sendTransaction}
+     */
+    signAndSendBundledActions(options: SignAndSendTransactionOptions): Promise<FinalExecutionOutcome> {
+        return this.signAndSendTransaction(options);
     }
 
     /**

--- a/packages/near-api-js/src/wallet-account.ts
+++ b/packages/near-api-js/src/wallet-account.ts
@@ -290,6 +290,14 @@ export class ConnectedWalletAccount extends Account {
     // Overriding Account methods
 
     /**
+     * Sign a transaction to perform a list of actions and broadcast it using the RPC API.
+     * @see {@link JsonRpcProvider.sendTransaction}
+     */
+    signAndSendBundledActions(options: SignAndSendTransactionOptions): Promise<FinalExecutionOutcome> {
+        return this.signAndSendTransaction(options);
+    }
+
+    /**
      * Sign a transaction by redirecting to the NEAR Wallet
      * @see {@link WalletConnection.requestSignTransactions}
      */

--- a/packages/near-api-js/test/account.test.js
+++ b/packages/near-api-js/test/account.test.js
@@ -3,6 +3,7 @@ const { Account, Contract, providers } = require('../src/index');
 const testUtils  = require('./test-utils');
 const fs = require('fs');
 const BN = require('bn.js');
+const { transfer } = require('../src/transaction');
 
 let nearjs;
 let workingAccount;
@@ -41,6 +42,15 @@ test('send money', async() => {
     const receiver = await testUtils.createAccount(nearjs);
     const { amount: receiverAmount } = await receiver.state();
     await sender.sendMoney(receiver.accountId, new BN(10000));
+    const state = await receiver.state();
+    expect(state.amount).toEqual(new BN(receiverAmount).add(new BN(10000)).toString());
+});
+
+test('send money through signAndSendBundledActions', async() => {
+    const sender = await testUtils.createAccount(nearjs);
+    const receiver = await testUtils.createAccount(nearjs);
+    const { amount: receiverAmount } = await receiver.state();
+    await sender.signAndSendBundledActions({receiverId: receiver.accountId, actions: [transfer(new BN(10000))]});
     const state = await receiver.state();
     expect(state.amount).toEqual(new BN(receiverAmount).add(new BN(10000)).toString());
 });

--- a/packages/near-api-js/test/account_multisig.test.js
+++ b/packages/near-api-js/test/account_multisig.test.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const BN = require('bn.js');
 const testUtils  = require('./test-utils');
 const semver = require('semver');
+const { transfer } = require('../src/transaction');
 
 let nearjs;
 let startFromVersion;
@@ -119,5 +120,16 @@ describe('account2fa transactions', () => {
         const state = await receiver.state();
         expect(BigInt(state.amount)).toBeGreaterThanOrEqual(BigInt(new BN(receiverAmount).add(new BN(parseNearAmount('0.9'))).toString()));
     });
-    
+
+    test('send money through signAndSendBundledActions', async() => {
+        let sender = await testUtils.createAccount(nearjs);
+        let receiver = await testUtils.createAccount(nearjs);
+        sender = await getAccount2FA(sender);
+        receiver = await getAccount2FA(receiver);
+        const { amount: receiverAmount } = await receiver.state();
+        await sender.signAndSendBundledActions({receiverId: receiver.accountId, actions: [transfer(new BN(parseNearAmount('1')))]});
+        const state = await receiver.state();
+        expect(BigInt(state.amount)).toBeGreaterThanOrEqual(BigInt(new BN(receiverAmount).add(new BN(parseNearAmount('0.9'))).toString()));
+    });
+        
 });


### PR DESCRIPTION
signAndSendBundledActions method added

## Motivation
NAJ-44

## Description
signAndSendBundledActions method added to expose the functionality of signAndSendTransaction.

## Checklist
- [✓] Read the [contributing](https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md) guidelines
- [✓] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [✓] Performed a self-review of the PR
- [✓] Added automated tests
- [✓] Manually tested the change
