### PR TITLE
Naj 44 make sign and send transaction functionality public

### DIFF
--- a/.changeset/lazy-candles-hide.md
+++ b/.changeset/lazy-candles-hide.md
@@ -1,0 +1,5 @@
+---
+"near-api-js": minor
+---
+
+Make Account.signAndSendTransaction public so transactions can be sent directly from Account instances

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 #IDE
 .idea
+.vscode
 
 storage
 node_modules

--- a/packages/near-api-js/src/account.ts
+++ b/packages/near-api-js/src/account.ts
@@ -222,6 +222,14 @@ export class Account {
     }
 
     /**
+     * Sign a transaction to perform a list of actions and broadcast it using the RPC API.
+     * @see {@link JsonRpcProvider.sendTransaction}
+     */
+    signAndSendBundledActions(options: SignAndSendTransactionOptions): Promise<FinalExecutionOutcome> {
+        return this.signAndSendTransaction(options);
+    }
+
+    /**
      * Sign a transaction to preform a list of actions and broadcast it using the RPC API.
      * @see {@link providers/json-rpc-provider!JsonRpcProvider#sendTransaction | JsonRpcProvider.sendTransaction}
      */

--- a/packages/near-api-js/src/account.ts
+++ b/packages/near-api-js/src/account.ts
@@ -222,18 +222,10 @@ export class Account {
     }
 
     /**
-     * Sign a transaction to perform a list of actions and broadcast it using the RPC API.
-     * @see {@link JsonRpcProvider.sendTransaction}
-     */
-    signAndSendBundledActions(options: SignAndSendTransactionOptions): Promise<FinalExecutionOutcome> {
-        return this.signAndSendTransaction(options);
-    }
-
-    /**
      * Sign a transaction to preform a list of actions and broadcast it using the RPC API.
      * @see {@link providers/json-rpc-provider!JsonRpcProvider#sendTransaction | JsonRpcProvider.sendTransaction}
      */
-    protected async signAndSendTransaction({ receiverId, actions, returnError }: SignAndSendTransactionOptions): Promise<FinalExecutionOutcome> {
+    async signAndSendTransaction({ receiverId, actions, returnError }: SignAndSendTransactionOptions): Promise<FinalExecutionOutcome> {
         let txHash, signedTx;
         // TODO: TX_NONCE (different constants for different uses of exponentialBackoff?)
         const result = await exponentialBackoff(TX_NONCE_RETRY_WAIT, TX_NONCE_RETRY_NUMBER, TX_NONCE_RETRY_WAIT_BACKOFF, async () => {

--- a/packages/near-api-js/src/account_multisig.ts
+++ b/packages/near-api-js/src/account_multisig.ts
@@ -62,15 +62,7 @@ export class AccountMultisig extends Account {
         return super.signAndSendTransaction({ receiverId, actions });
     }
 
-    /**
-     * Sign a transaction to perform a list of actions and broadcast it using the RPC API.
-     * @see {@link JsonRpcProvider.sendTransaction}
-     */
-    signAndSendBundledActions(options: SignAndSendTransactionOptions): Promise<FinalExecutionOutcome> {
-        return this.signAndSendTransaction(options);
-    }
-
-    protected async signAndSendTransaction({ receiverId, actions }: SignAndSendTransactionOptions): Promise<FinalExecutionOutcome> {
+    async signAndSendTransaction({ receiverId, actions }: SignAndSendTransactionOptions): Promise<FinalExecutionOutcome> {
         const { accountId } = this;
 
         const args = Buffer.from(JSON.stringify({
@@ -236,14 +228,6 @@ export class Account2FA extends AccountMultisig {
         this.getCode = options.getCode || this.getCodeDefault;
         this.verifyCode = options.verifyCode || this.verifyCodeDefault;
         this.onConfirmResult = options.onConfirmResult;
-    }
-
-    /**
-     * Sign a transaction to perform a list of actions and broadcast it using the RPC API.
-     * @see {@link JsonRpcProvider.sendTransaction}
-     */
-    signAndSendBundledActions(options: SignAndSendTransactionOptions): Promise<FinalExecutionOutcome> {
-        return this.signAndSendTransaction(options);
     }
 
     /**

--- a/packages/near-api-js/src/account_multisig.ts
+++ b/packages/near-api-js/src/account_multisig.ts
@@ -62,6 +62,14 @@ export class AccountMultisig extends Account {
         return super.signAndSendTransaction({ receiverId, actions });
     }
 
+    /**
+     * Sign a transaction to perform a list of actions and broadcast it using the RPC API.
+     * @see {@link JsonRpcProvider.sendTransaction}
+     */
+    signAndSendBundledActions(options: SignAndSendTransactionOptions): Promise<FinalExecutionOutcome> {
+        return this.signAndSendTransaction(options);
+    }
+
     protected async signAndSendTransaction({ receiverId, actions }: SignAndSendTransactionOptions): Promise<FinalExecutionOutcome> {
         const { accountId } = this;
 
@@ -228,6 +236,14 @@ export class Account2FA extends AccountMultisig {
         this.getCode = options.getCode || this.getCodeDefault;
         this.verifyCode = options.verifyCode || this.verifyCodeDefault;
         this.onConfirmResult = options.onConfirmResult;
+    }
+
+    /**
+     * Sign a transaction to perform a list of actions and broadcast it using the RPC API.
+     * @see {@link JsonRpcProvider.sendTransaction}
+     */
+    signAndSendBundledActions(options: SignAndSendTransactionOptions): Promise<FinalExecutionOutcome> {
+        return this.signAndSendTransaction(options);
     }
 
     /**

--- a/packages/near-api-js/src/wallet-account.ts
+++ b/packages/near-api-js/src/wallet-account.ts
@@ -292,6 +292,14 @@ export class ConnectedWalletAccount extends Account {
     // Overriding Account methods
 
     /**
+     * Sign a transaction to perform a list of actions and broadcast it using the RPC API.
+     * @see {@link JsonRpcProvider.sendTransaction}
+     */
+    signAndSendBundledActions(options: SignAndSendTransactionOptions): Promise<FinalExecutionOutcome> {
+        return this.signAndSendTransaction(options);
+    }
+
+    /**
      * Sign a transaction by redirecting to the NEAR Wallet
      * @see {@link WalletConnection.requestSignTransactions}
      */

--- a/packages/near-api-js/src/wallet-account.ts
+++ b/packages/near-api-js/src/wallet-account.ts
@@ -292,18 +292,10 @@ export class ConnectedWalletAccount extends Account {
     // Overriding Account methods
 
     /**
-     * Sign a transaction to perform a list of actions and broadcast it using the RPC API.
-     * @see {@link JsonRpcProvider.sendTransaction}
-     */
-    signAndSendBundledActions(options: SignAndSendTransactionOptions): Promise<FinalExecutionOutcome> {
-        return this.signAndSendTransaction(options);
-    }
-
-    /**
      * Sign a transaction by redirecting to the NEAR Wallet
      * @see {@link WalletConnection.requestSignTransactions}
      */
-    protected async signAndSendTransaction({ receiverId, actions, walletMeta, walletCallbackUrl = window.location.href }: SignAndSendTransactionOptions): Promise<FinalExecutionOutcome> {
+    async signAndSendTransaction({ receiverId, actions, walletMeta, walletCallbackUrl = window.location.href }: SignAndSendTransactionOptions): Promise<FinalExecutionOutcome> {
         const localKey = await this.connection.signer.getPublicKey(this.accountId, this.connection.networkId);
         let accessKey = await this.accessKeyForTransaction(receiverId, actions, localKey);
         if (!accessKey) {

--- a/packages/near-api-js/test/account.test.js
+++ b/packages/near-api-js/test/account.test.js
@@ -51,7 +51,7 @@ test('send money through signAndSendBundledActions', async() => {
     const sender = await testUtils.createAccount(nearjs);
     const receiver = await testUtils.createAccount(nearjs);
     const { amount: receiverAmount } = await receiver.state();
-    await sender.signAndSendBundledActions({receiverId: receiver.accountId, actions: [transfer(new BN(10000))]});
+    await sender.signAndSendTransaction({receiverId: receiver.accountId, actions: [transfer(new BN(10000))]});
     const state = await receiver.state();
     expect(state.amount).toEqual(new BN(receiverAmount).add(new BN(10000)).toString());
 });

--- a/packages/near-api-js/test/account.test.js
+++ b/packages/near-api-js/test/account.test.js
@@ -47,7 +47,7 @@ test('send money', async() => {
     expect(state.amount).toEqual(new BN(receiverAmount).add(new BN(10000)).toString());
 });
 
-test('send money through signAndSendBundledActions', async() => {
+test('send money through signAndSendTransaction', async() => {
     const sender = await testUtils.createAccount(nearjs);
     const receiver = await testUtils.createAccount(nearjs);
     const { amount: receiverAmount } = await receiver.state();

--- a/packages/near-api-js/test/account.test.js
+++ b/packages/near-api-js/test/account.test.js
@@ -4,6 +4,7 @@ const testUtils  = require('./test-utils');
 const { TypedError } = require('../src/utils/errors');
 const fs = require('fs');
 const BN = require('bn.js');
+const { transfer } = require('../src/transaction');
 
 let nearjs;
 let workingAccount;
@@ -42,6 +43,15 @@ test('send money', async() => {
     const receiver = await testUtils.createAccount(nearjs);
     const { amount: receiverAmount } = await receiver.state();
     await sender.sendMoney(receiver.accountId, new BN(10000));
+    const state = await receiver.state();
+    expect(state.amount).toEqual(new BN(receiverAmount).add(new BN(10000)).toString());
+});
+
+test('send money through signAndSendBundledActions', async() => {
+    const sender = await testUtils.createAccount(nearjs);
+    const receiver = await testUtils.createAccount(nearjs);
+    const { amount: receiverAmount } = await receiver.state();
+    await sender.signAndSendBundledActions({receiverId: receiver.accountId, actions: [transfer(new BN(10000))]});
     const state = await receiver.state();
     expect(state.amount).toEqual(new BN(receiverAmount).add(new BN(10000)).toString());
 });

--- a/packages/near-api-js/test/account_multisig.test.js
+++ b/packages/near-api-js/test/account_multisig.test.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const BN = require('bn.js');
 const testUtils  = require('./test-utils');
 const semver = require('semver');
+const { transfer } = require('../src/transaction');
 
 let nearjs;
 let startFromVersion;
@@ -119,5 +120,16 @@ describe('account2fa transactions', () => {
         const state = await receiver.state();
         expect(BigInt(state.amount)).toBeGreaterThanOrEqual(BigInt(new BN(receiverAmount).add(new BN(parseNearAmount('0.9'))).toString()));
     });
-    
+
+    test('send money through signAndSendBundledActions', async() => {
+        let sender = await testUtils.createAccount(nearjs);
+        let receiver = await testUtils.createAccount(nearjs);
+        sender = await getAccount2FA(sender);
+        receiver = await getAccount2FA(receiver);
+        const { amount: receiverAmount } = await receiver.state();
+        await sender.signAndSendBundledActions({receiverId: receiver.accountId, actions: [transfer(new BN(parseNearAmount('1')))]});
+        const state = await receiver.state();
+        expect(BigInt(state.amount)).toBeGreaterThanOrEqual(BigInt(new BN(receiverAmount).add(new BN(parseNearAmount('0.9'))).toString()));
+    });
+        
 });

--- a/packages/near-api-js/test/account_multisig.test.js
+++ b/packages/near-api-js/test/account_multisig.test.js
@@ -121,13 +121,13 @@ describe('account2fa transactions', () => {
         expect(BigInt(state.amount)).toBeGreaterThanOrEqual(BigInt(new BN(receiverAmount).add(new BN(parseNearAmount('0.9'))).toString()));
     });
 
-    test('send money through signAndSendBundledActions', async() => {
+    test('send money through signAndSendTransaction', async() => {
         let sender = await testUtils.createAccount(nearjs);
         let receiver = await testUtils.createAccount(nearjs);
         sender = await getAccount2FA(sender);
         receiver = await getAccount2FA(receiver);
         const { amount: receiverAmount } = await receiver.state();
-        await sender.signAndSendBundledActions({receiverId: receiver.accountId, actions: [transfer(new BN(parseNearAmount('1')))]});
+        await sender.signAndSendTransaction({receiverId: receiver.accountId, actions: [transfer(new BN(parseNearAmount('1')))]});
         const state = await receiver.state();
         expect(BigInt(state.amount)).toBeGreaterThanOrEqual(BigInt(new BN(receiverAmount).add(new BN(parseNearAmount('0.9'))).toString()));
     });


### PR DESCRIPTION
## Motivation
NAJ-44

## Description
`signAndSendBundledActions` methods added to expose the functionality of `protected signAndSendTransaction`

## Checklist
- [x] Read the [contributing](https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md) guidelines
- [x] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [x] Performed a self-review of the PR
- [x] Added automated tests
- [x] Manually tested the change
