### PR TITLE
fix: NAJ-61

### DIFF
--- a/packages/near-api-js/src/account.ts
+++ b/packages/near-api-js/src/account.ts
@@ -253,6 +253,7 @@ export class Account {
         }, []);
         this.printLogsAndFailures(signedTx.transaction.receiverId, flatLogs);
 
+       // Should be falsy if result.status.Failure is null
         if (!returnError && typeof result.status === 'object' && typeof result.status.Failure === 'object'  && result.status.Failure !== null) {
             // if error data has error_message and error_type properties, we consider that node returned an error in the old format
             if (result.status.Failure.error_message && result.status.Failure.error_type) {

--- a/packages/near-api-js/src/account.ts
+++ b/packages/near-api-js/src/account.ts
@@ -253,7 +253,7 @@ export class Account {
         }, []);
         this.printLogsAndFailures(signedTx.transaction.receiverId, flatLogs);
 
-       // Should be falsy if result.status.Failure is null
+        // Should be falsy if result.status.Failure is null
         if (!returnError && typeof result.status === 'object' && typeof result.status.Failure === 'object'  && result.status.Failure !== null) {
             // if error data has error_message and error_type properties, we consider that node returned an error in the old format
             if (result.status.Failure.error_message && result.status.Failure.error_type) {

--- a/packages/near-api-js/src/account.ts
+++ b/packages/near-api-js/src/account.ts
@@ -253,7 +253,7 @@ export class Account {
         }, []);
         this.printLogsAndFailures(signedTx.transaction.receiverId, flatLogs);
 
-        if (!returnError && typeof result.status === 'object' && typeof result.status.Failure === 'object') {
+        if (!returnError && typeof result.status === 'object' && typeof result.status.Failure === 'object'  && result.status.Failure !== null) {
             // if error data has error_message and error_type properties, we consider that node returned an error in the old format
             if (result.status.Failure.error_message && result.status.Failure.error_type) {
                 throw new TypedError(


### PR DESCRIPTION
## Motivation
NAJ-61

## Description
This case can occurred (typeof result.status.Failure === 'object' can process on Failure object in case of null). Fixed!

## Checklist
- [x] Read the [contributing](https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md) guidelines
- [x] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [x] Performed a self-review of the PR
- [ ] Added automated tests
- [x] Manually tested the change
