### PR TITLE
feat!: console usage controllable by the caller

### DIFF
--- a/packages/near-api-js/src/connect.ts
+++ b/packages/near-api-js/src/connect.ts
@@ -25,7 +25,7 @@ import { readKeyFile } from './key_stores/unencrypted_file_system_keystore';
 import { InMemoryKeyStore, MergeKeyStore } from './key_stores';
 import { Near, NearConfig } from './near';
 import fetch from './utils/setup-node-fetch';
-import { logWarning } from './utils';
+import { Logger } from './utils/near-logger';
 
 global.fetch = fetch;
 
@@ -56,12 +56,10 @@ export async function connect(config: ConnectConfig): Promise<Near> {
                     keyPathStore,
                     config.keyStore
                 ], { writeKeyStoreIndex: 1 });
-                if (!process.env['NEAR_NO_LOGS']) {
-                    console.log(`Loaded master account ${accountKeyFile[0]} key from ${config.keyPath} with public key = ${keyPair.getPublicKey()}`);
-                }
+                Logger.log(`Loaded master account ${accountKeyFile[0]} key from ${config.keyPath} with public key = ${keyPair.getPublicKey()}`);
             }
         } catch (error) {
-            logWarning(`Failed to load master account key from ${config.keyPath}: ${error}`);
+            Logger.warn(`Failed to load master account key from ${config.keyPath}: ${error}`);
         }
     }
     return new Near(config);

--- a/packages/near-api-js/src/index.ts
+++ b/packages/near-api-js/src/index.ts
@@ -3,3 +3,4 @@ export * as keyStores from './key_stores/index';
 export * from './common-index';
 export * from './connect';
 export * from './constants';
+export { configureLogging } from './utils/near-logger';

--- a/packages/near-api-js/src/providers/json-rpc-provider.ts
+++ b/packages/near-api-js/src/providers/json-rpc-provider.ts
@@ -28,6 +28,7 @@ import { baseEncode } from 'borsh';
 import exponentialBackoff from '../utils/exponential-backoff';
 import { parseRpcError } from '../utils/rpc_errors';
 import { SignedTransaction } from '../transaction';
+import { Logger } from '../utils/near-logger';
 
 /** @hidden */
 export { TypedError, ErrorContext };
@@ -350,9 +351,7 @@ export class JsonRpcProvider extends Provider {
                 return response;
             } catch (error) {
                 if (error.type === 'TimeoutError') {
-                    if (!process.env['NEAR_NO_LOGS']) {
-                        console.warn(`Retrying request to ${method} as it has timed out`, params);
-                    }
+                    Logger.warn(`Retrying request to ${method} as it has timed out`, params);
                     return null;
                 }
 

--- a/packages/near-api-js/src/utils/errors.ts
+++ b/packages/near-api-js/src/utils/errors.ts
@@ -26,9 +26,3 @@ export class ErrorContext {
         this.transactionHash = transactionHash;
     }
 }
-
-export function logWarning(...args: any[]): void {
-    if (!process.env['NEAR_NO_LOGS']){
-        console.warn(...args);
-    }
-}

--- a/packages/near-api-js/src/utils/index.ts
+++ b/packages/near-api-js/src/utils/index.ts
@@ -7,7 +7,6 @@ import * as format from './format';
 import * as rpc_errors from './rpc_errors';
 
 import { PublicKey, KeyPair, KeyPairEd25519 } from './key_pair';
-import { logWarning } from './errors';
 
 export {
     key_pair,
@@ -19,5 +18,4 @@ export {
     KeyPair,
     KeyPairEd25519,
     rpc_errors,
-    logWarning,
 };

--- a/packages/near-api-js/src/utils/near-logger.ts
+++ b/packages/near-api-js/src/utils/near-logger.ts
@@ -1,0 +1,78 @@
+type LogEvent = (... args: any[]) => void;
+type LogConfigurations = { showLogs?: BooleanEvent, onLog?: LogEvent; onWarn?: LogEvent; onInfo?: LogEvent; onError?: LogEvent };
+type BooleanEvent = () => boolean;
+
+class NearLogger {
+    log: LogEvent;
+    warn: LogEvent;
+    info: LogEvent;
+    error: LogEvent;
+  
+    showLogs: BooleanEvent;
+  
+    private static _logger?: NearLogger;
+
+    private readonly defaultLog = console.log;
+    private readonly defaultWarn = console.warn;
+    private readonly defaultInfo = console.info;
+    private readonly defaultError = console.error;
+
+    private bindWithCondition(event: LogEvent): LogEvent {
+        if (event) {
+            return (... args: any[]) => {
+                if (this.showLogs()) {
+                    event(args);
+                }
+            };
+        } else {
+            return null;
+        }
+    }
+
+    constructor() {
+        this.reset();
+    }
+
+    configure({ showLogs, onLog, onWarn, onInfo, onError}: LogConfigurations) {
+        this.showLogs = showLogs ?? this.showLogs;
+        this.log = this.bindWithCondition(onLog) ?? this.log;
+        this.warn = this.bindWithCondition(onWarn) ?? this.warn;
+        this.info = this.bindWithCondition(onInfo) ?? this.info;
+        this.error = this.bindWithCondition(onError) ?? this.error;
+    }
+
+    reset() {
+        this.showLogs = () => !process.env?.['NEAR_NO_LOGS'];
+        this.log = this.bindWithCondition(this.defaultLog);
+        this.warn = this.bindWithCondition(this.defaultWarn);
+        this.info = this.bindWithCondition(this.defaultInfo);
+        this.error = this.bindWithCondition(this.defaultError);
+    }
+
+    static getSharedInstance(): NearLogger {
+        if (!this._logger) {
+            this._logger = new NearLogger();
+        }
+        return this._logger;
+    }
+}
+
+const logger = NearLogger.getSharedInstance();
+
+export const Logger = logger;
+
+/**
+ * To configure all near js api logs
+ * 
+ * @param configurations {@link LogConfigurations} 
+ * with {
+ * @prop {BooleanEvent} showLogs = () => boolean
+ * @prop {LogEvent} onLog = (... args: any[]) => void
+ * @prop {LogEvent} onWarn = (... args: any[]) => void
+ * @prop {LogEvent} onInfo = (... args: any[]) => void
+ * @prop {LogEvent} onError = (... args: any[]) => void
+ * }
+ */
+export function configureLogging(configurations: LogConfigurations) {
+    logger.configure(configurations);
+}

--- a/packages/near-api-js/src/utils/web.ts
+++ b/packages/near-api-js/src/utils/web.ts
@@ -2,7 +2,7 @@ import createError from 'http-errors';
 
 import exponentialBackoff from './exponential-backoff';
 import { TypedError } from '../providers';
-import { logWarning } from './errors';
+import { Logger } from './near-logger';
 
 const START_WAIT_TIME_MS = 1000;
 const BACKOFF_MULTIPLIER = 1.5;
@@ -34,7 +34,7 @@ export async function fetchJson(connectionInfoOrUrl: string | ConnectionInfo, js
             });
             if (!response.ok) {
                 if (response.status === 503) {
-                    logWarning(`Retrying HTTP request for ${connectionInfo.url} as it's not available now`);
+                    Logger.warn(`Retrying HTTP request for ${connectionInfo.url} as it's not available now`);
                     return null;
                 }
                 throw createError(response.status, await response.text());
@@ -42,7 +42,7 @@ export async function fetchJson(connectionInfoOrUrl: string | ConnectionInfo, js
             return response;
         } catch (error) {
             if (error.toString().includes('FetchError') || error.toString().includes('Failed to fetch')) {
-                logWarning(`Retrying HTTP request for ${connectionInfo.url} because of error: ${error}`);
+                Logger.warn(`Retrying HTTP request for ${connectionInfo.url} because of error: ${error}`);
                 return null;
             }
             throw error;

--- a/packages/near-api-js/test/account.access_key.test.js
+++ b/packages/near-api-js/test/account.access_key.test.js
@@ -1,5 +1,6 @@
 const nearApi = require('../src/index');
 const testUtils = require('./test-utils');
+const { Logger } = require('../src/utils/near-logger');
 
 let nearjs;
 let workingAccount;
@@ -9,7 +10,12 @@ let contract;
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 50000;
 
 beforeAll(async () => {
+    nearApi.configureLogging({ showLogs: () => false });
     nearjs = await testUtils.setUpTestConnection();
+});
+
+afterAll(async () => {
+    Logger.reset();
 });
 
 beforeEach(async () => {

--- a/packages/near-api-js/test/account_multisig.test.js
+++ b/packages/near-api-js/test/account_multisig.test.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const BN = require('bn.js');
 const testUtils  = require('./test-utils');
 const semver = require('semver');
+const { Logger } = require('../src/utils/near-logger');
 
 let nearjs;
 let startFromVersion;
@@ -53,10 +54,15 @@ const getAccount2FA = async (account, keyMapping = ({ public_key: publicKey }) =
 };
 
 beforeAll(async () => {
+    nearApi.configureLogging({showLogs: () => false });
     nearjs = await testUtils.setUpTestConnection();
     let nodeStatus = await nearjs.connection.provider.status();
     startFromVersion = (version) => semver.gte(nodeStatus.version.version, version);
     console.log(startFromVersion);
+});
+
+afterAll(async () => {
+    Logger.reset();
 });
 
 describe('deployMultisig key rotations', () => {

--- a/packages/near-api-js/test/promise.test.js
+++ b/packages/near-api-js/test/promise.test.js
@@ -1,5 +1,6 @@
 const BN = require('bn.js');
 const testUtils = require('./test-utils');
+const { Logger, configureLogging } = require('../src/utils/near-logger');
 
 let nearjs;
 let workingAccount;
@@ -9,13 +10,17 @@ jasmine.DEFAULT_TIMEOUT_INTERVAL = 120000;
 const CONTRACT_CALL_GAS = new BN(300000000000000);
 
 beforeAll(async () => {
+    configureLogging({ showLogs: () => false });
     nearjs = await testUtils.setUpTestConnection();
     workingAccount = await testUtils.createAccount(nearjs);
 });
 
+afterAll(async () => {
+    Logger.reset();
+});
+
 describe('with promises', () => {
     let contract, contract1, contract2;
-    let oldLog;
     let logs;
     let contractName = testUtils.generateUniqueString('cnt');
     let contractName1 = testUtils.generateUniqueString('cnt');
@@ -28,15 +33,17 @@ describe('with promises', () => {
     });
 
     beforeEach(async () => {
-        oldLog = console.log;
         logs = [];
-        console.log = function() {
-            logs.push(Array.from(arguments).join(' '));
-        };
+        configureLogging({
+            showLogs: () => true,
+            onLog: (args) => {
+                logs.push(Array.from(args).join(' '));
+            }, onWarn: () => {}
+        });
     });
 
     afterEach(async () => {
-        console.log = oldLog;
+        configureLogging({ showLogs: () => false });
     });
 
     // -> means async call

--- a/packages/near-api-js/test/providers.test.js
+++ b/packages/near-api-js/test/providers.test.js
@@ -2,6 +2,7 @@ const nearApi = require('../src/index');
 const testUtils  = require('./test-utils');
 const BN = require('bn.js');
 const base58 = require('bs58');
+const { Logger } = require('../src/utils/near-logger');
 
 jest.setTimeout(20000);
 
@@ -10,6 +11,14 @@ const withProvider = (fn) => {
     const provider = new nearApi.providers.JsonRpcProvider(config.nodeUrl);
     return () => fn(provider);
 };
+
+beforeAll(async () => {
+    nearApi.configureLogging({ showLogs: () => false });
+});
+
+afterAll(async () => {
+    Logger.reset();
+});
 
 test('json rpc fetch node status', withProvider(async (provider) => {
     let response = await provider.status();


### PR DESCRIPTION
## Motivation
NAJ-64

## Description
Simple customisable logger added and all the internal logging of api should be done by it and have exposed the configureLogging so the end user can control logging accordingly.

## Checklist
- [x] Read the [contributing](https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md) guidelines
- [x] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [x] Performed a self-review of the PR
- [x] Added automated tests
- [x] Manually tested the change
