### PR TITLE
fix(near-api-js): optional headers in NearConfig

### DIFF
--- a/packages/near-api-js/src/near.ts
+++ b/packages/near-api-js/src/near.ts
@@ -55,7 +55,7 @@ export interface NearConfig {
      * NEAR RPC API headers. Can be used to pass API KEY and other parameters.
      * @see {@link JsonRpcProvider.JsonRpcProvider | JsonRpcProvider}
      */
-    headers: { [key: string]: string | number };
+    headers?: { [key: string]: string | number };
 
     /**
      * NEAR wallet url used to redirect users to their wallet in browser applications.


### PR DESCRIPTION
## Motivation
So that folks can construct a `Near` instance without providing `headers`

## Description
Updates `headers` in TS `NearConfig` type to optional

## Checklist
- [x] Read the [contributing](https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md) guidelines
- [x] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [x] Performed a self-review of the PR
- [ ] Added automated tests
- [x] Manually tested the change
