### PR TITLE
Revert "Fixed appKeyPrefix undefined value"

### DIFF
--- a/packages/near-api-js/src/wallet-account.ts
+++ b/packages/near-api-js/src/wallet-account.ts
@@ -83,16 +83,16 @@ export class WalletConnection {
     _completeSignInPromise: Promise<void>;
 
     constructor(near: Near, appKeyPrefix: string | null) {
-        if (typeof window === 'undefined') {
+        if(typeof window === 'undefined') {
             return new Proxy(this, {
                 get(target, property) {
-                    if (property === 'isSignedIn') {
+                    if(property === 'isSignedIn') {
                         return () => false;
                     }
-                    if (property === 'getAccountId') {
+                    if(property === 'getAccountId') {
                         return () => '';
                     }
-                    if (target[property] && typeof target[property] === 'function') {
+                    if(target[property] && typeof target[property] === 'function') {
                         return () => {
                             throw new Error('No window found in context, please ensure you are using WalletConnection on the browser');
                         };
@@ -102,16 +102,7 @@ export class WalletConnection {
             });
         }
         this._near = near;
-        const DEPRECATED_authDataKey = appKeyPrefix + LOCAL_STORAGE_KEY_SUFFIX;
-        const DEPRECATED_authData = JSON.parse(window.localStorage.getItem(DEPRECATED_authDataKey));
-        const authDataKey = (appKeyPrefix || near.config.contractName || 'default') + LOCAL_STORAGE_KEY_SUFFIX;
-
-        // Migrate dApps that previously used a faulty authDataKey.
-        if (DEPRECATED_authData) {
-            window.localStorage.removeItem(DEPRECATED_authDataKey);
-            window.localStorage.setItem(authDataKey, JSON.stringify(DEPRECATED_authData));
-        }
-
+        const authDataKey = appKeyPrefix + LOCAL_STORAGE_KEY_SUFFIX;
         const authData = JSON.parse(window.localStorage.getItem(authDataKey));
         this._networkId = near.config.networkId;
         this._walletBaseUrl = near.config.walletUrl;

--- a/packages/near-api-js/test/wallet-account.test.js
+++ b/packages/near-api-js/test/wallet-account.test.js
@@ -17,7 +17,6 @@ const nearApi = require('../src/index');
 
 let history;
 let nearFake;
-let nearFakeWithoutContract;
 let walletConnection;
 let keyStore = new nearApi.keyStores.InMemoryKeyStore();
 beforeEach(() => {
@@ -34,7 +33,7 @@ beforeEach(() => {
         },
         account() {
             return {
-                state() { }
+                state() {}
             };
         }
     };
@@ -86,7 +85,7 @@ describe('fails gracefully on the server side (without window)', () => {
 
     it('throws explicit error when calling other methods on the instance', () => {
         const serverWalletConnection = new nearApi.WalletConnection(nearFake);
-        expect(() => serverWalletConnection.requestSignIn('signInContract', 'signInTitle', 'http://example.com/success', 'http://example.com/fail')).toThrow(/please ensure you are using WalletConnection on the browser/);
+        expect(() => serverWalletConnection.requestSignIn('signInContract', 'signInTitle', 'http://example.com/success',  'http://example.com/fail')).toThrow(/please ensure you are using WalletConnection on the browser/);
     });
 
     it('can access other props on the instance', () => {
@@ -97,11 +96,11 @@ describe('fails gracefully on the server side (without window)', () => {
 
 describe('can request sign in', () => {
     beforeEach(() => keyStore.clear());
-
+    
     it('V2', () => {
         return walletConnection.requestSignIn({
             contractId: 'signInContract',
-            successUrl: 'http://example.com/success',
+            successUrl: 'http://example.com/success', 
             failureUrl: 'http://example.com/fail'
         });
     });
@@ -127,7 +126,7 @@ it('can request sign in with methodNames', async () => {
     await walletConnection.requestSignIn({
         contractId: 'signInContract',
         methodNames: ['hello', 'goodbye'],
-        successUrl: 'http://example.com/success',
+        successUrl: 'http://example.com/success', 
         failureUrl: 'http://example.com/fail'
     });
 
@@ -155,48 +154,10 @@ it('can complete sign in', async () => {
     await walletConnection._completeSignInWithAccessKey();
 
     expect(await keyStore.getKey('networkId', 'near.account')).toEqual(keyPair);
-    expect(localStorage.getItem('contractId_wallet_auth_key')).toBeTruthy();
+    expect(localStorage.getItem('contractId_wallet_auth_key'));
     expect(history.slice(1)).toEqual([
         [{}, 'documentTitle', 'http://example.com/location']
     ]);
-});
-
-it('can get the default appKeyPrefix', async () => {
-    nearFakeWithoutContract = {
-        config: {
-            networkId: 'networkId',
-            walletUrl: 'http://example.com/wallet',
-        },
-        connection: {
-            networkId: 'networkId',
-            signer: new nearApi.InMemorySigner(keyStore)
-        },
-        account() {
-            return {
-                state() { }
-            };
-        }
-    };
-
-    const keyPair = nearApi.KeyPair.fromRandom('ed25519');
-    global.window.location.href = `http://example.com/location?account_id=near.account&public_key=${keyPair.publicKey}`;
-    await keyStore.setKey('networkId', 'pending_key' + keyPair.publicKey, keyPair);
-
-    const newWalletConnection = new nearApi.WalletConnection(nearFakeWithoutContract);
-    await newWalletConnection._completeSignInWithAccessKey();
-
-    expect(localStorage.getItem('default_wallet_auth_key')).toBeTruthy();
-});
-
-it('can get the near-app appKeyPrefix', async () => {
-    const keyPair = nearApi.KeyPair.fromRandom('ed25519');
-    global.window.location.href = `http://example.com/location?account_id=near.account&public_key=${keyPair.publicKey}`;
-    await keyStore.setKey('networkId', 'pending_key' + keyPair.publicKey, keyPair);
-
-    const newWalletConnection = new nearApi.WalletConnection(nearFake, 'near-app');
-    await newWalletConnection._completeSignInWithAccessKey();
-
-    expect(localStorage.getItem('near-app_wallet_auth_key')).toBeTruthy();
 });
 
 it('Promise until complete sign in', async () => {
@@ -209,7 +170,7 @@ it('Promise until complete sign in', async () => {
     expect(newWalletConn.isSignedIn()).toEqual(false);
     expect(await newWalletConn.isSignedInAsync()).toEqual(true);
     expect(await keyStore.getKey('networkId', 'near2.account')).toEqual(keyPair);
-    expect(localStorage.getItem('promise_on_complete_signin_wallet_auth_key')).toBeTruthy();
+    expect(localStorage.getItem('promise_on_complete_signin_wallet_auth_key'));
     expect(history).toEqual([
         [{}, 'documentTitle', 'http://example.com/location']
     ]);
@@ -291,7 +252,7 @@ function setupWalletConnectionForSigning({ allKeys, accountAccessKeys }) {
     nearFake.connection.provider = {
         query(params) {
             if (params.request_type === 'view_account' && params.account_id === 'signer.near') {
-                return {};
+                return { };
             }
             if (params.request_type === 'view_access_key_list' && params.account_id === 'signer.near') {
                 return { keys: accountAccessKeys };
@@ -327,7 +288,7 @@ describe('requests transaction signing automatically when there is no local key'
     let transactions;
     beforeEach(() => {
         setupWalletConnectionForSigning({
-            allKeys: ['no_such_access_key', keyPair.publicKey.toString()],
+            allKeys: [ 'no_such_access_key', keyPair.publicKey.toString() ],
             accountAccessKeys: [{
                 access_key: {
                     nonce: 1,
@@ -338,7 +299,7 @@ describe('requests transaction signing automatically when there is no local key'
         });
     });
 
-    it('V2', async () => {
+    it('V2', async() => {
         try {
             await walletConnection.account().signAndSendTransaction({
                 receiverId: 'receiver.near',
@@ -371,11 +332,11 @@ describe('requests transaction signing automatically when there is no local key'
 });
 
 describe('requests transaction signing automatically when function call has attached deposit', () => {
-    beforeEach(async () => {
+    beforeEach(async() => {
         const localKeyPair = nearApi.KeyPair.fromRandom('ed25519');
         const walletKeyPair = nearApi.KeyPair.fromRandom('ed25519');
         setupWalletConnectionForSigning({
-            allKeys: [walletKeyPair.publicKey.toString()],
+            allKeys: [ walletKeyPair.publicKey.toString() ],
             accountAccessKeys: [{
                 access_key: {
                     nonce: 1,
@@ -399,7 +360,7 @@ describe('requests transaction signing automatically when function call has atta
         await keyStore.setKey('networkId', 'signer.near', localKeyPair);
     });
 
-    it('V2', async () => {
+    it('V2', async() => {
         try {
             await walletConnection.account().signAndSendTransaction({
                 receiverId: 'receiver.near',
@@ -411,7 +372,7 @@ describe('requests transaction signing automatically when function call has atta
         } catch (e) {
             expect(e.message).toEqual('Failed to redirect to sign transaction');
         }
-
+    
         const transactions = parseTransactionsFromUrl(lastRedirectUrl, 'http://example.com/after');
         expect(transactions).toHaveLength(1);
     });
@@ -422,7 +383,7 @@ describe('requests transaction signing with 2fa access key', () => {
         let localKeyPair = nearApi.KeyPair.fromRandom('ed25519');
         let walletKeyPair = nearApi.KeyPair.fromRandom('ed25519');
         setupWalletConnectionForSigning({
-            allKeys: [walletKeyPair.publicKey.toString()],
+            allKeys: [ walletKeyPair.publicKey.toString() ],
             accountAccessKeys: [{
                 access_key: {
                     nonce: 1,
@@ -461,7 +422,7 @@ describe('fails requests transaction signing without 2fa access key', () => {
         const localKeyPair = nearApi.KeyPair.fromRandom('ed25519');
         const walletKeyPair = nearApi.KeyPair.fromRandom('ed25519');
         setupWalletConnectionForSigning({
-            allKeys: [walletKeyPair.publicKey.toString()],
+            allKeys: [ walletKeyPair.publicKey.toString() ],
             accountAccessKeys: [{
                 access_key: {
                     nonce: 1,
@@ -493,7 +454,7 @@ describe('can sign transaction locally when function call has no attached deposi
     beforeEach(async () => {
         const localKeyPair = nearApi.KeyPair.fromRandom('ed25519');
         setupWalletConnectionForSigning({
-            allKeys: [ /* no keys in wallet needed */],
+            allKeys: [ /* no keys in wallet needed */ ],
             accountAccessKeys: [{
                 access_key: {
                     nonce: 1,
@@ -518,7 +479,7 @@ describe('can sign transaction locally when function call has no attached deposi
     ])('V2', async (functionCall) => {
         await walletConnection.account().signAndSendTransaction({
             receiverId: 'receiver.near',
-            actions: [functionCall]
+            actions: [ functionCall ]
         });
         // NOTE: Transaction gets signed without wallet in this test
         expect(lastTransaction).toMatchObject({


### PR DESCRIPTION
Reverts near/near-api-js#927

While this isn't buggy, we'd like to improve the following and release a better version in 1.1:

1. [Not unnecessarily delete and recreate the key in localStorage if the new and old key are the same](https://github.com/near/near-api-js/pull/927/files/40e049b3ee19c00bd80d21c0890f84da2ab04d44#r953147205)
2. [More test cases especially around migrating storage from old to new authDataKey](https://github.com/near/near-api-js/pull/927#discussion_r953151759) (migration is only relevant when old appKeyPrefix is `undefined_..` and new `appKeyPrefix` is `default_..`)
3. Refactor the `WalletConnection` constructor to make it easier to reason about `authDataKey` and `DEPRECATED_authDataKey` possibly by moving them to the top of the block and having clear conditions