### PR TITLE
refactor(near-api-js): remove unnecessary nonce from AccessKey

### DIFF
--- a/packages/near-api-js/src/transaction.ts
+++ b/packages/near-api-js/src/transaction.ts
@@ -20,16 +20,15 @@ export class AccessKeyPermission extends Enum {
 }
 
 export class AccessKey extends Assignable {
-    nonce: number;
     permission: AccessKeyPermission;
 }
 
 export function fullAccessKey(): AccessKey {
-    return new AccessKey({ nonce: 0, permission: new AccessKeyPermission({fullAccess: new FullAccessPermission({})}) });
+    return new AccessKey({ permission: new AccessKeyPermission({fullAccess: new FullAccessPermission({})}) });
 }
 
 export function functionCallAccessKey(receiverId: string, methodNames: string[], allowance?: BN): AccessKey {
-    return new AccessKey({ nonce: 0, permission: new AccessKeyPermission({functionCall: new FunctionCallPermission({receiverId, allowance, methodNames})})});
+    return new AccessKey({ permission: new AccessKeyPermission({functionCall: new FunctionCallPermission({receiverId, allowance, methodNames})})});
 }
 
 export class IAction extends Assignable {}


### PR DESCRIPTION
## Motivation
Closes #587 

## Description
This PR no longer sends a `nonce` when adding an access key since this is set at the protocol level and the sent value is ignored.

## Checklist
- [x] Read the [contributing](https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md) guidelines
- [x] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [x] Performed a self-review of the PR
- [ ] Added automated tests
- [x] Manually tested the change
