### PR TITLE
fix: blockId field

### DIFF
--- a/packages/near-api-js/src/providers/json-rpc-provider.ts
+++ b/packages/near-api-js/src/providers/json-rpc-provider.ts
@@ -202,7 +202,8 @@ export class JsonRpcProvider extends Provider {
      * @param blockReference specifies the block to get the protocol config for
      */
     async experimental_protocolConfig(blockReference: BlockReference | { sync_checkpoint: 'genesis' }): Promise<NearProtocolConfig> {
-        return await this.sendJsonRpc('EXPERIMENTAL_protocol_config', blockReference);
+        const { blockId, ...otherParams } = blockReference as any;
+        return await this.sendJsonRpc('EXPERIMENTAL_protocol_config', {...otherParams, block_id: blockId});
     }
 
     /**


### PR DESCRIPTION
## Motivation
Closes issue https://github.com/near/near-api-js/issues/844

## Description
Changed the implementation of experimental_protocolConfig to properly handle blockId param.

## Checklist
- [ ] Read the [contributing](https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md) guidelines
- [ ] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [ ] Performed a self-review of the PR
- [ ] Added automated tests
- [ ] Manually tested the change
