### PR TITLE
Secp256k1 support PR rebased

### DIFF
--- a/.changeset/dry-buttons-exercise.md
+++ b/.changeset/dry-buttons-exercise.md
@@ -1,0 +1,5 @@
+---
+"near-api-js": minor
+---
+
+Add support for the secp256k1 curve

--- a/packages/near-api-js/package.json
+++ b/packages/near-api-js/package.json
@@ -20,6 +20,7 @@
         "js-sha256": "^0.9.0",
         "mustache": "^4.0.0",
         "node-fetch": "^2.6.1",
+        "secp256k1": "^4.0.3",
         "text-encoding-utf-8": "^1.0.2",
         "tweetnacl": "^1.0.1"
     },
@@ -67,7 +68,7 @@
         "files": [
             {
                 "path": "dist/near-api-js.min.js",
-                "maxSize": "105kB"
+                "maxSize": "250kB"
             }
         ]
     },

--- a/packages/near-api-js/src/key_stores/in_memory_key_store.ts
+++ b/packages/near-api-js/src/key_stores/in_memory_key_store.ts
@@ -1,5 +1,5 @@
 import { KeyStore } from './keystore';
-import { KeyPair } from '../utils/key_pair';
+import { KeyPair, KeyPairString } from '../utils/key_pair';
 
 /**
  * Simple in-memory keystore for mainly for testing purposes.
@@ -30,7 +30,7 @@ import { KeyPair } from '../utils/key_pair';
  */
 export class InMemoryKeyStore extends KeyStore {
     /** @hidden */
-    private keys: { [key: string]: string };
+    private keys: { [key: string]: KeyPairString };
 
     constructor() {
         super();

--- a/packages/near-api-js/src/signer.ts
+++ b/packages/near-api-js/src/signer.ts
@@ -1,5 +1,5 @@
 import sha256 from 'js-sha256';
-import { Signature, KeyPair, PublicKey } from './utils/key_pair';
+import { Signature, KeyType, KeyPair, PublicKey } from './utils/key_pair';
 import { KeyStore } from './key_stores/keystore';
 import { InMemoryKeyStore } from './key_stores/in_memory_key_store';
 
@@ -11,7 +11,7 @@ export abstract class Signer {
     /**
      * Creates new key and returns public key.
      */
-    abstract createKey(accountId: string, networkId?: string): Promise<PublicKey>;
+    abstract createKey(accountId: string, networkId?: string, keyType?: KeyType): Promise<PublicKey>;
 
     /**
      * Returns public key for given account / network.
@@ -61,8 +61,8 @@ export class InMemorySigner extends Signer {
      * @param networkId The targeted network. (ex. default, betanet, etc…)
      * @returns {Promise<PublicKey>}
      */
-    async createKey(accountId: string, networkId: string): Promise<PublicKey> {
-        const keyPair = KeyPair.fromRandom('ed25519');
+    async createKey(accountId: string, networkId: string, keyType?: KeyType): Promise<PublicKey> {
+        const keyPair = keyType === KeyType.SECP256K1 ? KeyPair.fromRandom('secp256k1') : KeyPair.fromRandom('ed25519');
         await this.keyStore.setKey(networkId, accountId, keyPair);
         return keyPair.getPublicKey();
     }

--- a/packages/near-api-js/src/transaction.ts
+++ b/packages/near-api-js/src/transaction.ts
@@ -100,22 +100,22 @@ export class Signature extends Assignable {
     
     static borshDeserialize(reader: BinaryReader) {
         const keyType = reader.readU8();
-        let data: Uint8Array
+        let data: Uint8Array;
         switch (keyType) {
             case KeyType.ED25519: 
-            data = reader.readFixedArray(64)
-            break
+                data = reader.readFixedArray(64);
+                break;
             case KeyType.SECP256K1: 
-            data = reader.readFixedArray(65)
-            break
+                data = reader.readFixedArray(65);
+                break;
             default: throw new Error(`Unknown key type ${keyType}`);
         }
-        return new Signature({keyType, data})
-     }
+        return new Signature({keyType, data});
+    }
     
     borshSerialize(writer: BinaryWriter) {
         writer.writeU8(this.keyType);
-        writer.writeFixedArray(this.data)
+        writer.writeFixedArray(this.data);
     }
 }
 

--- a/packages/near-api-js/src/utils/key_pair.ts
+++ b/packages/near-api-js/src/utils/key_pair.ts
@@ -78,13 +78,13 @@ export class PublicKey extends Assignable {
         const keyType = reader.readU8();
         let data: Uint8Array;
         switch (keyType) {
-        case KeyType.ED25519: 
-            data = reader.readFixedArray(32);
-            break;
-        case KeyType.SECP256K1: 
-            data = reader.readFixedArray(64);
-            break;
-        default: throw new Error(`Unknown key type ${keyType}`);
+            case KeyType.ED25519: 
+                data = reader.readFixedArray(32);
+                break;
+            case KeyType.SECP256K1: 
+                data = reader.readFixedArray(64);
+                break;
+            default: throw new Error(`Unknown key type ${keyType}`);
         }
         return new PublicKey({keyType, data});
     }

--- a/packages/near-api-js/src/utils/key_pair.ts
+++ b/packages/near-api-js/src/utils/key_pair.ts
@@ -1,6 +1,9 @@
 import nacl from 'tweetnacl';
 import { base_encode, base_decode } from './serialize';
 import { Assignable } from './enums';
+import { randomBytes } from 'crypto';
+import {BinaryReader, BinaryWriter} from 'borsh'
+import secp256k1 from 'secp256k1';
 
 export type Arrayish = string | ArrayLike<number>;
 
@@ -12,11 +15,13 @@ export interface Signature {
 /** All supported key types */
 export enum KeyType {
     ED25519 = 0,
+    SECP256K1 = 1, 
 }
 
 function key_type_to_str(keyType: KeyType): string {
     switch (keyType) {
         case KeyType.ED25519: return 'ed25519';
+        case KeyType.SECP256K1: return 'secp256k1';
         default: throw new Error(`Unknown key type ${keyType}`);
     }
 }
@@ -24,6 +29,7 @@ function key_type_to_str(keyType: KeyType): string {
 function str_to_key_type(keyType: string): KeyType {
     switch (keyType.toLowerCase()) {
         case 'ed25519': return KeyType.ED25519;
+        case 'secp256k1': return KeyType.SECP256K1;
         default: throw new Error(`Unknown key type ${keyType}`);
     }
 }
@@ -41,7 +47,7 @@ export class PublicKey extends Assignable {
         }
         return value;
     }
-
+    
     static fromString(encodedKey: string): PublicKey {
         const parts = encodedKey.split(':');
         if (parts.length === 1) {
@@ -52,7 +58,7 @@ export class PublicKey extends Assignable {
             throw new Error('Invalid encoded key format, must be <curve>:<encoded key>');
         }
     }
-
+    
     toString(): string {
         return `${key_type_to_str(this.keyType)}:${base_encode(this.data)}`;
     }
@@ -60,8 +66,32 @@ export class PublicKey extends Assignable {
     verify(message: Uint8Array, signature: Uint8Array): boolean {
         switch (this.keyType) {
             case KeyType.ED25519: return nacl.sign.detached.verify(message, signature, this.data);
+            // we don't need the recovery id to verify secp25k61 signatures locally, so drop  it here
+            // also inject the 0x04 header back into the pubkey before trying to interact with it in
+            // the secp256k1 library
+            case KeyType.SECP256K1: return secp256k1.ecdsaVerify(signature.subarray(0, 64), message, new Uint8Array([0x04, ...this.data]));
             default: throw new Error(`Unknown key type ${this.keyType}`);
         }
+    }
+    
+    static borshDeserialize(reader: BinaryReader) {
+        const keyType = reader.readU8();
+        let data: Uint8Array
+        switch (keyType) {
+        case KeyType.ED25519: 
+            data = reader.readFixedArray(32)
+            break
+        case KeyType.SECP256K1: 
+            data = reader.readFixedArray(64)
+            break
+        default: throw new Error(`Unknown key type ${keyType}`);
+        }
+        return new PublicKey({keyType, data})
+     }
+    
+    borshSerialize(writer: BinaryWriter) {
+        writer.writeU8(this.keyType);
+        writer.writeFixedArray(this.data)
     }
 }
 
@@ -78,17 +108,20 @@ export abstract class KeyPair {
     static fromRandom(curve: string): KeyPair {
         switch (curve.toUpperCase()) {
             case 'ED25519': return KeyPairEd25519.fromRandom();
+            case 'SECP256K1': return KeyPairSecp256k1.fromRandom();
             default: throw new Error(`Unknown curve ${curve}`);
         }
     }
 
     static fromString(encodedKey: string): KeyPair {
         const parts = encodedKey.split(':');
+        //TODO: clarify what we must do here
         if (parts.length === 1) {
             return new KeyPairEd25519(parts[0]);
         } else if (parts.length === 2) {
             switch (parts[0].toUpperCase()) {
                 case 'ED25519': return new KeyPairEd25519(parts[1]);
+                case 'SECP256K1': return new KeyPairSecp256k1(parts[1]);
                 default: throw new Error(`Unknown curve: ${parts[0]}`);
             }
         } else {
@@ -143,6 +176,70 @@ export class KeyPairEd25519 extends KeyPair {
 
     toString(): string {
         return `ed25519:${this.secretKey}`;
+    }
+
+    getPublicKey(): PublicKey {
+        return this.publicKey;
+    }
+}
+/**
+ * This class provides key pair functionality for secp256k1 curve:
+ * generating key pairs, encoding key pairs, signing and verifying.
+ * nearcore expects secp256k1 public keys to be 64 bytes at all times, 
+ * even when string encoded the secp256k1 library returns 65 byte keys 
+ * (including a 1 byte header that indicates how the pubkey was encoded).
+ * We'll force the secp256k1 library to always encode uncompressed
+ * keys with the corresponding 0x04 header byte, then manually 
+ * insert/remove that byte as needed.
+ */
+export class KeyPairSecp256k1 extends KeyPair {
+    readonly publicKey: PublicKey;
+    readonly secretKey: string;
+
+    /**
+     * Construct an instance of key pair given a secret key.
+     * It's generally assumed that these are encoded in base58.
+     * @param {string} secretKey
+     */
+    constructor(secretKey: string) {
+        super();
+        const withHeader = secp256k1.publicKeyCreate(base_decode(secretKey), false)
+        const data = withHeader.subarray(1, withHeader.length) // remove the 0x04 header byte
+        this.publicKey = new PublicKey({
+            keyType: KeyType.SECP256K1,
+            data
+        });
+        this.secretKey = secretKey;
+    }
+
+    /**
+     * Generate a new random keypair.
+     * @example
+     * const keyRandom = KeyPair.fromRandom();
+     * keyRandom.publicKey
+     * // returns [PUBLIC_KEY]
+     *
+     * keyRandom.secretKey
+     * // returns [SECRET_KEY]
+     */
+    static fromRandom() {
+        // TODO: find better way to generate PK
+        const secretKey = randomBytes(32);
+        return new KeyPairSecp256k1(base_encode(secretKey));
+    }
+
+    sign(message: Uint8Array): Signature {
+        // nearcore expects 65 byte signatures formed by appending the recovery id to the 64 byte signature
+        const { signature, recid } = secp256k1.ecdsaSign(message, base_decode(this.secretKey)); 
+        return { signature: new Uint8Array([...signature, recid]), publicKey: this.publicKey };
+    }
+
+    verify(message: Uint8Array, signature: Uint8Array): boolean {
+        return this.publicKey.verify(message, signature);
+    }
+
+    toString(): string {
+        return `secp256k1:${this.secretKey}`;
     }
 
     getPublicKey(): PublicKey {

--- a/packages/near-api-js/src/utils/key_pair.ts
+++ b/packages/near-api-js/src/utils/key_pair.ts
@@ -2,7 +2,7 @@ import nacl from 'tweetnacl';
 import { base_encode, base_decode } from './serialize';
 import { Assignable } from './enums';
 import { randomBytes } from 'crypto';
-import {BinaryReader, BinaryWriter} from 'borsh'
+import {BinaryReader, BinaryWriter} from 'borsh';
 import secp256k1 from 'secp256k1';
 
 export type Arrayish = string | ArrayLike<number>;
@@ -76,22 +76,22 @@ export class PublicKey extends Assignable {
     
     static borshDeserialize(reader: BinaryReader) {
         const keyType = reader.readU8();
-        let data: Uint8Array
+        let data: Uint8Array;
         switch (keyType) {
         case KeyType.ED25519: 
-            data = reader.readFixedArray(32)
-            break
+            data = reader.readFixedArray(32);
+            break;
         case KeyType.SECP256K1: 
-            data = reader.readFixedArray(64)
-            break
+            data = reader.readFixedArray(64);
+            break;
         default: throw new Error(`Unknown key type ${keyType}`);
         }
-        return new PublicKey({keyType, data})
-     }
+        return new PublicKey({keyType, data});
+    }
     
     borshSerialize(writer: BinaryWriter) {
         writer.writeU8(this.keyType);
-        writer.writeFixedArray(this.data)
+        writer.writeFixedArray(this.data);
     }
 }
 
@@ -203,8 +203,8 @@ export class KeyPairSecp256k1 extends KeyPair {
      */
     constructor(secretKey: string) {
         super();
-        const withHeader = secp256k1.publicKeyCreate(base_decode(secretKey), false)
-        const data = withHeader.subarray(1, withHeader.length) // remove the 0x04 header byte
+        const withHeader = secp256k1.publicKeyCreate(base_decode(secretKey), false);
+        const data = withHeader.subarray(1, withHeader.length); // remove the 0x04 header byte
         this.publicKey = new PublicKey({
             keyType: KeyType.SECP256K1,
             data

--- a/packages/near-api-js/src/utils/key_pair.ts
+++ b/packages/near-api-js/src/utils/key_pair.ts
@@ -105,7 +105,7 @@ export abstract class KeyPair {
      * @param curve Name of elliptical curve, case-insensitive
      * @returns Random KeyPair based on the curve
      */
-    static fromRandom(curve: string): KeyPair {
+    static fromRandom(curve: 'ed25519' | 'secp256k1'): KeyPair {
         switch (curve.toUpperCase()) {
             case 'ED25519': return KeyPairEd25519.fromRandom();
             case 'SECP256K1': return KeyPairSecp256k1.fromRandom();

--- a/packages/near-api-js/src/utils/key_pair.ts
+++ b/packages/near-api-js/src/utils/key_pair.ts
@@ -47,7 +47,7 @@ export class PublicKey extends Assignable {
         }
         return value;
     }
-    
+
     static fromString(encodedKey: string): PublicKey {
         const parts = encodedKey.split(':');
         if (parts.length === 1) {
@@ -58,7 +58,7 @@ export class PublicKey extends Assignable {
             throw new Error('Invalid encoded key format, must be <curve>:<encoded key>');
         }
     }
-    
+
     toString(): string {
         return `${key_type_to_str(this.keyType)}:${base_encode(this.data)}`;
     }
@@ -113,12 +113,10 @@ export abstract class KeyPair {
         }
     }
 
-    static fromString(encodedKey: string): KeyPair {
+    static fromString(encodedKey: `${'secp256k1' | 'ed25519'}:${string}`): KeyPair {
         const parts = encodedKey.split(':');
         //TODO: clarify what we must do here
-        if (parts.length === 1) {
-            return new KeyPairEd25519(parts[0]);
-        } else if (parts.length === 2) {
+        if (parts.length === 2) {
             switch (parts[0].toUpperCase()) {
                 case 'ED25519': return new KeyPairEd25519(parts[1]);
                 case 'SECP256K1': return new KeyPairSecp256k1(parts[1]);

--- a/packages/near-api-js/src/utils/key_pair.ts
+++ b/packages/near-api-js/src/utils/key_pair.ts
@@ -95,10 +95,12 @@ export class PublicKey extends Assignable {
     }
 }
 
+export type KeyPairString = `ed25519:${string}` | `secp256k1:${string}`;
+
 export abstract class KeyPair {
     abstract sign(message: Uint8Array): Signature;
     abstract verify(message: Uint8Array, signature: Uint8Array): boolean;
-    abstract toString(): string;
+    abstract toString(): KeyPairString;
     abstract getPublicKey(): PublicKey;
 
     /**
@@ -113,7 +115,7 @@ export abstract class KeyPair {
         }
     }
 
-    static fromString(encodedKey: `${'secp256k1' | 'ed25519'}:${string}`): KeyPair {
+    static fromString(encodedKey: KeyPairString): KeyPair {
         const parts = encodedKey.split(':');
         //TODO: clarify what we must do here
         if (parts.length === 2) {
@@ -172,7 +174,7 @@ export class KeyPairEd25519 extends KeyPair {
         return this.publicKey.verify(message, signature);
     }
 
-    toString(): string {
+    toString(): KeyPairString {
         return `ed25519:${this.secretKey}`;
     }
 
@@ -236,7 +238,7 @@ export class KeyPairSecp256k1 extends KeyPair {
         return this.publicKey.verify(message, signature);
     }
 
-    toString(): string {
+    toString(): KeyPairString {
         return `secp256k1:${this.secretKey}`;
     }
 

--- a/packages/near-api-js/src/utils/key_pair.ts
+++ b/packages/near-api-js/src/utils/key_pair.ts
@@ -117,7 +117,6 @@ export abstract class KeyPair {
 
     static fromString(encodedKey: KeyPairString): KeyPair {
         const parts = encodedKey.split(':');
-        //TODO: clarify what we must do here
         if (parts.length === 2) {
             switch (parts[0].toUpperCase()) {
                 case 'ED25519': return new KeyPairEd25519(parts[1]);

--- a/packages/near-api-js/src/wallet-account.ts
+++ b/packages/near-api-js/src/wallet-account.ts
@@ -29,6 +29,7 @@ interface SignInOptions {
     // TODO: Replace following with single callbackUrl
     successUrl?: string;
     failureUrl?: string;
+    keyType: 'ed25519' | 'secp256k1'
 }
 
 /**
@@ -174,7 +175,7 @@ export class WalletConnection {
      * wallet.requestSignIn({ contractId: 'account-with-deploy-contract.near' });
      * ```
      */
-    async requestSignIn({ contractId, methodNames, successUrl, failureUrl }: SignInOptions) {
+    async requestSignIn({ contractId, methodNames, successUrl, failureUrl, keyType = 'ed25519' }: SignInOptions) {
         const currentUrl = new URL(window.location.href);
         const newUrl = new URL(this._walletBaseUrl + LOGIN_WALLET_URL_SUFFIX);
         newUrl.searchParams.set('success_url', successUrl || currentUrl.href);
@@ -185,7 +186,7 @@ export class WalletConnection {
             await contractAccount.state();
 
             newUrl.searchParams.set('contract_id', contractId);
-            const accessKey = KeyPair.fromRandom('ed25519');
+            const accessKey = KeyPair.fromRandom(keyType);
             newUrl.searchParams.set('public_key', accessKey.getPublicKey().toString());
             await this._keyStore.setKey(this._networkId, PENDING_ACCESS_KEY_PREFIX + accessKey.getPublicKey(), accessKey);
         }

--- a/packages/near-api-js/test/account.access_key.test.js
+++ b/packages/near-api-js/test/account.access_key.test.js
@@ -29,6 +29,16 @@ test('make function call using access key', async() => {
     expect(await contract.getValue()).toEqual(setCallValue);
 });
 
+test('make function call using secp256k1 access key', async() => {
+    const keyPair = nearApi.utils.KeyPair.fromRandom('secp256k1');
+    await workingAccount.addKey(keyPair.getPublicKey(), contractId, '', '2000000000000000000000000');
+    // Override in the key store the workingAccount key to the given access key.
+    await nearjs.connection.signer.keyStore.setKey(testUtils.networkId, workingAccount.accountId, keyPair);
+    const setCallValue = testUtils.generateUniqueString('setCallPrefix');
+    await contract.setValue({ args: { value: setCallValue } });
+    expect(await contract.getValue()).toEqual(setCallValue);
+});
+
 test('remove access key no longer works', async() => {
     const keyPair = nearApi.utils.KeyPair.fromRandom('ed25519');
     let publicKey = keyPair.getPublicKey();

--- a/packages/near-api-js/test/account.test.js
+++ b/packages/near-api-js/test/account.test.js
@@ -36,6 +36,17 @@ test('create account and then view account returns the created account', async (
     expect(state.amount).toEqual(newAmount.toString());
 });
 
+test('create account with a secp256k1 key and then view account returns the created account', async () => {
+    const newAccountName = testUtils.generateUniqueString('test');
+    const newAccountPublicKey = 'secp256k1:45KcWwYt6MYRnnWFSxyQVkuu9suAzxoSkUMEnFNBi9kDayTo5YPUaqMWUrf7YHUDNMMj3w75vKuvfAMgfiFXBy28';
+    const { amount } = await workingAccount.state();
+    const newAmount = new BN(amount).div(new BN(10));
+    await workingAccount.createAccount(newAccountName, newAccountPublicKey, newAmount);
+    const newAccount = new Account(nearjs.connection, newAccountName);
+    const state = await newAccount.state();
+    expect(state.amount).toEqual(newAmount.toString());
+});
+
 test('send money', async() => {
     const sender = await testUtils.createAccount(nearjs);
     const receiver = await testUtils.createAccount(nearjs);

--- a/packages/near-api-js/test/key_pair.test.js
+++ b/packages/near-api-js/test/key_pair.test.js
@@ -1,41 +1,82 @@
 
 const nearApi = require('../src/index');
 const { sha256 } = require('js-sha256');
+describe('Using Ed25519 Curve', () => {
+    test('test sign and verify', async () => {
+        const keyPair = new nearApi.utils.key_pair.KeyPairEd25519('26x56YPzPDro5t2smQfGcYAPy3j7R2jB2NUb7xKbAGK23B6x4WNQPh3twb6oDksFov5X8ts5CtntUNbpQpAKFdbR');
+        expect(keyPair.publicKey.toString()).toEqual('ed25519:AYWv9RAN1hpSQA4p1DLhCNnpnNXwxhfH9qeHN8B4nJ59');
+        const message = new Uint8Array(sha256.array('message'));
+        const signature = keyPair.sign(message);
+        expect(nearApi.utils.serialize.base_encode(signature.signature)).toEqual('26gFr4xth7W9K7HPWAxq3BLsua8oTy378mC1MYFiEXHBBpeBjP8WmJEJo8XTBowetvqbRshcQEtBUdwQcAqDyP8T');
+    });
 
-test('test sign and verify', async () => {
-    const keyPair = new nearApi.utils.key_pair.KeyPairEd25519('26x56YPzPDro5t2smQfGcYAPy3j7R2jB2NUb7xKbAGK23B6x4WNQPh3twb6oDksFov5X8ts5CtntUNbpQpAKFdbR');
-    expect(keyPair.publicKey.toString()).toEqual('ed25519:AYWv9RAN1hpSQA4p1DLhCNnpnNXwxhfH9qeHN8B4nJ59');
-    const message = new Uint8Array(sha256.array('message'));
-    const signature = keyPair.sign(message);
-    expect(nearApi.utils.serialize.base_encode(signature.signature)).toEqual('26gFr4xth7W9K7HPWAxq3BLsua8oTy378mC1MYFiEXHBBpeBjP8WmJEJo8XTBowetvqbRshcQEtBUdwQcAqDyP8T');
+    test('test sign and verify with random', async () => {
+        const keyPair = nearApi.utils.key_pair.KeyPairEd25519.fromRandom();
+        const message = new Uint8Array(sha256.array('message'));
+        const signature = keyPair.sign(message);
+        expect(keyPair.verify(message, signature.signature)).toBeTruthy();
+    });
+
+    test('test sign and verify with public key', async () => {
+        const keyPair = new nearApi.utils.key_pair.KeyPairEd25519('5JueXZhEEVqGVT5powZ5twyPP8wrap2K7RdAYGGdjBwiBdd7Hh6aQxMP1u3Ma9Yanq1nEv32EW7u8kUJsZ6f315C');
+        const message = new Uint8Array(sha256.array('message'));
+        const signature = keyPair.sign(message);
+        const publicKey = nearApi.utils.key_pair.PublicKey.from('ed25519:EWrekY1deMND7N3Q7Dixxj12wD7AVjFRt2H9q21QHUSW');
+        expect(publicKey.verify(message, signature.signature)).toBeTruthy();
+    });
+
+    test('test from secret', async () => {
+        const keyPair = new nearApi.utils.key_pair.KeyPairEd25519('5JueXZhEEVqGVT5powZ5twyPP8wrap2K7RdAYGGdjBwiBdd7Hh6aQxMP1u3Ma9Yanq1nEv32EW7u8kUJsZ6f315C');
+        expect(keyPair.publicKey.toString()).toEqual('ed25519:EWrekY1deMND7N3Q7Dixxj12wD7AVjFRt2H9q21QHUSW');
+    });
+
+    test('convert to string', async () => {
+        const keyPair = nearApi.utils.key_pair.KeyPairEd25519.fromRandom();
+        const newKeyPair = nearApi.utils.key_pair.KeyPair.fromString(keyPair.toString());
+        expect(newKeyPair.secretKey).toEqual(keyPair.secretKey);
+
+        const keyString = 'ed25519:2wyRcSwSuHtRVmkMCGjPwnzZmQLeXLzLLyED1NDMt4BjnKgQL6tF85yBx6Jr26D2dUNeC716RBoTxntVHsegogYw';
+        const keyPair2 = nearApi.utils.key_pair.KeyPair.fromString(keyString);
+        expect(keyPair2.toString()).toEqual(keyString);
+    });
 });
 
-test('test sign and verify with random', async () => {
-    const keyPair = nearApi.utils.key_pair.KeyPairEd25519.fromRandom();
-    const message = new Uint8Array(sha256.array('message'));
-    const signature = keyPair.sign(message);
-    expect(keyPair.verify(message, signature.signature)).toBeTruthy();
-});
+describe('Using Secp256k1 Curve', () => {
+    test('Should sign and verify with Secp256k1', async () => {
+        const keyPair = new nearApi.utils.key_pair.KeyPairSecp256k1('Cqmi5vHc59U1MHhq7JCxTSJentvVBYMcKGUA7s7kwnKn');
+        expect(keyPair.publicKey.toString()).toEqual('secp256k1:45KcWwYt6MYRnnWFSxyQVkuu9suAzxoSkUMEnFNBi9kDayTo5YPUaqMWUrf7YHUDNMMj3w75vKuvfAMgfiFXBy28');
+        const message = new Uint8Array(sha256.array('message'));
+        const signature = keyPair.sign(message);
+        expect(nearApi.utils.serialize.base_encode(signature.signature)).toEqual('3xamkuNXQr4HHLXygRdp42Q19BRs6X5vENHbVtj7duaphZpdaRR2dZD7NvxWHw2twFiUxCvYXue6ZDsWg77DWBxNb');
+    });
 
-test('test sign and verify with public key', async () => {
-    const keyPair = new nearApi.utils.key_pair.KeyPairEd25519('5JueXZhEEVqGVT5powZ5twyPP8wrap2K7RdAYGGdjBwiBdd7Hh6aQxMP1u3Ma9Yanq1nEv32EW7u8kUJsZ6f315C');
-    const message = new Uint8Array(sha256.array('message'));
-    const signature = keyPair.sign(message);
-    const publicKey = nearApi.utils.key_pair.PublicKey.from('ed25519:EWrekY1deMND7N3Q7Dixxj12wD7AVjFRt2H9q21QHUSW');
-    expect(publicKey.verify(message, signature.signature)).toBeTruthy();
-});
+    test('Should sign and verify random message using Secp256k1 curve', async () => {
+        const keyPair = nearApi.utils.key_pair.KeyPairSecp256k1.fromRandom();
+        const message = new Uint8Array(sha256.array('message'));
+        const signature = keyPair.sign(message);
+        expect(keyPair.verify(message, signature.signature)).toBeTruthy();
+    });
 
-test('test from secret', async () => {
-    const keyPair = new nearApi.utils.key_pair.KeyPairEd25519('5JueXZhEEVqGVT5powZ5twyPP8wrap2K7RdAYGGdjBwiBdd7Hh6aQxMP1u3Ma9Yanq1nEv32EW7u8kUJsZ6f315C');
-    expect(keyPair.publicKey.toString()).toEqual('ed25519:EWrekY1deMND7N3Q7Dixxj12wD7AVjFRt2H9q21QHUSW');
-});
+    test('Should sign and verify public key created using Secp256k1', async () => {
+        const keyPair = new nearApi.utils.key_pair.KeyPairSecp256k1('Cqmi5vHc59U1MHhq7JCxTSJentvVBYMcKGUA7s7kwnKn');
+        const message = new Uint8Array(sha256.array('message'));
+        const signature = keyPair.sign(message);
+        const publicKey = nearApi.utils.key_pair.PublicKey.from('secp256k1:45KcWwYt6MYRnnWFSxyQVkuu9suAzxoSkUMEnFNBi9kDayTo5YPUaqMWUrf7YHUDNMMj3w75vKuvfAMgfiFXBy28');
+        expect(publicKey.verify(message, signature.signature)).toBeTruthy();
+    });
 
-test('convert to string', async () => {
-    const keyPair = nearApi.utils.key_pair.KeyPairEd25519.fromRandom();
-    const newKeyPair = nearApi.utils.key_pair.KeyPair.fromString(keyPair.toString());
-    expect(newKeyPair.secretKey).toEqual(keyPair.secretKey);
+    test('Should create proper publicKey from secret using Secp256k1', async () => {
+        const keyPair = new nearApi.utils.key_pair.KeyPairSecp256k1('Cqmi5vHc59U1MHhq7JCxTSJentvVBYMcKGUA7s7kwnKn');
+        expect(keyPair.publicKey.toString()).toEqual('secp256k1:45KcWwYt6MYRnnWFSxyQVkuu9suAzxoSkUMEnFNBi9kDayTo5YPUaqMWUrf7YHUDNMMj3w75vKuvfAMgfiFXBy28');
+    });
 
-    const keyString = 'ed25519:2wyRcSwSuHtRVmkMCGjPwnzZmQLeXLzLLyED1NDMt4BjnKgQL6tF85yBx6Jr26D2dUNeC716RBoTxntVHsegogYw';
-    const keyPair2 = nearApi.utils.key_pair.KeyPair.fromString(keyString);
-    expect(keyPair2.toString()).toEqual(keyString);
+    test('Should return proper key converted to string using Secp256k1', async () => {
+        const keyPair = nearApi.utils.key_pair.KeyPairSecp256k1.fromRandom();
+        const newKeyPair = nearApi.utils.key_pair.KeyPair.fromString(keyPair.toString());
+        expect(newKeyPair.secretKey).toEqual(keyPair.secretKey);
+
+        const keyString = 'secp256k1:7s1Jno8tbqFHBMqLh3epaFBbk194zAuMqo8yPbxvTbXn';
+        const keyPair2 = nearApi.utils.key_pair.KeyPair.fromString(keyString);
+        expect(keyPair2.toString()).toEqual(keyString);
+    });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,6 +64,7 @@ importers:
       near-hello: ^0.5.1
       node-fetch: ^2.6.1
       rimraf: ^3.0.0
+      secp256k1: ^4.0.3
       semver: ^7.1.1
       text-encoding-utf-8: ^1.0.2
       ts-jest: ^26.5.6
@@ -80,6 +81,7 @@ importers:
       js-sha256: 0.9.0
       mustache: 4.2.0
       node-fetch: 2.6.7
+      secp256k1: 4.0.3
       text-encoding-utf-8: 1.0.2
       tweetnacl: 1.0.3
     devDependencies:
@@ -1886,7 +1888,6 @@ packages:
 
   /bn.js/4.12.0:
     resolution: {integrity: sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==}
-    dev: true
 
   /bn.js/5.2.1:
     resolution: {integrity: sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==}
@@ -1945,15 +1946,14 @@ packages:
 
   /brorand/1.1.0:
     resolution: {integrity: sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==}
-    dev: true
 
   /browser-pack/6.1.0:
     resolution: {integrity: sha512-erYug8XoqzU3IfcU8fUgyHqyOXqIE4tUTTQ+7mqUjQlvnXkOO6OlT9c/ZoJVHYoAaqGxr09CN53G7XIsO4KtWA==}
     hasBin: true
     dependencies:
+      JSONStream: 1.3.5
       combine-source-map: 0.8.0
       defined: 1.0.0
-      JSONStream: 1.3.5
       safe-buffer: 5.2.1
       through2: 2.0.5
       umd: 3.0.3
@@ -2029,6 +2029,7 @@ packages:
     engines: {node: '>= 0.8'}
     hasBin: true
     dependencies:
+      JSONStream: 1.3.5
       assert: 1.5.0
       browser-pack: 6.1.0
       browser-resolve: 2.0.0
@@ -2050,7 +2051,6 @@ packages:
       https-browserify: 1.0.0
       inherits: 2.0.4
       insert-module-globals: 7.2.1
-      JSONStream: 1.3.5
       labeled-stream-splicer: 2.0.2
       mkdirp-classic: 0.5.3
       module-deps: 6.2.3
@@ -2453,8 +2453,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
-      is-text-path: 1.0.1
       JSONStream: 1.3.5
+      is-text-path: 1.0.1
       lodash: 4.17.21
       meow: 8.1.2
       split2: 3.2.2
@@ -2973,7 +2973,6 @@ packages:
       inherits: 2.0.4
       minimalistic-assert: 1.0.1
       minimalistic-crypto-utils: 1.0.1
-    dev: true
 
   /emittery/0.7.2:
     resolution: {integrity: sha512-A8OG5SR/ij3SsJdWDJdkkSYUjQdCUx6APQXem0SaEePBSRg4eymGYwBkKo1Y6DU+af/Jn2dBQqDBvjnr9Vi8nQ==}
@@ -3856,7 +3855,6 @@ packages:
     dependencies:
       inherits: 2.0.4
       minimalistic-assert: 1.0.1
-    dev: true
 
   /hasurl/1.0.0:
     resolution: {integrity: sha512-43ypUd3DbwyCT01UYpA99AEZxZ4aKtRxWGBHEIbjcOsUghd9YUON0C+JF6isNjaiwC/UF5neaUudy6JS9jZPZQ==}
@@ -3869,7 +3867,6 @@ packages:
       hash.js: 1.1.7
       minimalistic-assert: 1.0.1
       minimalistic-crypto-utils: 1.0.1
-    dev: true
 
   /homedir-polyfill/1.0.3:
     resolution: {integrity: sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==}
@@ -4074,11 +4071,11 @@ packages:
     resolution: {integrity: sha512-ufS5Qq9RZN+Bu899eA9QCAYThY+gGW7oRkmb0vC93Vlyu/CFGcH0OYPEjVkDXA5FEbTt1+VWzdoOD3Ny9N+8tg==}
     hasBin: true
     dependencies:
+      JSONStream: 1.3.5
       acorn-node: 1.8.2
       combine-source-map: 0.8.0
       concat-stream: 1.6.2
       is-buffer: 1.1.6
-      JSONStream: 1.3.5
       path-is-absolute: 1.0.1
       process: 0.11.10
       through2: 2.0.5
@@ -5396,11 +5393,9 @@ packages:
 
   /minimalistic-assert/1.0.1:
     resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
-    dev: true
 
   /minimalistic-crypto-utils/1.0.1:
     resolution: {integrity: sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==}
-    dev: true
 
   /minimatch/3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -5456,6 +5451,7 @@ packages:
     engines: {node: '>= 0.8.0'}
     hasBin: true
     dependencies:
+      JSONStream: 1.3.5
       browser-resolve: 2.0.0
       cached-path-relative: 1.1.0
       concat-stream: 1.6.2
@@ -5463,7 +5459,6 @@ packages:
       detective: 5.2.1
       duplexer2: 0.1.4
       inherits: 2.0.4
-      JSONStream: 1.3.5
       parents: 1.0.1
       readable-stream: 2.3.7
       resolve: 1.22.1
@@ -5517,6 +5512,10 @@ packages:
     resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
     dev: true
 
+  /node-addon-api/2.0.2:
+    resolution: {integrity: sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA==}
+    dev: false
+
   /node-cleanup/2.1.2:
     resolution: {integrity: sha512-qN8v/s2PAJwGUtr1/hYTpNKlD6Y9rc4p8KSmJXyGdYGZsDGKXrGThikLFP9OCHFeLeEpQzPwiAtdIvBLqm//Hw==}
     dev: true
@@ -5531,6 +5530,11 @@ packages:
         optional: true
     dependencies:
       whatwg-url: 5.0.0
+
+  /node-gyp-build/4.5.0:
+    resolution: {integrity: sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==}
+    hasBin: true
+    dev: false
 
   /node-int64/0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
@@ -6337,6 +6341,16 @@ packages:
     dependencies:
       xmlchars: 2.2.0
     dev: true
+
+  /secp256k1/4.0.3:
+    resolution: {integrity: sha512-NLZVf+ROMxwtEj3Xa562qgv2BK5e2WNmXPiOdVIPLgs6lyTzMvBq0aWTYMI5XCP9jZMVKOcqZLw/Wc4vDkuxhA==}
+    engines: {node: '>=10.0.0'}
+    requiresBuild: true
+    dependencies:
+      elliptic: 6.5.4
+      node-addon-api: 2.0.2
+      node-gyp-build: 4.5.0
+    dev: false
 
   /semver/5.7.1:
     resolution: {integrity: sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==}


### PR DESCRIPTION
## Motivation
Rebased version of #810 

## Description
Adds support for secp256k1 curve

## Checklist
- [x] Read the [contributing](https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md) guidelines
- [ ] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [ ] Performed a self-review of the PR
- [ ] Added automated tests
- [ ] Manually tested the change
