### PR TITLE
fix: typo in changeset release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           publish: yarn release
           commit: "chore(release): publish packages"
           title: "Publish packages"
-          createGithubRelease: true
+          createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ github.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Motivation
Changeset action takes `createGithubReleases` (plural) rather than `createGithubRelease`

## Description
Updates the changeset workflow to use the correct key

## Checklist
- [x] Read the [contributing](https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md) guidelines
- [x] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [x] Performed a self-review of the PR
- [ ] Added automated tests
- [ ] Manually tested the change
