### PR TITLE
fix: error types

### DIFF
--- a/.changeset/wild-teachers-marry.md
+++ b/.changeset/wild-teachers-marry.md
@@ -1,0 +1,7 @@
+---
+"near-api-js": patch
+---
+
+Fix error types. WIth this changes both `JsonRpcProvider.query` and `JsonRpcProvider.sendJsonRpc` methods will return proper error type for these errors: `AccountDoesNotExist`, `AccessKeyDoesNotExist`, `CodeDoesNotExist`, `InvalidNonce`.
+
+An additional fix to `getErrorTypeFromErrorMessage` function. Now `getErrorTypeFromErrorMessage` will not change error type if it already exists. 

--- a/packages/near-api-js/src/providers/json-rpc-provider.ts
+++ b/packages/near-api-js/src/providers/json-rpc-provider.ts
@@ -28,7 +28,7 @@ import { ConnectionInfo, fetchJson } from '../utils/web';
 import { TypedError, ErrorContext } from '../utils/errors';
 import { baseEncode } from 'borsh';
 import exponentialBackoff from '../utils/exponential-backoff';
-import { parseRpcError } from '../utils/rpc_errors';
+import { parseRpcError, getErrorTypeFromErrorMessage } from '../utils/rpc_errors';
 import { SignedTransaction } from '../transaction';
 
 /** @hidden */
@@ -147,7 +147,10 @@ export class JsonRpcProvider extends Provider {
             result = await this.sendJsonRpc<T>('query', [path, data]);
         }
         if (result && result.error) {
-            throw new TypedError(`Querying failed: ${result.error}.\n${JSON.stringify(result, null, 2)}`, result.error.name);
+            throw new TypedError(
+                `Querying failed: ${result.error}.\n${JSON.stringify(result, null, 2)}`,
+                getErrorTypeFromErrorMessage(result.error, result.error.name)
+            );
         }
         return result;
     }

--- a/packages/near-api-js/src/providers/json-rpc-provider.ts
+++ b/packages/near-api-js/src/providers/json-rpc-provider.ts
@@ -347,7 +347,7 @@ export class JsonRpcProvider extends Provider {
                             throw new TypedError(errorMessage, 'TimeoutError');
                         }
 
-                        throw new TypedError(errorMessage, response.error.name);
+                        throw new TypedError(errorMessage, getErrorTypeFromErrorMessage(response.error.data, response.error.name));
                     }
                 }
                 // Success when response.error is not exist

--- a/packages/near-api-js/src/utils/rpc_errors.ts
+++ b/packages/near-api-js/src/utils/rpc_errors.ts
@@ -85,6 +85,24 @@ function walkSubtype(errorObj, schema, result, typeName) {
     }
 }
 
+export function getErrorTypeFromErrorMessage(errorMessage, errorType) {
+    // This function should be removed when JSON RPC starts returning typed errors.
+    switch (true) {
+        case /^account .*? does not exist while viewing$/.test(errorMessage):
+            return 'AccountDoesNotExist';
+        case /^Account .*? doesn't exist$/.test(errorMessage):
+            return 'AccountDoesNotExist';
+        case /^access key .*? does not exist while viewing$/.test(errorMessage):
+            return 'AccessKeyDoesNotExist';
+        case /wasm execution failed with error: FunctionCallError\(CompilationError\(CodeDoesNotExist/.test(errorMessage):
+            return 'CodeDoesNotExist';
+        case /Transaction nonce \d+ must be larger than nonce of the used access key \d+/.test(errorMessage):
+            return 'InvalidNonce';
+        default:
+            return errorType;
+    }
+}
+
 /**
  * Helper function determining if the argument is an object
  * @param n Value to check

--- a/packages/near-api-js/test/account.access_key.test.js
+++ b/packages/near-api-js/test/account.access_key.test.js
@@ -40,8 +40,8 @@ test('remove access key no longer works', async() => {
         await contract.setValue({ args: { value: 'test' } });
         fail('should throw an error');
     } catch (e) {
-        expect(e.message).toContain(`Querying failed: access key ${publicKey} does not exist while viewing.`);
-        expect(e.type).toEqual('UntypedError');
+        expect(e.message).toEqual(`Can not sign transactions for account ${workingAccount.accountId} on network ${testUtils.networkId}, no matching key pair exists for this account`);
+        expect(e.type).toEqual('KeyNotFound');
     }
 });
 

--- a/packages/near-api-js/test/utils/rpc-errors.test.js
+++ b/packages/near-api-js/test/utils/rpc-errors.test.js
@@ -3,6 +3,7 @@ const { ServerError } = require('../../src/utils/rpc_errors');
 const {
     parseRpcError,
     formatError,
+    getErrorTypeFromErrorMessage
 } = nearApi.utils.rpc_errors;
 describe('rpc-errors', () => {
     test('test AccountAlreadyExists error', async () => {
@@ -82,6 +83,19 @@ describe('rpc-errors', () => {
         const errorStr = '{"status":{"Failure":{"ActionError":{"index":0,"kind":{"FunctionCallError":{"EvmError":"ArgumentParseError"}}}}},"transaction":{"signer_id":"test.near","public_key":"ed25519:D5HVgBE8KgXkSirDE4UQ8qwieaLAR4wDDEgrPRtbbNep","nonce":110,"receiver_id":"evm","actions":[{"FunctionCall":{"method_name":"transfer","args":"888ZO7SvECKvfSCJ832LrnFXuF/QKrSGztwAAA==","gas":300000000000000,"deposit":"0"}}],"signature":"ed25519:7JtWQ2Ux63ixaKy7bTDJuRTWnv6XtgE84ejFMMjYGKdv2mLqPiCfkMqbAPt5xwLWwFdKjJniTcxWZe7FdiRWpWv","hash":"E1QorKKEh1WLJwRQSQ1pdzQN3f8yeFsQQ8CbJjnz1ZQe"},"transaction_outcome":{"proof":[],"block_hash":"HXXBPjGp65KaFtam7Xr67B8pZVGujZMZvTmVW6Fy9tXf","id":"E1QorKKEh1WLJwRQSQ1pdzQN3f8yeFsQQ8CbJjnz1ZQe","outcome":{"logs":[],"receipt_ids":["ZsKetkrZQGVTtmXr2jALgNjzcRqpoQQsk9HdLmFafeL"],"gas_burnt":2428001493624,"tokens_burnt":"2428001493624000000000","executor_id":"test.near","status":{"SuccessReceiptId":"ZsKetkrZQGVTtmXr2jALgNjzcRqpoQQsk9HdLmFafeL"}}},"receipts_outcome":[{"proof":[],"block_hash":"H6fQCVpxBDv9y2QtmTVHoxHibJvamVsHau7fDi7AmFa2","id":"ZsKetkrZQGVTtmXr2jALgNjzcRqpoQQsk9HdLmFafeL","outcome":{"logs":[],"receipt_ids":["DgRyf1Wv3ZYLFvM8b67k2yZjdmnyUUJtRkTxAwoFi3qD"],"gas_burnt":2428001493624,"tokens_burnt":"2428001493624000000000","executor_id":"evm","status":{"Failure":{"ActionError":{"index":0,"kind":{"FunctionCallError":{"EvmError":"ArgumentParseError"}}}}}}},{"proof":[],"block_hash":"9qNVA235L9XdZ8rZLBAPRNBbiGPyNnMUfpbi9WxbRdbB","id":"DgRyf1Wv3ZYLFvM8b67k2yZjdmnyUUJtRkTxAwoFi3qD","outcome":{"logs":[],"receipt_ids":[],"gas_burnt":0,"tokens_burnt":"0","executor_id":"test.near","status":{"SuccessValue":""}}}]}';
         const error = parseRpcError(JSON.parse(errorStr).status.Failure);
         expect(error).toEqual(new ServerError('{"index":0,"kind":{"EvmError":"ArgumentParseError"}}'));
+    });
+
+    test('test getErrorTypeFromErrorMessage', () => {
+        const err1 = 'account random.near does not exist while viewing';
+        const err2 = 'Account random2.testnet doesn\'t exist';
+        const err3 = 'access key ed25519:DvXowCpBHKdbD2qutgfhG6jvBMaXyUh7DxrDSjkLxMHp does not exist while viewing';
+        const err4 = 'wasm execution failed with error: FunctionCallError(CompilationError(CodeDoesNotExist { account_id: "random.testnet" }))';
+        const err5 = '[-32000] Server error: Invalid transaction: Transaction nonce 1 must be larger than nonce of the used access key 1';
+        expect(getErrorTypeFromErrorMessage(err1)).toEqual('AccountDoesNotExist');
+        expect(getErrorTypeFromErrorMessage(err2)).toEqual('AccountDoesNotExist');
+        expect(getErrorTypeFromErrorMessage(err3)).toEqual('AccessKeyDoesNotExist');
+        expect(getErrorTypeFromErrorMessage(err4)).toEqual('CodeDoesNotExist');
+        expect(getErrorTypeFromErrorMessage(err5)).toEqual('InvalidNonce');
     });
 
     test('test NotEnoughBalance message uses human readable values', () => {


### PR DESCRIPTION
## Motivation
This is a partial restoration of changes from #910 . At this moment near-api-js is not returning proper error types for errors: `AccountDoesNotExist`, `AccessKeyDoesNotExist`, `CodeDoesNotExist`, `InvalidNonce`. Issue: #980 .

## Description
1. Restoring `getErrorTypeFromErrorMessage` function, with a default value change. The previous implementation was always returning `UntypedError` if the error message doesn't match pointed strings, which means it could possibly change the type even if it already exists, which was not ideal - this function should return the proper type if it matches, and don't change the type if not matches. If the request doesn't have a type at all, we have a proper condition to change the type if it doesn't exist in the `TypedError` class.
2. Restoring usage of `getErrorTypeFromErrorMessage` in `JsonRpcProvider.query` method, but with the current message.
3. Restoring usage of `getErrorTypeFromErrorMessage ` in `JsonRpcProvider.sendJsonRpc` method.
4. Restoring the test and also removing `UntypedError` case from it.

## Checklist
- [x] Read the [contributing](https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md) guidelines
- [x] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [x] Performed a self-review of the PR
- [x] Added automated tests
- [x] Manually tested the change
