### PR TITLE
Revert "Naj 44 make sign and send transaction functionality public"

### DIFF
--- a/.changeset/beige-suits-march.md
+++ b/.changeset/beige-suits-march.md
@@ -1,5 +1,0 @@
----
-"near-api-js": major
----
-
-Make `Account.signAndSendTransaction` `public` so transactions can be sent directly from `Account` instances

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 #IDE
 .idea
-.vscode
 
 storage
 node_modules

--- a/packages/near-api-js/src/account.ts
+++ b/packages/near-api-js/src/account.ts
@@ -225,7 +225,7 @@ export class Account {
      * Sign a transaction to preform a list of actions and broadcast it using the RPC API.
      * @see {@link providers/json-rpc-provider!JsonRpcProvider#sendTransaction | JsonRpcProvider.sendTransaction}
      */
-    async signAndSendTransaction({ receiverId, actions, returnError }: SignAndSendTransactionOptions): Promise<FinalExecutionOutcome> {
+    protected async signAndSendTransaction({ receiverId, actions, returnError }: SignAndSendTransactionOptions): Promise<FinalExecutionOutcome> {
         let txHash, signedTx;
         // TODO: TX_NONCE (different constants for different uses of exponentialBackoff?)
         const result = await exponentialBackoff(TX_NONCE_RETRY_WAIT, TX_NONCE_RETRY_NUMBER, TX_NONCE_RETRY_WAIT_BACKOFF, async () => {

--- a/packages/near-api-js/src/account_multisig.ts
+++ b/packages/near-api-js/src/account_multisig.ts
@@ -62,7 +62,7 @@ export class AccountMultisig extends Account {
         return super.signAndSendTransaction({ receiverId, actions });
     }
 
-    async signAndSendTransaction({ receiverId, actions }: SignAndSendTransactionOptions): Promise<FinalExecutionOutcome> {
+    protected async signAndSendTransaction({ receiverId, actions }: SignAndSendTransactionOptions): Promise<FinalExecutionOutcome> {
         const { accountId } = this;
 
         const args = Buffer.from(JSON.stringify({
@@ -234,7 +234,7 @@ export class Account2FA extends AccountMultisig {
      * Sign a transaction to preform a list of actions and broadcast it using the RPC API.
      * @see {@link providers/json-rpc-provider!JsonRpcProvider#sendTransaction | JsonRpcProvider.sendTransaction}
      */
-    async signAndSendTransaction({ receiverId, actions }: SignAndSendTransactionOptions): Promise<FinalExecutionOutcome> {
+    protected async signAndSendTransaction({ receiverId, actions }: SignAndSendTransactionOptions): Promise<FinalExecutionOutcome> {
         await super.signAndSendTransaction({ receiverId, actions });
         // TODO: Should following override onRequestResult in superclass instead of doing custom signAndSendTransaction?
         await this.sendCode();

--- a/packages/near-api-js/src/wallet-account.ts
+++ b/packages/near-api-js/src/wallet-account.ts
@@ -295,7 +295,7 @@ export class ConnectedWalletAccount extends Account {
      * Sign a transaction by redirecting to the NEAR Wallet
      * @see {@link WalletConnection.requestSignTransactions}
      */
-    async signAndSendTransaction({ receiverId, actions, walletMeta, walletCallbackUrl = window.location.href }: SignAndSendTransactionOptions): Promise<FinalExecutionOutcome> {
+    protected async signAndSendTransaction({ receiverId, actions, walletMeta, walletCallbackUrl = window.location.href }: SignAndSendTransactionOptions): Promise<FinalExecutionOutcome> {
         const localKey = await this.connection.signer.getPublicKey(this.accountId, this.connection.networkId);
         let accessKey = await this.accessKeyForTransaction(receiverId, actions, localKey);
         if (!accessKey) {

--- a/packages/near-api-js/test/account.test.js
+++ b/packages/near-api-js/test/account.test.js
@@ -4,7 +4,6 @@ const testUtils  = require('./test-utils');
 const { TypedError } = require('../src/utils/errors');
 const fs = require('fs');
 const BN = require('bn.js');
-const { transfer } = require('../src/transaction');
 
 let nearjs;
 let workingAccount;
@@ -43,15 +42,6 @@ test('send money', async() => {
     const receiver = await testUtils.createAccount(nearjs);
     const { amount: receiverAmount } = await receiver.state();
     await sender.sendMoney(receiver.accountId, new BN(10000));
-    const state = await receiver.state();
-    expect(state.amount).toEqual(new BN(receiverAmount).add(new BN(10000)).toString());
-});
-
-test('send money through signAndSendTransaction', async() => {
-    const sender = await testUtils.createAccount(nearjs);
-    const receiver = await testUtils.createAccount(nearjs);
-    const { amount: receiverAmount } = await receiver.state();
-    await sender.signAndSendTransaction({receiverId: receiver.accountId, actions: [transfer(new BN(10000))]});
     const state = await receiver.state();
     expect(state.amount).toEqual(new BN(receiverAmount).add(new BN(10000)).toString());
 });

--- a/packages/near-api-js/test/account_multisig.test.js
+++ b/packages/near-api-js/test/account_multisig.test.js
@@ -4,7 +4,6 @@ const fs = require('fs');
 const BN = require('bn.js');
 const testUtils  = require('./test-utils');
 const semver = require('semver');
-const { transfer } = require('../src/transaction');
 
 let nearjs;
 let startFromVersion;
@@ -120,16 +119,5 @@ describe('account2fa transactions', () => {
         const state = await receiver.state();
         expect(BigInt(state.amount)).toBeGreaterThanOrEqual(BigInt(new BN(receiverAmount).add(new BN(parseNearAmount('0.9'))).toString()));
     });
-
-    test('send money through signAndSendTransaction', async() => {
-        let sender = await testUtils.createAccount(nearjs);
-        let receiver = await testUtils.createAccount(nearjs);
-        sender = await getAccount2FA(sender);
-        receiver = await getAccount2FA(receiver);
-        const { amount: receiverAmount } = await receiver.state();
-        await sender.signAndSendTransaction({receiverId: receiver.accountId, actions: [transfer(new BN(parseNearAmount('1')))]});
-        const state = await receiver.state();
-        expect(BigInt(state.amount)).toBeGreaterThanOrEqual(BigInt(new BN(receiverAmount).add(new BN(parseNearAmount('0.9'))).toString()));
-    });
-        
+    
 });


### PR DESCRIPTION
Reverts near/near-api-js#1002

Doing this so we can release the minor/patch changes first and then commit to a major bump.