### PR TITLE
feat!: make appKeyPrefix required

### DIFF
--- a/.changeset/gentle-points-shake.md
+++ b/.changeset/gentle-points-shake.md
@@ -1,0 +1,19 @@
+---
+"near-api-js": major
+---
+
+Make `appKeyPrefix` a required arg to `WalletConnection` constructor
+
+Users that were doing
+
+```typescript
+new WalletConnection(near);
+```
+
+will now have to do
+
+```typescript
+new WalletConnection(near, "undefined");
+```
+
+If they want to access the keys they had potentially accumulated

--- a/packages/near-api-js/src/wallet-account.ts
+++ b/packages/near-api-js/src/wallet-account.ts
@@ -84,7 +84,10 @@ export class WalletConnection {
     /** @hidden */
     _completeSignInPromise: Promise<void>;
 
-    constructor(near: Near, appKeyPrefix: string | null) {
+    constructor(near: Near, appKeyPrefix: string) {
+        if(typeof(appKeyPrefix) != 'string') {
+            throw new Error('Please define a clear appKeyPrefix for this WalletConnection instance as the second argument to the constructor');
+        }
         if(typeof window === 'undefined') {
             return new Proxy(this, {
                 get(target, property) {
@@ -108,7 +111,6 @@ export class WalletConnection {
         const authData = JSON.parse(window.localStorage.getItem(authDataKey));
         this._networkId = near.config.networkId;
         this._walletBaseUrl = near.config.walletUrl;
-        appKeyPrefix = appKeyPrefix || near.config.contractName || 'default';
         this._keyStore = (near.connection.signer as InMemorySigner).keyStore;
         this._authData = authData || { allKeys: [] };
         this._authDataKey = authDataKey;

--- a/packages/near-api-js/test/wallet-account.test.js
+++ b/packages/near-api-js/test/wallet-account.test.js
@@ -50,11 +50,18 @@ beforeEach(() => {
             replaceState: (state, title, url) => history.push([state, title, url])
         }
     });
-    walletConnection = new nearApi.WalletConnection(nearFake);
+    walletConnection = new nearApi.WalletConnection(nearFake, '');
 });
 
 it('not signed in by default', () => {
     expect(walletConnection.isSignedIn()).not.toBeTruthy();
+});
+
+it('throws if non string appKeyPrefix', () => {
+    expect(() => new nearApi.WalletConnection(nearFake)).toThrow(/appKeyPrefix/);
+    expect(() => new nearApi.WalletConnection(nearFake, 1)).toThrow(/appKeyPrefix/);
+    expect(() => new nearApi.WalletConnection(nearFake, null)).toThrow(/appKeyPrefix/);
+    expect(() => new nearApi.WalletConnection(nearFake, undefined)).toThrow(/appKeyPrefix/);
 });
 
 describe('fails gracefully on the server side (without window)', () => {
@@ -70,26 +77,33 @@ describe('fails gracefully on the server side (without window)', () => {
     });
 
     it('does not throw on instantiation', () => {
-        expect(() => new nearApi.WalletConnection(nearFake)).not.toThrowError();
+        expect(() => new nearApi.WalletConnection(nearFake, '')).not.toThrowError();
+    });
+
+    it('throws if non string appKeyPrefix in server context', () => {
+        expect(() => new nearApi.WalletConnection(nearFake)).toThrow(/appKeyPrefix/);
+        expect(() => new nearApi.WalletConnection(nearFake, 1)).toThrow(/appKeyPrefix/);
+        expect(() => new nearApi.WalletConnection(nearFake, null)).toThrow(/appKeyPrefix/);
+        expect(() => new nearApi.WalletConnection(nearFake, undefined)).toThrow(/appKeyPrefix/);
     });
 
     it('returns an empty string as accountId', () => {
-        const serverWalletConnection = new nearApi.WalletConnection(nearFake);
+        const serverWalletConnection = new nearApi.WalletConnection(nearFake, '');
         expect(serverWalletConnection.getAccountId()).toEqual('');
     });
 
     it('returns false as isSignedIn', () => {
-        const serverWalletConnection = new nearApi.WalletConnection(nearFake);
+        const serverWalletConnection = new nearApi.WalletConnection(nearFake, '');
         expect(serverWalletConnection.isSignedIn()).toEqual(false);
     });
 
     it('throws explicit error when calling other methods on the instance', () => {
-        const serverWalletConnection = new nearApi.WalletConnection(nearFake);
+        const serverWalletConnection = new nearApi.WalletConnection(nearFake, '');
         expect(() => serverWalletConnection.requestSignIn('signInContract', 'signInTitle', 'http://example.com/success',  'http://example.com/fail')).toThrow(/please ensure you are using WalletConnection on the browser/);
     });
 
     it('can access other props on the instance', () => {
-        const serverWalletConnection = new nearApi.WalletConnection(nearFake);
+        const serverWalletConnection = new nearApi.WalletConnection(nearFake, '');
         expect(serverWalletConnection['randomValue']).toEqual(undefined);
     });
 });


### PR DESCRIPTION
## Motivation
Alternative approach to key migration implemented in #947 . Closes #325 

## Description
Makes `appKeyPrefix` a required arg to `WalletConnection` constructor

Users that were doing

```typescript
new WalletConnection(near);
```

will now have to do

```typescript
new WalletConnection(near, "undefined");
```

If they want to access the keys they had potentially accumulated

## Checklist
- [x] Read the [contributing](https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md) guidelines
- [x] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [x] Performed a self-review of the PR
- [x] Added automated tests
- [x] Manually tested the change
