### PR TITLE
chore(ts): enforce noImplicitAny

### DIFF
--- a/packages/near-api-js/package.json
+++ b/packages/near-api-js/package.json
@@ -79,5 +79,8 @@
         "dist",
         "browser-exports.js"
     ],
-    "author": "NEAR Inc"
+    "author": "NEAR Inc",
+    "optionalDependencies": {
+        "form-data": "^4.0.0"
+    }
 }

--- a/packages/near-api-js/package.json
+++ b/packages/near-api-js/package.json
@@ -25,8 +25,12 @@
     },
     "devDependencies": {
         "@types/bn.js": "^5.1.0",
+        "@types/depd": "^1.1.32",
+        "@types/form-data": "^2.5.0",
         "@types/http-errors": "^1.6.1",
+        "@types/mustache": "^4.2.1",
         "@types/node": "^18.7.14",
+        "@types/node-fetch": "^2.6.2",
         "browserify": "^16.2.3",
         "bundlewatch": "^0.3.1",
         "concurrently": "^7.3.0",

--- a/packages/near-api-js/src/account.ts
+++ b/packages/near-api-js/src/account.ts
@@ -226,7 +226,7 @@ export class Account {
             throw new TypedError('nonce retries exceeded for transaction. This usually means there are too many parallel requests with the same access key.', 'RetriesExceeded');
         }
 
-        printTxOutcomeLogsAndFailures({ contractId: signedTx.transaction.receiverId, outcome: result });
+        printTxOutcomeLogsAndFailures({ contractId: (signedTx as SignedTransaction)?.transaction.receiverId, outcome: result });
 
         // Should be falsy if result.status.Failure is null
         if (!returnError && typeof result.status === 'object' && typeof result.status.Failure === 'object'  && result.status.Failure !== null) {

--- a/packages/near-api-js/src/account.ts
+++ b/packages/near-api-js/src/account.ts
@@ -365,7 +365,7 @@ export class Account {
     }
 
     /** @hidden */
-    private encodeJSContractArgs(contractId: string, method: string, args) {
+    private encodeJSContractArgs(contractId: string, method: string, args: string) {
         return Buffer.concat([Buffer.from(contractId), Buffer.from([0]), Buffer.from(method), Buffer.from([0]), Buffer.from(args)]);
     }
 

--- a/packages/near-api-js/src/connect.ts
+++ b/packages/near-api-js/src/connect.ts
@@ -27,6 +27,8 @@ import { Near, NearConfig } from './near';
 import fetch from './utils/setup-node-fetch';
 import { logWarning } from './utils';
 
+/* TODO this is grandfathered in and will be removed as we migrate to packages */
+/* @ts-expect-error: the global fetch type is being narrowed here but it doesn't impact our current use */
 global.fetch = fetch;
 
 export interface ConnectConfig extends NearConfig {

--- a/packages/near-api-js/src/providers/json-rpc-provider.ts
+++ b/packages/near-api-js/src/providers/json-rpc-provider.ts
@@ -149,7 +149,7 @@ export class JsonRpcProvider extends Provider {
         if (result && result.error) {
             throw new TypedError(
                 `Querying failed: ${result.error}.\n${JSON.stringify(result, null, 2)}`,
-                getErrorTypeFromErrorMessage(result.error, result.error.name)
+                getErrorTypeFromErrorMessage(result.error.toString(), result.error.name)
             );
         }
         return result;

--- a/packages/near-api-js/src/providers/provider.ts
+++ b/packages/near-api-js/src/providers/provider.ts
@@ -315,6 +315,7 @@ export interface AccessKeyWithPublicKey {
 export interface QueryResponseKind {
     block_height: BlockHeight;
     block_hash: BlockHash;
+    error: Error;
 }
 
 export interface AccountView extends QueryResponseKind {

--- a/packages/near-api-js/src/transaction.ts
+++ b/packages/near-api-js/src/transaction.ts
@@ -244,7 +244,7 @@ async function signTransactionObject(transaction: Transaction, signer: Signer, a
 
 export async function signTransaction(transaction: Transaction, signer: Signer, accountId?: string, networkId?: string): Promise<[Uint8Array, SignedTransaction]>;
 export async function signTransaction(receiverId: string, nonce: BN, actions: Action[], blockHash: Uint8Array, signer: Signer, accountId?: string, networkId?: string): Promise<[Uint8Array, SignedTransaction]>;
-export async function signTransaction(...args): Promise<[Uint8Array, SignedTransaction]> {
+export async function signTransaction(...args: any[]): Promise<[Uint8Array, SignedTransaction]> {
     if (args[0].constructor === Transaction) {
         const [ transaction, signer, accountId, networkId ] = args;
         return signTransactionObject(transaction, signer, accountId, networkId);

--- a/packages/near-api-js/src/utils/exponential-backoff.ts
+++ b/packages/near-api-js/src/utils/exponential-backoff.ts
@@ -1,4 +1,4 @@
-export default async function exponentialBackoff(startWaitTime, retryNumber, waitBackoff, getResult) {
+export default async function exponentialBackoff(startWaitTime: number, retryNumber: number, waitBackoff: number, getResult: () => Promise<any>) {
     // TODO: jitter?
 
     let waitTime = startWaitTime;

--- a/packages/near-api-js/src/utils/setup-node-fetch.ts
+++ b/packages/near-api-js/src/utils/setup-node-fetch.ts
@@ -1,3 +1,4 @@
+
 import fetch from 'node-fetch';
 import http from 'http';
 import https from 'https';
@@ -5,7 +6,7 @@ import https from 'https';
 const httpAgent = new http.Agent({ keepAlive: true });
 const httpsAgent = new https.Agent({ keepAlive: true });
 
-function agent(_parsedURL) {
+function agent(_parsedURL: URL) {
     if (_parsedURL.protocol === 'http:') {
         return httpAgent;
     } else {
@@ -13,7 +14,7 @@ function agent(_parsedURL) {
     }
 }
 
-export default function (resource, init) {
+export default function (resource: string, init: object) {
     return fetch(resource, {
         agent: agent(new URL(resource.toString())),
         ...init,

--- a/packages/near-api-js/src/wallet-account.ts
+++ b/packages/near-api-js/src/wallet-account.ts
@@ -10,6 +10,7 @@ import { Account, SignAndSendTransactionOptions } from './account';
 import { Near } from './near';
 import { KeyStore } from './key_stores';
 import { FinalExecutionOutcome } from './providers';
+import { AccessKeyInfoView } from './providers/provider';
 import { InMemorySigner } from './signer';
 import { Transaction, Action, SCHEMA, createTransaction } from './transaction';
 import { KeyPair, PublicKey } from './utils';
@@ -94,12 +95,15 @@ export class WalletConnection {
                     if(property === 'getAccountId') {
                         return () => '';
                     }
-                    if(target[property] && typeof target[property] === 'function') {
+
+                    const targetProperty = (target as { [key: string | symbol]: any })[property];
+                    if (targetProperty && typeof targetProperty === 'function') {
                         return () => {
                             throw new Error('No window found in context, please ensure you are using WalletConnection on the browser');
                         };
                     }
-                    return target[property];
+
+                    return targetProperty;
                 }
             });
         }
@@ -343,7 +347,7 @@ export class ConnectedWalletAccount extends Account {
      * @param receiverId The NEAR account attempting to have access
      * @param actions The action(s) needed to be checked for access
      */
-    async accessKeyMatchesTransaction(accessKey, receiverId: string, actions: Action[]): Promise<boolean> {
+    async accessKeyMatchesTransaction(accessKey: AccessKeyInfoView, receiverId: string, actions: Action[]): Promise<boolean> {
         const { access_key: { permission } } = accessKey;
         if (permission === 'FullAccess') {
             return true;

--- a/packages/near-api-js/tsconfig.json
+++ b/packages/near-api-js/tsconfig.json
@@ -17,7 +17,7 @@
         "pretty": false,
         "forceConsistentCasingInFileNames": true,
         "noFallthroughCasesInSwitch": true,
-        "noImplicitAny": false,
+        "noImplicitAny": true,
         "noImplicitReturns": true,
         "noUnusedLocals": true,
         "experimentalDecorators": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,8 +43,12 @@ importers:
   packages/near-api-js:
     specifiers:
       '@types/bn.js': ^5.1.0
+      '@types/depd': ^1.1.32
+      '@types/form-data': ^2.5.0
       '@types/http-errors': ^1.6.1
+      '@types/mustache': ^4.2.1
       '@types/node': ^18.7.14
+      '@types/node-fetch': ^2.6.2
       bn.js: 5.2.1
       borsh: ^0.7.0
       browserify: ^16.2.3
@@ -83,8 +87,12 @@ importers:
       tweetnacl: 1.0.3
     devDependencies:
       '@types/bn.js': 5.1.1
+      '@types/depd': 1.1.32
+      '@types/form-data': 2.5.0
       '@types/http-errors': 1.8.2
+      '@types/mustache': 4.2.1
       '@types/node': 18.7.14
+      '@types/node-fetch': 2.6.2
       browserify: 16.5.2
       bundlewatch: 0.3.3
       concurrently: 7.3.0
@@ -1305,6 +1313,19 @@ packages:
       '@types/node': 18.7.14
     dev: true
 
+  /@types/depd/1.1.32:
+    resolution: {integrity: sha512-kB2cpXs3A0TGWl4a4h74yIwvclYZUTW6Irpee/3Dc1s4Cr5rGPHtpGPpBBpEV1MaKH5z/oul+57oDkEkeRXRnw==}
+    dependencies:
+      '@types/node': 18.7.14
+    dev: true
+
+  /@types/form-data/2.5.0:
+    resolution: {integrity: sha512-23/wYiuckYYtFpL+4RPWiWmRQH2BjFuqCUi2+N3amB1a1Drv+i/byTrGvlLwRVLFNAZbwpbQ7JvTK+VCAPMbcg==}
+    deprecated: This is a stub types definition. form-data provides its own type definitions, so you do not need this installed.
+    dependencies:
+      form-data: 3.0.1
+    dev: true
+
   /@types/graceful-fs/4.1.5:
     resolution: {integrity: sha512-anKkLmZZ+xm4p8JWBf4hElkM4XR+EZeA2M9BAkkTldmcyDY4mbdIJnRghDJH3Ov5ooY7/UAoENtmdMSkaAd7Cw==}
     dependencies:
@@ -1343,6 +1364,17 @@ packages:
 
   /@types/minimist/1.2.2:
     resolution: {integrity: sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==}
+    dev: true
+
+  /@types/mustache/4.2.1:
+    resolution: {integrity: sha512-gFAlWL9Ik21nJioqjlGCnNYbf9zHi0sVbaZ/1hQEBcCEuxfLJDvz4bVJSV6v6CUaoLOz0XEIoP7mSrhJ6o237w==}
+    dev: true
+
+  /@types/node-fetch/2.6.2:
+    resolution: {integrity: sha512-DHqhlq5jeESLy19TYhLakJ07kNumXWjcDdxXsLUMJZ6ue8VZJj4kLPQVE/2mdHh3xZziNF1xppu5lwmS53HR+A==}
+    dependencies:
+      '@types/node': 18.7.14
+      form-data: 3.0.1
     dev: true
 
   /@types/node/12.20.55:
@@ -1934,9 +1966,9 @@ packages:
     resolution: {integrity: sha512-erYug8XoqzU3IfcU8fUgyHqyOXqIE4tUTTQ+7mqUjQlvnXkOO6OlT9c/ZoJVHYoAaqGxr09CN53G7XIsO4KtWA==}
     hasBin: true
     dependencies:
+      JSONStream: 1.3.5
       combine-source-map: 0.8.0
       defined: 1.0.0
-      JSONStream: 1.3.5
       safe-buffer: 5.2.1
       through2: 2.0.5
       umd: 3.0.3
@@ -2012,6 +2044,7 @@ packages:
     engines: {node: '>= 0.8'}
     hasBin: true
     dependencies:
+      JSONStream: 1.3.5
       assert: 1.5.0
       browser-pack: 6.1.0
       browser-resolve: 2.0.0
@@ -2033,7 +2066,6 @@ packages:
       https-browserify: 1.0.0
       inherits: 2.0.4
       insert-module-globals: 7.2.1
-      JSONStream: 1.3.5
       labeled-stream-splicer: 2.0.2
       mkdirp-classic: 0.5.3
       module-deps: 6.2.3
@@ -2432,8 +2464,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
-      is-text-path: 1.0.1
       JSONStream: 1.3.5
+      is-text-path: 1.0.1
       lodash: 4.17.21
       meow: 8.1.2
       split2: 3.2.2
@@ -4053,11 +4085,11 @@ packages:
     resolution: {integrity: sha512-ufS5Qq9RZN+Bu899eA9QCAYThY+gGW7oRkmb0vC93Vlyu/CFGcH0OYPEjVkDXA5FEbTt1+VWzdoOD3Ny9N+8tg==}
     hasBin: true
     dependencies:
+      JSONStream: 1.3.5
       acorn-node: 1.8.2
       combine-source-map: 0.8.0
       concat-stream: 1.6.2
       is-buffer: 1.1.6
-      JSONStream: 1.3.5
       path-is-absolute: 1.0.1
       process: 0.11.10
       through2: 2.0.5
@@ -5428,6 +5460,7 @@ packages:
     engines: {node: '>= 0.8.0'}
     hasBin: true
     dependencies:
+      JSONStream: 1.3.5
       browser-resolve: 2.0.0
       cached-path-relative: 1.1.0
       concat-stream: 1.6.2
@@ -5435,7 +5468,6 @@ packages:
       detective: 5.2.1
       duplexer2: 0.1.4
       inherits: 2.0.4
-      JSONStream: 1.3.5
       parents: 1.0.1
       readable-stream: 2.3.7
       resolve: 1.22.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,7 @@ importers:
       danger-plugin-yarn: ^1.3.2
       depd: ^2.0.0
       error-polyfill: ^0.1.3
+      form-data: ^4.0.0
       http-errors: ^1.7.2
       in-publish: ^2.0.0
       jest: ^26.0.1
@@ -85,6 +86,8 @@ importers:
       node-fetch: 2.6.7
       text-encoding-utf-8: 1.0.2
       tweetnacl: 1.0.3
+    optionalDependencies:
+      form-data: 4.0.0
     devDependencies:
       '@types/bn.js': 5.1.1
       '@types/depd': 1.1.32
@@ -1323,7 +1326,7 @@ packages:
     resolution: {integrity: sha512-23/wYiuckYYtFpL+4RPWiWmRQH2BjFuqCUi2+N3amB1a1Drv+i/byTrGvlLwRVLFNAZbwpbQ7JvTK+VCAPMbcg==}
     deprecated: This is a stub types definition. form-data provides its own type definitions, so you do not need this installed.
     dependencies:
-      form-data: 3.0.1
+      form-data: 4.0.0
     dev: true
 
   /@types/graceful-fs/4.1.5:
@@ -1778,7 +1781,6 @@ packages:
 
   /asynckit/0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
-    dev: true
 
   /atob/2.1.2:
     resolution: {integrity: sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==}
@@ -2370,7 +2372,6 @@ packages:
     engines: {node: '>= 0.8'}
     dependencies:
       delayed-stream: 1.0.0
-    dev: true
 
   /commander/2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -2845,7 +2846,6 @@ packages:
   /delayed-stream/1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
-    dev: true
 
   /depd/1.1.2:
     resolution: {integrity: sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==}
@@ -3523,6 +3523,14 @@ packages:
       combined-stream: 1.0.8
       mime-types: 2.1.35
     dev: true
+
+  /form-data/4.0.0:
+    resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
+    engines: {node: '>= 6'}
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      mime-types: 2.1.35
 
   /fragment-cache/0.2.1:
     resolution: {integrity: sha512-GMBAbW9antB8iZRHLoGw0b3HANt57diZYFO/HL1JGIC1MjKrdmhxvrJbupnVvpys0zsz7yBApXdQyfepKly2kA==}
@@ -5386,14 +5394,12 @@ packages:
   /mime-db/1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
-    dev: true
 
   /mime-types/2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
     dependencies:
       mime-db: 1.52.0
-    dev: true
 
   /mimic-fn/2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}


### PR DESCRIPTION
## Motivation
This PR enables `noImplicitAny` to the tsconfig. It addresses part of #795 

## Description
- added missing type annotations
- added `@types` packages for dependencies without type declarations
- suppresses error around type narrowing when `global.fetch` is assigned to the local `fetch`

## Checklist
- [ ] Read the [contributing](https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md) guidelines
- [ ] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [ ] Performed a self-review of the PR
- [ ] Added automated tests
- [ ] Manually tested the change
