### PR TITLE
refactor: remove log/debug methods from `Account` class

### DIFF
--- a/packages/near-api-js/src/account.ts
+++ b/packages/near-api-js/src/account.ts
@@ -32,7 +32,7 @@ import { Connection } from './connection';
 import { baseDecode, baseEncode } from 'borsh';
 import { PublicKey } from './utils/key_pair';
 import { logWarning, PositionalArgsError } from './utils/errors';
-import { printLogs, printLogsAndFailures } from './utils/logging';
+import { printTxOutcomeLogs, printTxOutcomeLogsAndFailures } from './utils/logging';
 import { parseResultError } from './utils/rpc_errors';
 import { DEFAULT_FUNCTION_CALL_GAS } from './constants';
 
@@ -226,7 +226,7 @@ export class Account {
             throw new TypedError('nonce retries exceeded for transaction. This usually means there are too many parallel requests with the same access key.', 'RetriesExceeded');
         }
 
-        printLogsAndFailures({ contractId: signedTx.transaction.receiverId, outcome: result });
+        printTxOutcomeLogsAndFailures({ contractId: signedTx.transaction.receiverId, outcome: result });
 
         // Should be falsy if result.status.Failure is null
         if (!returnError && typeof result.status === 'object' && typeof result.status.Failure === 'object'  && result.status.Failure !== null) {
@@ -499,7 +499,7 @@ export class Account {
         });
 
         if (result.logs) {
-            printLogs({ contractId, logs: result.logs });
+            printTxOutcomeLogs({ contractId, logs: result.logs });
         }
 
         return result.result && result.result.length > 0 && parse(Buffer.from(result.result));

--- a/packages/near-api-js/src/utils/logging.ts
+++ b/packages/near-api-js/src/utils/logging.ts
@@ -1,0 +1,58 @@
+import { FinalExecutionOutcome } from '../providers';
+import { parseRpcError } from './rpc_errors';
+
+const SUPPRESS_LOGGING = !!process.env.NEAR_NO_LOGS;
+
+export function printLogsAndFailures({
+    contractId,
+    outcome,
+    suppressLogging = SUPPRESS_LOGGING,
+}: { contractId: string, outcome: FinalExecutionOutcome, suppressLogging?: boolean }) {
+    if (suppressLogging) {
+        return;
+    }
+
+    const flatLogs = [outcome.transaction_outcome, ...outcome.receipts_outcome]
+        .reduce((acc, it) => {
+            const isFailure = typeof it.outcome.status === 'object' && typeof it.outcome.status.Failure === 'object';
+            if (it.outcome.logs.length || isFailure) {
+                return acc.concat({
+                    receiptIds: it.outcome.receipt_ids,
+                    logs: it.outcome.logs,
+                    failure: typeof it.outcome.status === 'object' && it.outcome.status.Failure !== undefined
+                        ? parseRpcError(it.outcome.status.Failure)
+                        : null
+                });
+            } else {
+                return acc;
+            }
+        }, []);
+
+    for (const result of flatLogs) {
+        console.log(`Receipt${result.receiptIds.length > 1 ? 's' : ''}: ${result.receiptIds.join(', ')}`);
+        printLogs({
+            contractId,
+            logs: result.logs,
+            prefix: '\t',
+        });
+
+        if (result.failure) {
+            console.warn(`\tFailure [${contractId}]: ${result.failure}`);
+        }
+    }
+}
+
+export function printLogs({
+    contractId,
+    logs,
+    prefix = '',
+    suppressLogging = SUPPRESS_LOGGING,
+}: { contractId: string, logs: string[], prefix?: string, suppressLogging?: boolean }) {
+    if (suppressLogging) {
+        return;
+    }
+
+    for (const log of logs) {
+        console.log(`${prefix}Log [${contractId}]: ${log}`);
+    }
+}

--- a/packages/near-api-js/src/utils/logging.ts
+++ b/packages/near-api-js/src/utils/logging.ts
@@ -8,14 +8,12 @@ const SUPPRESS_LOGGING = !!process.env.NEAR_NO_LOGS;
  * @param params
  * @param params.contractId ID of the account/contract which made the query
  * @param params.outcome the query execution response
- * @param params.suppressLogging disables console output when `true`
  */
 export function printTxOutcomeLogsAndFailures({
     contractId,
     outcome,
-    suppressLogging = SUPPRESS_LOGGING,
-}: { contractId: string, outcome: FinalExecutionOutcome, suppressLogging?: boolean }) {
-    if (suppressLogging) {
+}: { contractId: string, outcome: FinalExecutionOutcome }) {
+    if (SUPPRESS_LOGGING) {
         return;
     }
 
@@ -54,15 +52,13 @@ export function printTxOutcomeLogsAndFailures({
  * @param params
  * @param params.contractId ID of the account/contract which made the query
  * @param params.logs log output from a query execution response
- * @param params.suppressLogging disables console output when `true`
  */
 export function printTxOutcomeLogs({
     contractId,
     logs,
     prefix = '',
-    suppressLogging = SUPPRESS_LOGGING,
-}: { contractId: string, logs: string[], prefix?: string, suppressLogging?: boolean }) {
-    if (suppressLogging) {
+}: { contractId: string, logs: string[], prefix?: string }) {
+    if (SUPPRESS_LOGGING) {
         return;
     }
 

--- a/packages/near-api-js/src/utils/logging.ts
+++ b/packages/near-api-js/src/utils/logging.ts
@@ -52,6 +52,7 @@ export function printTxOutcomeLogsAndFailures({
  * @param params
  * @param params.contractId ID of the account/contract which made the query
  * @param params.logs log output from a query execution response
+ * @param params.prefix string to append to the beginning of each log
  */
 export function printTxOutcomeLogs({
     contractId,

--- a/packages/near-api-js/src/utils/logging.ts
+++ b/packages/near-api-js/src/utils/logging.ts
@@ -3,6 +3,13 @@ import { parseRpcError } from './rpc_errors';
 
 const SUPPRESS_LOGGING = !!process.env.NEAR_NO_LOGS;
 
+/**
+ * Parse and print details from a query execution response
+ * @param params
+ * @param params.contractId ID of the account/contract which made the query
+ * @param params.outcome the query execution response
+ * @param params.suppressLogging disables console output when `true`
+ */
 export function printLogsAndFailures({
     contractId,
     outcome,
@@ -42,6 +49,13 @@ export function printLogsAndFailures({
     }
 }
 
+/**
+ * Format and print log output from a query execution response
+ * @param params
+ * @param params.contractId ID of the account/contract which made the query
+ * @param params.logs log output from a query execution response
+ * @param params.suppressLogging disables console output when `true`
+ */
 export function printLogs({
     contractId,
     logs,

--- a/packages/near-api-js/src/utils/logging.ts
+++ b/packages/near-api-js/src/utils/logging.ts
@@ -10,7 +10,7 @@ const SUPPRESS_LOGGING = !!process.env.NEAR_NO_LOGS;
  * @param params.outcome the query execution response
  * @param params.suppressLogging disables console output when `true`
  */
-export function printLogsAndFailures({
+export function printTxOutcomeLogsAndFailures({
     contractId,
     outcome,
     suppressLogging = SUPPRESS_LOGGING,
@@ -37,7 +37,7 @@ export function printLogsAndFailures({
 
     for (const result of flatLogs) {
         console.log(`Receipt${result.receiptIds.length > 1 ? 's' : ''}: ${result.receiptIds.join(', ')}`);
-        printLogs({
+        printTxOutcomeLogs({
             contractId,
             logs: result.logs,
             prefix: '\t',
@@ -56,7 +56,7 @@ export function printLogsAndFailures({
  * @param params.logs log output from a query execution response
  * @param params.suppressLogging disables console output when `true`
  */
-export function printLogs({
+export function printTxOutcomeLogs({
     contractId,
     logs,
     prefix = '',


### PR DESCRIPTION
## Motivation
This PR moves the `printLogs` and `printLogsAndFailures` private methods out of the `Account` class and into independent functions under `/utils`.

## Description
This is the first step towards refactoring the transaction signing/sending behavior out of the `Account` class hierarchy.

## Checklist
- [x] Read the [contributing](https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md) guidelines
- [x] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [x] Performed a self-review of the PR
- [x] Added automated tests
- [x] Manually tested the change
