### PR TITLE
Refactor: remove duplicate types and move out multisig

### DIFF
--- a/packages/near-api-js/src/account.ts
+++ b/packages/near-api-js/src/account.ts
@@ -31,7 +31,7 @@ import { PublicKey } from './utils/key_pair';
 import { PositionalArgsError } from './utils/errors';
 import { printLogs } from './utils/logging';
 import { DEFAULT_FUNCTION_CALL_GAS } from './constants';
-import { TransactionSender } from './transaction_sender';
+import { SignAndSendTransactionOptions, TransactionSender } from './transaction_sender';
 
 export interface AccountBalance {
     total: string;
@@ -44,25 +44,6 @@ export interface AccountAuthorizedApp {
     contractId: string;
     amount: string;
     publicKey: string;
-}
-
-/**
- * Options used to initiate sining and sending transactions
- */
-export interface SignAndSendTransactionOptions {
-    receiverId: string;
-    actions: Action[];
-    /**
-     * Metadata to send the NEAR Wallet if using it to sign transactions.
-     * @see {@link RequestSignTransactionsOptions}
-     */
-    walletMeta?: string;
-    /**
-     * Callback url to send the NEAR Wallet if using it to sign transactions.
-     * @see {@link RequestSignTransactionsOptions}
-     */
-    walletCallbackUrl?: string;
-    returnError?: boolean;
 }
 
 /**
@@ -179,7 +160,7 @@ export class Account {
      * Sign a transaction to preform a list of actions and broadcast it using the RPC API.
      * @see {@link providers/json-rpc-provider!JsonRpcProvider#sendTransaction | JsonRpcProvider.sendTransaction}
      */
-    async signAndSendTransaction({ receiverId, actions, returnError }: SignAndSendTransactionOptions): Promise<FinalExecutionOutcome> {
+    async signAndSendTransaction({ receiverId, actions, returnError }: Omit<SignAndSendTransactionOptions, 'signerId'>): Promise<FinalExecutionOutcome> {
         return this.sender.signAndSendTransaction({
             signerId: this.accountId,
             receiverId,

--- a/packages/near-api-js/src/transaction_sender.ts
+++ b/packages/near-api-js/src/transaction_sender.ts
@@ -3,13 +3,12 @@ import { baseDecode, baseEncode } from 'borsh';
 import { Connection } from './connection';
 import { ErrorContext, TypedError } from './providers';
 import { AccessKeyView, AccessKeyViewRaw, FinalExecutionOutcome } from './providers/provider';
-import { Action, functionCall, SignedTransaction, signTransaction } from './transaction';
+import { Action, SignedTransaction, signTransaction } from './transaction';
 import { logWarning } from './utils/errors';
 import { PublicKey } from './utils/key_pair';
 import { printLogsAndFailures } from './utils/logging';
 import exponentialBackoff from './utils/exponential-backoff';
 import { parseResultError } from './utils/rpc_errors';
-import { convertActionsForMultisig, MULTISIG_DEPOSIT, MULTISIG_GAS } from './utils/multisig';
 
 // Default number of retries with different nonce before giving up on a transaction.
 const TX_NONCE_RETRY_NUMBER = 12;
@@ -172,22 +171,5 @@ export class TransactionSender {
 
             throw e;
         }
-    }
-
-    signAndSendMultisigTransaction({ signerId, multisigAccountId, receiverId, actions }: SignAndSendTransactionOptions & { multisigAccountId: string }) {
-        const args = Buffer.from(JSON.stringify({
-            request: {
-                receiver_id: receiverId,
-                actions: convertActionsForMultisig(actions, signerId, receiverId)
-            }
-        }));
-
-        return this.signAndSendTransaction({
-            signerId,
-            receiverId: multisigAccountId,
-            actions: [
-                functionCall('add_request_and_confirm', args, MULTISIG_GAS, MULTISIG_DEPOSIT)
-            ]
-        });
     }
 }

--- a/packages/near-api-js/src/transaction_sender.ts
+++ b/packages/near-api-js/src/transaction_sender.ts
@@ -188,6 +188,6 @@ export class TransactionSender {
             actions: [
                 functionCall('add_request_and_confirm', args, MULTISIG_GAS, MULTISIG_DEPOSIT)
             ]
-        })
+        });
     }
 }

--- a/packages/near-api-js/src/transaction_sender.ts
+++ b/packages/near-api-js/src/transaction_sender.ts
@@ -3,12 +3,13 @@ import { baseDecode, baseEncode } from 'borsh';
 import { Connection } from './connection';
 import { ErrorContext, TypedError } from './providers';
 import { AccessKeyView, AccessKeyViewRaw, FinalExecutionOutcome } from './providers/provider';
-import { Action, SignedTransaction, signTransaction } from './transaction';
+import { Action, functionCall, SignedTransaction, signTransaction } from './transaction';
 import { logWarning } from './utils/errors';
 import { PublicKey } from './utils/key_pair';
 import { printLogsAndFailures } from './utils/logging';
 import exponentialBackoff from './utils/exponential-backoff';
 import { parseResultError } from './utils/rpc_errors';
+import { convertActionsForMultisig, MULTISIG_DEPOSIT, MULTISIG_GAS } from './utils/multisig';
 
 // Default number of retries with different nonce before giving up on a transaction.
 const TX_NONCE_RETRY_NUMBER = 12;
@@ -171,5 +172,22 @@ export class TransactionSender {
 
             throw e;
         }
+    }
+
+    signAndSendMultisigTransaction({ signerId, multisigAccountId, receiverId, actions }: SignAndSendTransactionOptions & { multisigAccountId: string }) {
+        const args = Buffer.from(JSON.stringify({
+            request: {
+                receiver_id: receiverId,
+                actions: convertActionsForMultisig(actions, signerId, receiverId)
+            }
+        }));
+
+        return this.signAndSendTransaction({
+            signerId,
+            receiverId: multisigAccountId,
+            actions: [
+                functionCall('add_request_and_confirm', args, MULTISIG_GAS, MULTISIG_DEPOSIT)
+            ]
+        })
     }
 }

--- a/packages/near-api-js/src/utils/index.ts
+++ b/packages/near-api-js/src/utils/index.ts
@@ -5,6 +5,8 @@ import * as web from './web';
 import * as enums from './enums';
 import * as format from './format';
 import * as rpc_errors from './rpc_errors';
+import * as logging from './logging';
+import * as multisig from './multisig'
 
 import { PublicKey, KeyPair, KeyPairEd25519 } from './key_pair';
 import { logWarning } from './errors';
@@ -20,4 +22,6 @@ export {
     KeyPairEd25519,
     rpc_errors,
     logWarning,
+    logging,
+    multisig
 };

--- a/packages/near-api-js/src/utils/index.ts
+++ b/packages/near-api-js/src/utils/index.ts
@@ -6,7 +6,7 @@ import * as enums from './enums';
 import * as format from './format';
 import * as rpc_errors from './rpc_errors';
 import * as logging from './logging';
-import * as multisig from './multisig'
+import * as multisig from './multisig';
 
 import { PublicKey, KeyPair, KeyPairEd25519 } from './key_pair';
 import { logWarning } from './errors';

--- a/packages/near-api-js/src/utils/multisig.ts
+++ b/packages/near-api-js/src/utils/multisig.ts
@@ -1,0 +1,46 @@
+import { BN } from 'bn.js';
+import { parseNearAmount } from './format';
+
+export const MULTISIG_ALLOWANCE = new BN(parseNearAmount('1') as string);
+
+export const MULTISIG_CHANGE_METHODS = ['add_request', 'add_request_and_confirm', 'delete_request', 'confirm'];
+
+export const MULTISIG_GAS = new BN('100000000000000');
+
+export const MULTISIG_DEPOSIT = new BN('0');
+
+export const convertPublicKeyForMultisig = (pk) => pk.toString().replace('ed25519:', '');
+
+export const convertActionsForMultisig = (actions, accountId, receiverId) => actions.map((a) => {
+    const type = a.enum;
+    const { gas, publicKey, methodName, args, deposit, accessKey, code } = a[type];
+    const action: any = {
+        type: type[0].toUpperCase() + type.substr(1),
+        gas: (gas && gas.toString()) || undefined,
+        public_key: (publicKey && convertPublicKeyForMultisig(publicKey)) || undefined,
+        method_name: methodName,
+        args: (args && Buffer.from(args).toString('base64')) || undefined,
+        code: (code && Buffer.from(code).toString('base64')) || undefined,
+        amount: (deposit && deposit.toString()) || undefined,
+        deposit: (deposit && deposit.toString()) || '0',
+        permission: undefined,
+    };
+    if (accessKey) {
+        if (receiverId === accountId && accessKey.permission.enum !== 'fullAccess') {
+            action.permission = {
+                receiver_id: accountId,
+                allowance: MULTISIG_ALLOWANCE.toString(),
+                method_names: MULTISIG_CHANGE_METHODS,
+            };
+        }
+        if (accessKey.permission.enum === 'functionCall') {
+            const { receiverId: receiver_id, methodNames: method_names, allowance } = accessKey.permission.functionCall;
+            action.permission = {
+                receiver_id,
+                allowance: (allowance && allowance.toString()) || undefined,
+                method_names
+            };
+        }
+    }
+    return action;
+});

--- a/packages/near-api-js/src/wallet-account.ts
+++ b/packages/near-api-js/src/wallet-account.ts
@@ -6,7 +6,7 @@
  * 
  * @module walletAccount
  */
-import { Account, SignAndSendTransactionOptions } from './account';
+import { Account } from './account';
 import { Near } from './near';
 import { KeyStore } from './key_stores';
 import { FinalExecutionOutcome } from './providers';
@@ -17,7 +17,7 @@ import { baseDecode } from 'borsh';
 import { Connection } from './connection';
 import { serialize } from 'borsh';
 import BN from 'bn.js';
-import { TransactionSender } from './transaction_sender';
+import { SignAndSendTransactionOptions, TransactionSender } from './transaction_sender';
 
 const LOGIN_WALLET_URL_SUFFIX = '/login/';
 const MULTISIG_HAS_METHOD = 'add_request_and_confirm';
@@ -300,7 +300,7 @@ export class ConnectedWalletAccount extends Account {
      * Sign a transaction by redirecting to the NEAR Wallet
      * @see {@link WalletConnection.requestSignTransactions}
      */
-    async signAndSendTransaction({ receiverId, actions, walletMeta, walletCallbackUrl = window.location.href }: SignAndSendTransactionOptions): Promise<FinalExecutionOutcome> {
+    async signAndSendTransaction({ receiverId, actions, walletMeta, walletCallbackUrl = window.location.href }: Omit<SignAndSendTransactionOptions, 'signerId'>): Promise<FinalExecutionOutcome> {
         const localKey = await this.connection.signer.getPublicKey(this.accountId, this.connection.networkId);
         let accessKey = await this.accessKeyForTransaction(receiverId, actions, localKey);
         if (!accessKey) {

--- a/packages/near-api-js/test/account_multisig.test.js
+++ b/packages/near-api-js/test/account_multisig.test.js
@@ -127,7 +127,6 @@ describe('account2fa transactions', () => {
         sender = await getAccount2FA(sender);
         receiver = await getAccount2FA(receiver);
         const { amount: receiverAmount } = await receiver.state();
-        console.log(receiverAmount, 'receiverAmt');
         await sender.signAndSendTransaction({receiverId: receiver.accountId, actions: [transfer(new BN(parseNearAmount('1')))]});
         const state = await receiver.state();
         expect(BigInt(state.amount)).toBeGreaterThanOrEqual(BigInt(new BN(receiverAmount).add(new BN(parseNearAmount('0.9'))).toString()));

--- a/packages/near-api-js/test/account_multisig.test.js
+++ b/packages/near-api-js/test/account_multisig.test.js
@@ -13,8 +13,8 @@ const {
     KeyPair,
     transactions: { functionCall },
     InMemorySigner,
-    multisig: { Account2FA, MULTISIG_GAS, MULTISIG_DEPOSIT },
-    utils: { format: { parseNearAmount } }
+    multisig: { Account2FA },
+    utils: { format: { parseNearAmount }, multisig: { MULTISIG_GAS, MULTISIG_DEPOSIT } }
 } = nearApi;
 
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 50000;
@@ -127,6 +127,7 @@ describe('account2fa transactions', () => {
         sender = await getAccount2FA(sender);
         receiver = await getAccount2FA(receiver);
         const { amount: receiverAmount } = await receiver.state();
+        console.log(receiverAmount, 'receiverAmt');
         await sender.signAndSendTransaction({receiverId: receiver.accountId, actions: [transfer(new BN(parseNearAmount('1')))]});
         const state = await receiver.state();
         expect(BigInt(state.amount)).toBeGreaterThanOrEqual(BigInt(new BN(receiverAmount).add(new BN(parseNearAmount('0.9'))).toString()));


### PR DESCRIPTION
## Motivation
Augments the refactor in #1018

## Description
Further decouples multisig logic for more explicit multisig vs regular transactions and removes duplicate types and `TransactionSender` instances

## Checklist
- [x] Read the [contributing](https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md) guidelines
- [x] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [x] Performed a self-review of the PR
- [x] Added automated tests
- [x] Manually tested the change
