### PR TITLE
feat: Account2FA methods for batch converting multisig LAKs

### DIFF
--- a/packages/near-api-js/src/account_multisig.ts
+++ b/packages/near-api-js/src/account_multisig.ts
@@ -422,6 +422,10 @@ export class Account2FA extends AccountMultisig {
      * @param signingPublicKey the public key used to sign transactions in the wallet
      */
     async batchConvertKeys(signingPublicKey: string) {
+        if (!signingPublicKey || !PublicKey.fromString(signingPublicKey)) {
+            throw new Error('invalid public key');
+        }
+
         await this.validateMultisigState();
 
         let batch = 0;

--- a/packages/near-api-js/src/account_multisig.ts
+++ b/packages/near-api-js/src/account_multisig.ts
@@ -397,6 +397,18 @@ export class Account2FA extends AccountMultisig {
     }
 
     /**
+     * Returns `false` if multisig cannot be disabled by calling disable() directly
+     * i.e. account has too many LAKs to delete and re-create as FAKs for a single transaction
+     */
+    async canDisableMultisig() {
+        const keys = await this.get2faLimitedAccessKeys();
+
+        // there are max 4 actions required to disable 2FA on top of the key conversion (2 actions per key)
+        // (100 - 4) / 2 = 48 = LAK_CONVERSION_LIMIT - 2
+        return keys.length <= (LAK_CONVERSION_LIMIT - 2);
+    }
+
+    /**
      * Converts multisig LAKs (excluding the active key in the wallet, provided here as the
      * `signingPublicKey` argument) back to FAKs when there are too many key conversions to be
      * executed within the same transaction.

--- a/packages/near-api-js/test/account_multisig.test.js
+++ b/packages/near-api-js/test/account_multisig.test.js
@@ -214,6 +214,20 @@ describe('2fa batch key conversion', () => {
         }));
     });
 
+    test('batchConvertKeys throws an exception for empty or invalid signing keys', async() => {
+        await expect(async () => {
+            await sender.batchConvertKeys();
+        }).rejects.toBeTruthy();
+
+        await expect(async () => {
+            await sender.batchConvertKeys('');
+        }).rejects.toBeTruthy();
+
+        await expect(async () => {
+            await sender.batchConvertKeys('ed25519:123xyz');
+        }).rejects.toBeTruthy();
+    });
+
     test('batchConvertKeys signs the expected number of transactions', async() => {
         const batches = [
             { numberOfLaks: 1, numberOfBatches: 0 }, // one key means it's the one doing signing and so is omitted


### PR DESCRIPTION
## Motivation
This is the `near-api-js` component for https://pagodaplatform.atlassian.net/browse/WEP-192

## Description
This PR adds two methods to facilitate batch conversion of multisig LAKs back to FAKs outside of the workflow implemented in the `disable` methods. For users with > 48 keys, the current implementation will not work because it attempts to perform all key conversions at the time of disabling, exceeding the limit of 100 actions per transaction.

To mitigate this, a new workflow will be added to the wallet to determine whether multisig can be disabled with a single transaction (by calling `canDisableMultisig`). If not, the user will need to call `batchConvertKeys` to sign multisig transactions converting the target LAKs back to FAKs until only the current wallet signing key remains. Each batch of key conversions will require a 2FA prompt, but if progress is interrupted at any point it can be resumed with no side effects. Once all keys but the wallet signing key have been converted, the user may use the existing `Disable 2FA` workflow to complete the disable workflow.

The only caveat here is that by converting LAKs to FAKs outside of the disable workflow, multisig will remain deployed but converted access keys will now sign transactions directly as opposed to calling multisig methods. While this undermines the guarantees of 2FA, the workflow is only intended as a cleanup step immediately prior to rolling back deployment of the multisig contract. In addition the wallet signing key remains a LAK throughout this conversion process, ensuring that transactions signed in the wallet will still require a successful 2FA prompt. So long as users complete the batch conversion + disable in a single browser instance this will be the case.

## Checklist
- [x] Read the [contributing](https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md) guidelines
- [x] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [x] Performed a self-review of the PR
- [x] Added automated tests
- [x] Manually tested the change
