### PR TITLE
fix: `getNetworks` and `getAccounts` in `browser_local_storage_key_st…

### DIFF
--- a/packages/near-api-js/src/key_stores/browser_local_storage_key_store.ts
+++ b/packages/near-api-js/src/key_stores/browser_local_storage_key_store.ts
@@ -1,18 +1,18 @@
-import { KeyStore } from './keystore';
-import { KeyPair } from '../utils/key_pair';
+import { KeyStore } from "./keystore";
+import { KeyPair } from "../utils/key_pair";
 
-const LOCAL_STORAGE_KEY_PREFIX = 'near-api-js:keystore:';
+const LOCAL_STORAGE_KEY_PREFIX = "near-api-js:keystore:";
 
 /**
  * This class is used to store keys in the browsers local storage.
- * 
+ *
  * @see [https://docs.near.org/docs/develop/front-end/naj-quick-reference#key-store](https://docs.near.org/docs/develop/front-end/naj-quick-reference#key-store)
  * @example
  * ```js
  * import { connect, keyStores } from 'near-api-js';
- * 
+ *
  * const keyStore = new keyStores.BrowserLocalStorageKeyStore();
- * const config = { 
+ * const config = {
  *   keyStore, // instance of BrowserLocalStorageKeyStore
  *   networkId: 'testnet',
  *   nodeUrl: 'https://rpc.testnet.near.org',
@@ -20,7 +20,7 @@ const LOCAL_STORAGE_KEY_PREFIX = 'near-api-js:keystore:';
  *   helperUrl: 'https://helper.testnet.near.org',
  *   explorerUrl: 'https://explorer.testnet.near.org'
  * };
- * 
+ *
  * // inside an async function
  * const near = await connect(config)
  * ```
@@ -35,7 +35,10 @@ export class BrowserLocalStorageKeyStore extends KeyStore {
      * @param localStorage defaults to window.localStorage
      * @param prefix defaults to `near-api-js:keystore:`
      */
-    constructor(localStorage: any = window.localStorage, prefix = LOCAL_STORAGE_KEY_PREFIX) {
+    constructor(
+        localStorage: any = window.localStorage,
+        prefix = LOCAL_STORAGE_KEY_PREFIX
+    ) {
         super();
         this.localStorage = localStorage;
         this.prefix = prefix;
@@ -47,8 +50,15 @@ export class BrowserLocalStorageKeyStore extends KeyStore {
      * @param accountId The NEAR account tied to the key pair
      * @param keyPair The key pair to store in local storage
      */
-    async setKey(networkId: string, accountId: string, keyPair: KeyPair): Promise<void> {
-        this.localStorage.setItem(this.storageKeyForSecretKey(networkId, accountId), keyPair.toString());
+    async setKey(
+        networkId: string,
+        accountId: string,
+        keyPair: KeyPair
+    ): Promise<void> {
+        this.localStorage.setItem(
+            this.storageKeyForSecretKey(networkId, accountId),
+            keyPair.toString()
+        );
     }
 
     /**
@@ -58,7 +68,9 @@ export class BrowserLocalStorageKeyStore extends KeyStore {
      * @returns {Promise<KeyPair>}
      */
     async getKey(networkId: string, accountId: string): Promise<KeyPair> {
-        const value = this.localStorage.getItem(this.storageKeyForSecretKey(networkId, accountId));
+        const value = this.localStorage.getItem(
+            this.storageKeyForSecretKey(networkId, accountId)
+        );
         if (!value) {
             return null;
         }
@@ -71,7 +83,9 @@ export class BrowserLocalStorageKeyStore extends KeyStore {
      * @param accountId The NEAR account tied to the key pair
      */
     async removeKey(networkId: string, accountId: string): Promise<void> {
-        this.localStorage.removeItem(this.storageKeyForSecretKey(networkId, accountId));
+        this.localStorage.removeItem(
+            this.storageKeyForSecretKey(networkId, accountId)
+        );
     }
 
     /**
@@ -93,8 +107,8 @@ export class BrowserLocalStorageKeyStore extends KeyStore {
         const result = new Set<string>();
         for (const key of this.storageKeys()) {
             if (key.startsWith(this.prefix)) {
-                const parts = key.substring(this.prefix.length).split(':');
-                result.add(parts[1]);
+                const parts = key.substring(this.prefix.length).split(":");
+                result.add(parts[2]);
             }
         }
         return Array.from(result.values());
@@ -108,9 +122,9 @@ export class BrowserLocalStorageKeyStore extends KeyStore {
         const result = new Array<string>();
         for (const key of this.storageKeys()) {
             if (key.startsWith(this.prefix)) {
-                const parts = key.substring(this.prefix.length).split(':');
-                if (parts[1] === networkId) {
-                    result.push(parts[0]);
+                const parts = key.substring(this.prefix.length).split(":");
+                if (parts[2] === networkId) {
+                    result.push(parts[1]);
                 }
             }
         }
@@ -124,7 +138,10 @@ export class BrowserLocalStorageKeyStore extends KeyStore {
      * @param accountId The NEAR account tied to the storage keythat's sought
      * @returns {string} An example might be: `near-api-js:keystore:near-friend:default`
      */
-    private storageKeyForSecretKey(networkId: string, accountId: string): string {
+    private storageKeyForSecretKey(
+        networkId: string,
+        accountId: string
+    ): string {
         return `${this.prefix}${accountId}:${networkId}`;
     }
 


### PR DESCRIPTION
`getNetworks` and `getAccounts` is returning incorrect values, precisely there is a split string manipulation and the results are off by 1.

## Motivation
```js
let accounts = await keyStore.getAccounts("testnet");
```

The above line of code returns incorrect values.


## Description

The keyStore code basically does string manipulation using split and the developer made a mistake thinking that the structure of the keys in the keystore is [prefix]:[accountId]:[network].

However, there is one more string in between and the actual structure looks like this
[prefix]:ed25519:[account]:[network]

This is why when querying for accounts using `networkId` it returns nothing and getting networks returns accounts. Basically everything is offset by 1.

The below picture should explain it pretty well.

<img width="601" alt="image" src="https://user-images.githubusercontent.com/38040789/201034623-915649bd-e22e-4745-b2ed-57552c5c16a7.png">
 

## Checklist
- [ ] Read the [contributing](https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md) guidelines
- [x] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [x] Performed a self-review of the PR
- [ ] Added automated tests
- [x] Manually tested the change
