### PR TITLE
feat(async_keys): keys should be async to allow HSMs

### DIFF
--- a/packages/near-api-js/src/key_stores/in_memory_key_store.ts
+++ b/packages/near-api-js/src/key_stores/in_memory_key_store.ts
@@ -44,7 +44,7 @@ export class InMemoryKeyStore extends KeyStore {
      * @param keyPair The key pair to store in local storage
      */    
     async setKey(networkId: string, accountId: string, keyPair: KeyPair): Promise<void> {
-        this.keys[`${accountId}:${networkId}`] = keyPair.toString();
+        this.keys[`${accountId}:${networkId}`] = await keyPair.toString();
     }
 
     /**

--- a/packages/near-api-js/src/key_stores/unencrypted_file_system_keystore.ts
+++ b/packages/near-api-js/src/key_stores/unencrypted_file_system_keystore.ts
@@ -98,7 +98,7 @@ export class UnencryptedFileSystemKeyStore extends KeyStore {
      */
     async setKey(networkId: string, accountId: string, keyPair: KeyPair): Promise<void> {
         await ensureDir(`${this.keyDir}/${networkId}`);
-        const content: AccountInfo = { account_id: accountId, public_key: keyPair.getPublicKey().toString(), private_key: keyPair.toString() };
+        const content: AccountInfo = { account_id: accountId, public_key: (await keyPair.getPublicKey()).toString(), private_key: await keyPair.toString() };
         await writeFile(this.getKeyFilePath(networkId, accountId), JSON.stringify(content), { mode: 0o600 });
     }
 

--- a/packages/near-api-js/src/utils/key_pair.ts
+++ b/packages/near-api-js/src/utils/key_pair.ts
@@ -66,10 +66,10 @@ export class PublicKey extends Assignable {
 }
 
 export abstract class KeyPair {
-    abstract sign(message: Uint8Array): Signature;
-    abstract verify(message: Uint8Array, signature: Uint8Array): boolean;
-    abstract toString(): string;
-    abstract getPublicKey(): PublicKey;
+    abstract sign(message: Uint8Array): Promise<Signature>;
+    abstract verify(message: Uint8Array, signature: Uint8Array): Promise<boolean>;
+    abstract toString(): Promise<string>;
+    abstract getPublicKey(): Promise<PublicKey>;
 
     /**
      * @param curve Name of elliptical curve, case-insensitive
@@ -132,20 +132,20 @@ export class KeyPairEd25519 extends KeyPair {
         return new KeyPairEd25519(base_encode(newKeyPair.secretKey));
     }
 
-    sign(message: Uint8Array): Signature {
+    sign(message: Uint8Array): Promise<Signature> {
         const signature = nacl.sign.detached(message, base_decode(this.secretKey));
-        return { signature, publicKey: this.publicKey };
+        return Promise.resolve({ signature, publicKey: this.publicKey });
     }
 
-    verify(message: Uint8Array, signature: Uint8Array): boolean {
-        return this.publicKey.verify(message, signature);
+    verify(message: Uint8Array, signature: Uint8Array): Promise<boolean> {
+        return Promise.resolve(this.publicKey.verify(message, signature));
     }
 
-    toString(): string {
-        return `ed25519:${this.secretKey}`;
+    toString(): Promise<string> {
+        return Promise.resolve(`ed25519:${this.secretKey}`);
     }
 
-    getPublicKey(): PublicKey {
-        return this.publicKey;
+    getPublicKey(): Promise<PublicKey> {
+        return Promise.resolve(this.publicKey);
     }
 }

--- a/packages/near-api-js/src/wallet-account.ts
+++ b/packages/near-api-js/src/wallet-account.ts
@@ -186,8 +186,8 @@ export class WalletConnection {
 
             newUrl.searchParams.set('contract_id', contractId);
             const accessKey = KeyPair.fromRandom('ed25519');
-            newUrl.searchParams.set('public_key', accessKey.getPublicKey().toString());
-            await this._keyStore.setKey(this._networkId, PENDING_ACCESS_KEY_PREFIX + accessKey.getPublicKey(), accessKey);
+            newUrl.searchParams.set('public_key', (await accessKey.getPublicKey()).toString());
+            await this._keyStore.setKey(this._networkId, PENDING_ACCESS_KEY_PREFIX + await accessKey.getPublicKey(), accessKey);
         }
 
         if (methodNames) {


### PR DESCRIPTION
## Motivation

We use AWS KMS to secure our private keys. Thankfully secp256k1 is supported by the near blockchain. However, this client is not robust enough to allow for a custom AWS KMS signer. There is a built in assumption that `sign` and `verify` are _always_ sync which is not true in our case.

There is another problematic behavior that may need to be addressed in the presence of a system that does not allow (or want) private key export which is the `toString` function is exporting the private key (which we will not have). That can be handled by throwing at runtime if it comes down to that but it is not particularly desirable. Private key export via `toString` feels like quite a bad idea generally anyway.

## Description

Update signatures to return promises. For local implementations use `Promise.resolve`.

This is, unfortunately, a breaking change I think and technically would require a major version bump.

@volovyks for review or to forward to someone 🙏 🙇 

Looking for feedback / thoughts on this

## Checklist
- [x] Read the [contributing](https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md) guidelines
- [x] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [x] Performed a self-review of the PR
- [ ] Added automated tests (not done but sortof n/a due to this being a refactor)
- [ ] Manually tested the change (same)
