### PR TITLE
fix: fix validators function to accept null to show latest block info

### DIFF
--- a/.changeset/smooth-moons-brush.md
+++ b/.changeset/smooth-moons-brush.md
@@ -1,0 +1,5 @@
+---
+"@near-js/providers": patch
+---
+
+Fix Provider.validators method signature to accept a `null` argument

--- a/packages/providers/src/provider.ts
+++ b/packages/providers/src/provider.ts
@@ -39,7 +39,7 @@ export abstract class Provider {
     abstract blockChanges(blockQuery: BlockId | BlockReference): Promise<BlockChangeResult>;
     abstract chunk(chunkId: ChunkId): Promise<ChunkResult>;
     // TODO: Use BlockQuery?
-    abstract validators(blockId: BlockId): Promise<EpochValidatorInfo>;
+    abstract validators(blockId: BlockId | null): Promise<EpochValidatorInfo>;
     abstract experimental_protocolConfig(blockReference: BlockReference): Promise<NearProtocolConfig>;
     abstract lightClientProof(request: LightClientProofRequest): Promise<LightClientProof>;
     abstract gasPrice(blockId: BlockId): Promise<GasPrice>;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to NEAR JavaScript API here: https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- ✅ I have read the [Contributing Guidelines on pull requests](https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md).
- ✅ Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- ✅ **If this is a code change**: I have written unit tests.
- ✅ **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
