### PR TITLE
fix: skip default JSON serialize when args is `Uint8Array` on `viewFunction`

### DIFF
--- a/packages/near-api-js/src/account.ts
+++ b/packages/near-api-js/src/account.ts
@@ -89,9 +89,9 @@ export interface FunctionCallOptions {
     /** The name of the method to invoke */
     methodName: string;
     /**
-     * named arguments to pass the method `{ messageText: 'my message' }`
+     * Json arguments like `{ "message": "my message" }` or raw byte stream arguments
      */
-    args?: object;
+    args?: Uint8Array | object;
     /** max amount of gas that method call can use */
     gas?: BN;
     /** amount of NEAR (in yoctoNEAR) to send together with the call */
@@ -137,10 +137,6 @@ interface ActiveDelegatedStakeBalance {
 
 function parseJsonFromRawResponse(response: Uint8Array): any {
     return JSON.parse(Buffer.from(response).toString());
-}
-
-function bytesJsonStringify(input: any): Buffer {
-    return Buffer.from(JSON.stringify(input));
 }
 
 /**
@@ -476,18 +472,18 @@ export class Account {
         methodName,
         args = {},
         parse = parseJsonFromRawResponse,
-        stringify = bytesJsonStringify,
+        stringify = stringifyJsonOrBytes,
         jsContract = false,
         blockQuery = { finality: 'optimistic' }
     }: ViewFunctionCallOptions): Promise<any> {
-        let encodedArgs;
+        let encodedArgs: Buffer;
         
         this.validateArgs(args);
     
         if(jsContract){
             encodedArgs = this.encodeJSContractArgs(contractId, methodName, Object.keys(args).length >  0 ? JSON.stringify(args): '');
         } else{
-            encodedArgs =  stringify(args);
+            encodedArgs = stringify(args);
         }
 
         const result = await this.connection.provider.query<CodeResult>({

--- a/packages/near-api-js/src/transaction.ts
+++ b/packages/near-api-js/src/transaction.ts
@@ -1,10 +1,10 @@
 import sha256 from 'js-sha256';
 import BN from 'bn.js';
 
-import { Enum, Assignable } from './utils/enums';
-import { serialize, deserialize } from 'borsh';
-import { KeyType, PublicKey } from './utils/key_pair';
-import { Signer } from './signer';
+import {Assignable, Enum} from './utils/enums';
+import {deserialize, serialize} from 'borsh';
+import {KeyType, PublicKey} from './utils/key_pair';
+import {Signer} from './signer';
 
 export class FunctionCallPermission extends Assignable {
     allowance?: BN;
@@ -52,8 +52,7 @@ export function deployContract(code: Uint8Array): Action {
 
 export function stringifyJsonOrBytes(args: any): Buffer {
     const isUint8Array = args.byteLength !== undefined && args.byteLength === args.length;
-    const serializedArgs = isUint8Array ? args : Buffer.from(JSON.stringify(args));
-    return serializedArgs;
+    return isUint8Array ? Buffer.from(args) : Buffer.from(JSON.stringify(args));
 }
 
 /**


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to NEAR JavaScript API here: https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md).
- [x] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [x] **If this is a code change**: I have written unit tests.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

Default stringify function will cause unexpected result of `Buffer` like args, if the args is `Buffer` like, we should skip JSON serialization.

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
