### PR TITLE
docs: omit new packages from changeset file

### DIFF
--- a/.changeset/slimy-baboons-itch.md
+++ b/.changeset/slimy-baboons-itch.md
@@ -1,16 +1,5 @@
 ---
 "near-api-js": major
-"@near-js/accounts": patch
-"@near-js/crypto": patch
-"@near-js/keystores": patch
-"@near-js/keystores-browser": patch
-"@near-js/keystores-node": patch
-"@near-js/providers": patch
-"@near-js/signers": patch
-"@near-js/transactions": patch
-"@near-js/types": patch
-"@near-js/utils": patch
-"@near-js/wallet-account": patch
 ---
 
 Major functionality in near-api-js has now been broken up into packages under @near-js


### PR DESCRIPTION
This PR updates the changeset from to the packages refactor to omit new packages. Including them is not the expected behavior, making the change log unnecessarily difficult to interpret.