### PR TITLE
Feat/biometric dependencies

### DIFF
--- a/.changeset/brave-forks-teach.md
+++ b/.changeset/brave-forks-teach.md
@@ -1,0 +1,6 @@
+---
+"@near-js/biometric-ed25519": patch
+"near-api-js": patch
+---
+
+Use new packages in @near-js/biometric-ed25519

--- a/packages/biometric-ed25519/package.json
+++ b/packages/biometric-ed25519/package.json
@@ -13,11 +13,12 @@
   "dependencies": {
     "@aws-crypto/sha256-js": "^4.0.0",
     "@hexagon/base64": "^1.1.26",
+    "@near-js/crypto": "workspace:*",
     "asn1-parser": "^1.1.8",
+    "borsh": "^0.7.0",
     "buffer": "^6.0.3",
     "elliptic": "^6.5.4",
-    "fido2-lib": "3.3.4",
-    "near-api-js": "workspace:*"
+    "fido2-lib": "3.3.4"
   },
   "devDependencies": {
     "@types/node": "^18.7.14"

--- a/packages/biometric-ed25519/src/index.ts
+++ b/packages/biometric-ed25519/src/index.ts
@@ -3,8 +3,8 @@ import { eddsa as EDDSA } from "elliptic";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { Buffer } from "buffer";
 import asn1 from "asn1-parser";
-import { KeyPair } from "near-api-js";
-import { base_encode } from "near-api-js/lib/utils/serialize";
+import { KeyPair } from "@near-js/crypto";
+import { baseEncode } from "borsh";
 import { getCleanName, preformatMakeCredReq, get64BytePublicKeyFromPEM, preformatGetAssertReq, publicKeyCredentialToJSON, recoverPublicKey } from "./utils";
 import { Fido2 } from "./fido2";
 import { AssertionResponse } from "./index.d";
@@ -53,7 +53,7 @@ export const createKey = async (username: string): Promise<KeyPair>  => {
       const edSha256 = new Sha256();
       edSha256.update(Buffer.from(publicKeyBytes));
       const key = ed.keyFromSecret(await edSha256.digest());
-      return KeyPair.fromString(base_encode(new Uint8Array(Buffer.concat([key.getSecret(), Buffer.from(key.getPublic())]))));
+      return KeyPair.fromString(baseEncode(new Uint8Array(Buffer.concat([key.getSecret(), Buffer.from(key.getPublic())]))));
     })
 };
 
@@ -96,8 +96,8 @@ export const getKeys = async (username: string): Promise<[KeyPair, KeyPair]> => 
 
       const firstED = ed.keyFromSecret(await firstEdSha256.digest());
       const secondED = ed.keyFromSecret(await secondEdSha256.digest());
-      const firstKeyPair = KeyPair.fromString(base_encode(new Uint8Array(Buffer.concat([firstED.getSecret(), Buffer.from(firstED.getPublic())]))));
-      const secondKeyPair = KeyPair.fromString(base_encode(new Uint8Array(Buffer.concat([secondED.getSecret(), Buffer.from(secondED.getPublic())]))));
+      const firstKeyPair = KeyPair.fromString(baseEncode(new Uint8Array(Buffer.concat([firstED.getSecret(), Buffer.from(firstED.getPublic())]))));
+      const secondKeyPair = KeyPair.fromString(baseEncode(new Uint8Array(Buffer.concat([secondED.getSecret(), Buffer.from(secondED.getPublic())]))));
       return [firstKeyPair, secondKeyPair];
     });
 };

--- a/packages/biometric-ed25519/src/utils.ts
+++ b/packages/biometric-ed25519/src/utils.ts
@@ -1,7 +1,7 @@
 import base64 from "@hexagon/base64";
 import { ec as EC } from "elliptic";
 import { Sha256 } from "@aws-crypto/sha256-js";
-import { PublicKey } from "near-api-js/lib/utils";
+import { PublicKey } from "@near-js/crypto";
 
 const USER_NAME_MAX_LENGTH = 25;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,20 +77,22 @@ importers:
     specifiers:
       '@aws-crypto/sha256-js': ^4.0.0
       '@hexagon/base64': ^1.1.26
+      '@near-js/crypto': workspace:*
       '@types/node': ^18.7.14
       asn1-parser: ^1.1.8
+      borsh: ^0.7.0
       buffer: ^6.0.3
       elliptic: ^6.5.4
       fido2-lib: 3.3.4
-      near-api-js: workspace:*
     dependencies:
       '@aws-crypto/sha256-js': 4.0.0
       '@hexagon/base64': 1.1.26
+      '@near-js/crypto': link:../crypto
       asn1-parser: 1.1.8
+      borsh: 0.7.0
       buffer: 6.0.3
       elliptic: 6.5.4
       fido2-lib: 3.3.4
-      near-api-js: link:../near-api-js
     devDependencies:
       '@types/node': 18.11.18
 


### PR DESCRIPTION
This PR replaces the `near-api-js` dependency with `borsh` and the new `@near-js/crypto` package