### PR TITLE
ci: add explicit build before publishing

### DIFF
--- a/.changeset/sixty-cycles-itch.md
+++ b/.changeset/sixty-cycles-itch.md
@@ -1,0 +1,5 @@
+---
+"near-api-js": patch
+---
+
+CI update

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,9 @@ jobs:
       - name: Install Dependencies
         run: pnpm install
 
+      - name: Build Packages
+        run: pnpm build
+
       - name: Create Release Pull Request or Publish to NPM
         uses: changesets/action@v1
         with:


### PR DESCRIPTION
This PR updates the `release` workflow to call `pnpm build` prior to publishing. The refactor PR removed the `prepare` script, which was implicitly called previously.