### PR TITLE
ci: partial revert to use near-api-js NPM key

### DIFF
--- a/.changeset/soft-days-type.md
+++ b/.changeset/soft-days-type.md
@@ -1,0 +1,5 @@
+---
+"near-api-js": patch
+---
+
+Publish repackaging

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,4 +41,4 @@ jobs:
           createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          NPM_TOKEN: ${{ secrets.NEARJS_NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This PR reverts to usage of `NPM_TOKEN` for publishing the `near-api-js` package