### PR TITLE
fix: fix validators function to accept null to show latest block info

### DIFF
--- a/.changeset/olive-cooks-study.md
+++ b/.changeset/olive-cooks-study.md
@@ -1,0 +1,5 @@
+---
+"@near-js/providers": patch
+---
+
+Fix Provider.validators method signature to accept a `null` argument

--- a/packages/providers/src/provider.ts
+++ b/packages/providers/src/provider.ts
@@ -39,7 +39,7 @@ export abstract class Provider {
     abstract blockChanges(blockQuery: BlockId | BlockReference): Promise<BlockChangeResult>;
     abstract chunk(chunkId: ChunkId): Promise<ChunkResult>;
     // TODO: Use BlockQuery?
-    abstract validators(blockId: BlockId): Promise<EpochValidatorInfo>;
+    abstract validators(blockId: BlockId | null): Promise<EpochValidatorInfo>;
     abstract experimental_protocolConfig(blockReference: BlockReference): Promise<NearProtocolConfig>;
     abstract lightClientProof(request: LightClientProofRequest): Promise<LightClientProof>;
     abstract gasPrice(blockId: BlockId): Promise<GasPrice>;


### PR DESCRIPTION
This is the rebased PR for #1071 since splitting up `near-api-js` into packages.