### PR TITLE
ci: publish to both @near-js and near-api-js until orgs are merged

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,13 +32,31 @@ jobs:
       - name: Build Packages
         run: pnpm build
 
-      - name: Create Release Pull Request or Publish to NPM
+      - name: Create Release Pull Request
+        if: steps.changesets.outputs.hasChangesets == 'true'
         uses: changesets/action@v1
         with:
           publish: pnpm release
           commit: "chore(release): publish packages"
           title: "Publish packages"
           createGithubReleases: true
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Publish @near-js to NPM
+        if: steps.changesets.outputs.hasChangesets == 'false'
+        uses: changesets/action@v1
+        with:
+            publish: pnpm --filter=!near-api-js release
+        env:
+            GITHUB_TOKEN: ${{ github.token }}
+            NPM_TOKEN: ${{ secrets.NEARJS_NPM_TOKEN }}
+
+      - name: Publish near-api-js to NPM
+        if: steps.changesets.outputs.hasChangesets == 'false'
+        uses: changesets/action@v1
+        with:
+          publish: pnpm --filter near-api-js release
         env:
           GITHUB_TOKEN: ${{ github.token }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This PR updates the publish workflow to make the distinction between creating a release PR and publishing to NPM, the latter of which must be applied to `near-api-js` and `@near-js/*` packages separately until they are under the same NPM organization.