### PR TITLE
fix: update enum field types to optional to match functionality

### DIFF
--- a/.changeset/short-lions-learn.md
+++ b/.changeset/short-lions-learn.md
@@ -1,0 +1,5 @@
+---
+"@near-js/transactions": patch
+---
+
+Update enum fields to all be optional

--- a/packages/transactions/src/actions.ts
+++ b/packages/transactions/src/actions.ts
@@ -28,8 +28,8 @@ export class FunctionCallPermission extends Assignable {
 export class FullAccessPermission extends Assignable {}
 
 export class AccessKeyPermission extends Enum {
-    functionCall: FunctionCallPermission;
-    fullAccess: FullAccessPermission;
+    functionCall?: FunctionCallPermission;
+    fullAccess?: FullAccessPermission;
 }
 
 export class AccessKey extends Assignable {
@@ -53,13 +53,13 @@ export class SignedDelegate extends IAction { delegateAction: DelegateAction; si
  * @see {@link https://nomicon.io/RuntimeSpec/Actions.html | Actions Spec}
  */
 export class Action extends Enum {
-    createAccount: CreateAccount;
-    deployContract: DeployContract;
-    functionCall: FunctionCall;
-    transfer: Transfer;
-    stake: Stake;
-    addKey: AddKey;
-    deleteKey: DeleteKey;
-    deleteAccount: DeleteAccount;
-    signedDelegate: SignedDelegate;
+    createAccount?: CreateAccount;
+    deployContract?: DeployContract;
+    functionCall?: FunctionCall;
+    transfer?: Transfer;
+    stake?: Stake;
+    addKey?: AddKey;
+    deleteKey?: DeleteKey;
+    deleteAccount?: DeleteAccount;
+    signedDelegate?: SignedDelegate;
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to NEAR JavaScript API here: https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md).
- [x] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [x] **If this is a code change**: I have written unit tests.
- [x] **If this changes code in a published package**: I have run `pnpm changeset` to create a `changeset` JSON document appropriate for this change.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

For enum deserialization, only the field that matches the pattern will be defined, where the other fields will not be set. These types incorrectly indicate through the type that all fields are defined, which is not correct.

Likely this should be more than a patch release since breaking, but just opening this PR more as a suggestion (I don't need for anything, just noticed when reading code).

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
