### PR TITLE
fix: dynamically import module with native node dependencies

### DIFF
--- a/.changeset/dry-bulldogs-develop.md
+++ b/.changeset/dry-bulldogs-develop.md
@@ -1,0 +1,5 @@
+---
+"@near-js/providers": patch
+---
+
+Only fall back on `node-fetch` when global.fetch is `undefined`


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to NEAR JavaScript API here: https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md).
- [x] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [ ] **If this is a code change**: I have written unit tests.
- [x] **If this changes code in a published package**: I have run `pnpm changeset` to create a `changeset` JSON document appropriate for this change.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

Fixes #1109 

## Test Plan

NodeJS tests passing ensures that no changes will affect that environment. Browser bundles will similarly continue to function the same way as this change does not change evaluation order of `global.fetch`. React Native environments will now be able to import `@near-js/providers`.

## Related issues/PRs

Fixes #1109 
