### PR TITLE
fix: add missing fields to execution outcome and test

### DIFF
--- a/.changeset/rotten-monkeys-tie.md
+++ b/.changeset/rotten-monkeys-tie.md
@@ -1,0 +1,6 @@
+---
+"near-api-js": patch
+"@near-js/types": patch
+---
+
+added tokens_burnt and executor_id fields to ExecutionOutcome JSON response

--- a/.changeset/rotten-monkeys-tie.md
+++ b/.changeset/rotten-monkeys-tie.md
@@ -1,5 +1,4 @@
 ---
-"near-api-js": patch
 "@near-js/types": patch
 ---
 

--- a/packages/accounts/test/providers.test.js
+++ b/packages/accounts/test/providers.test.js
@@ -33,6 +33,13 @@ test('txStatusReciept with string hash and buffer hash', withProvider(async (pro
 
     const responseWithString = await provider.txStatusReceipts(outcome.transaction.hash, sender.accountId);
     const responseWithUint8Array = await provider.txStatusReceipts(base58.decode(outcome.transaction.hash), sender.accountId);
+    expect('transaction_outcome' in responseWithString).toBeTruthy();
+    expect('logs' in responseWithString.transaction_outcome.outcome).toBeTruthy();
+    expect('receipt_ids' in responseWithString.transaction_outcome.outcome).toBeTruthy();
+    expect('gas_burnt' in responseWithString.transaction_outcome.outcome).toBeTruthy();
+    expect('tokens_burnt' in responseWithString.transaction_outcome.outcome).toBeTruthy();
+    expect('executor_id' in responseWithString.transaction_outcome.outcome).toBeTruthy();
+    expect('status' in responseWithString.transaction_outcome.outcome).toBeTruthy();
     expect(responseWithString).toMatchObject(reciepts);
     expect(responseWithUint8Array).toMatchObject(reciepts);
 }));

--- a/packages/near-api-js/test/providers.test.js
+++ b/packages/near-api-js/test/providers.test.js
@@ -82,13 +82,6 @@ test('txStatusReciept with string hash and buffer hash', withProvider(async(prov
 
     const responseWithString = await provider.txStatusReceipts(outcome.transaction.hash, sender.accountId);
     const responseWithUint8Array = await provider.txStatusReceipts(base58.decode(outcome.transaction.hash), sender.accountId);
-    expect('transaction_outcome' in responseWithString).toBeTruthy();
-    expect('logs' in responseWithString.transaction_outcome.outcome).toBeTruthy();
-    expect('receipt_ids' in responseWithString.transaction_outcome.outcome).toBeTruthy();
-    expect('gas_burnt' in responseWithString.transaction_outcome.outcome).toBeTruthy();
-    expect('tokens_burnt' in responseWithString.transaction_outcome.outcome).toBeTruthy();
-    expect('executor_id' in responseWithString.transaction_outcome.outcome).toBeTruthy();
-    expect('status' in responseWithString.transaction_outcome.outcome).toBeTruthy();
     expect(responseWithString).toMatchObject(reciepts);
     expect(responseWithUint8Array).toMatchObject(reciepts);
 }));

--- a/packages/near-api-js/test/providers.test.js
+++ b/packages/near-api-js/test/providers.test.js
@@ -82,6 +82,13 @@ test('txStatusReciept with string hash and buffer hash', withProvider(async(prov
 
     const responseWithString = await provider.txStatusReceipts(outcome.transaction.hash, sender.accountId);
     const responseWithUint8Array = await provider.txStatusReceipts(base58.decode(outcome.transaction.hash), sender.accountId);
+    expect('transaction_outcome' in responseWithString).toBeTruthy();
+    expect('logs' in responseWithString.transaction_outcome.outcome).toBeTruthy();
+    expect('receipt_ids' in responseWithString.transaction_outcome.outcome).toBeTruthy();
+    expect('gas_burnt' in responseWithString.transaction_outcome.outcome).toBeTruthy();
+    expect('tokens_burnt' in responseWithString.transaction_outcome.outcome).toBeTruthy();
+    expect('executor_id' in responseWithString.transaction_outcome.outcome).toBeTruthy();
+    expect('status' in responseWithString.transaction_outcome.outcome).toBeTruthy();
     expect(responseWithString).toMatchObject(reciepts);
     expect(responseWithUint8Array).toMatchObject(reciepts);
 }));

--- a/packages/types/src/provider/response.ts
+++ b/packages/types/src/provider/response.ts
@@ -3,14 +3,14 @@
  * @module
  */
 
-import BN from "bn.js";
+import BN from 'bn.js';
 
-import { BlockHash, BlockHeight, MerklePath } from "./protocol";
+import { BlockHash, BlockHeight, MerklePath } from './protocol';
 
 export enum ExecutionStatusBasic {
-    Unknown = "Unknown",
-    Pending = "Pending",
-    Failure = "Failure",
+    Unknown = 'Unknown',
+    Pending = 'Pending',
+    Failure = 'Failure',
 }
 
 export interface ExecutionStatus {
@@ -20,9 +20,9 @@ export interface ExecutionStatus {
 }
 
 export enum FinalExecutionStatusBasic {
-    NotStarted = "NotStarted",
-    Started = "Started",
-    Failure = "Failure",
+    NotStarted = 'NotStarted',
+    Started = 'Started',
+    Failure = 'Failure',
 }
 
 export interface ExecutionError {
@@ -107,11 +107,11 @@ export interface FunctionCallPermissionView {
 
 export interface AccessKeyViewRaw extends QueryResponseKind {
     nonce: number;
-    permission: "FullAccess" | FunctionCallPermissionView;
+    permission: 'FullAccess' | FunctionCallPermissionView;
 }
 export interface AccessKeyView extends QueryResponseKind {
     nonce: BN;
-    permission: "FullAccess" | FunctionCallPermissionView;
+    permission: 'FullAccess' | FunctionCallPermissionView;
 }
 
 export interface AccessKeyInfoView {

--- a/packages/types/src/provider/response.ts
+++ b/packages/types/src/provider/response.ts
@@ -3,14 +3,14 @@
  * @module
  */
 
-import BN from 'bn.js';
+import BN from "bn.js";
 
-import { BlockHash, BlockHeight, MerklePath } from './protocol';
+import { BlockHash, BlockHeight, MerklePath } from "./protocol";
 
 export enum ExecutionStatusBasic {
-    Unknown = 'Unknown',
-    Pending = 'Pending',
-    Failure = 'Failure',
+    Unknown = "Unknown",
+    Pending = "Pending",
+    Failure = "Failure",
 }
 
 export interface ExecutionStatus {
@@ -20,9 +20,9 @@ export interface ExecutionStatus {
 }
 
 export enum FinalExecutionStatusBasic {
-    NotStarted = 'NotStarted',
-    Started = 'Started',
-    Failure = 'Failure',
+    NotStarted = "NotStarted",
+    Started = "Started",
+    Failure = "Failure",
 }
 
 export interface ExecutionError {
@@ -44,6 +44,8 @@ export interface ExecutionOutcome {
     logs: string[];
     receipt_ids: string[];
     gas_burnt: number;
+    tokens_burnt: string;
+    executor_id: string;
     status: ExecutionStatus | ExecutionStatusBasic;
 }
 
@@ -105,11 +107,11 @@ export interface FunctionCallPermissionView {
 
 export interface AccessKeyViewRaw extends QueryResponseKind {
     nonce: number;
-    permission: 'FullAccess' | FunctionCallPermissionView;
+    permission: "FullAccess" | FunctionCallPermissionView;
 }
 export interface AccessKeyView extends QueryResponseKind {
     nonce: BN;
-    permission: 'FullAccess' | FunctionCallPermissionView;
+    permission: "FullAccess" | FunctionCallPermissionView;
 }
 
 export interface AccessKeyInfoView {


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md).
- [x] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [x] **If this is a code change**: I have written unit tests.
- [x] **If this changes code in a published package**: I have run `pnpm changeset` to create a `changeset` JSON document appropriate for this change.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

This RPC type is missing fields that are required for proof verification. There is another `metadata` field and `compute_usage` fields that are missing also, but I opted to keeping these changes light.

I defaulted to having this be a patch changeset, but can change to minor if intended. Unclear how semver is with TS adding fields to interfaces (esp in this case since those types shouldn't be constructed manually)

## Test Plan

updated an existing test

## Related issues/PRs

