### PR TITLE
Restore deps key

### DIFF
--- a/.changeset/slimy-fans-tan.md
+++ b/.changeset/slimy-fans-tan.md
@@ -1,0 +1,6 @@
+---
+"near-api-js": patch
+"@near-js/wallet-account": patch
+---
+
+Allow use of legacy `deps.keyStore` path in NearConfig

--- a/packages/near-api-js/src/connect.ts
+++ b/packages/near-api-js/src/connect.ts
@@ -6,6 +6,7 @@
  * To sign transactions you can also pass:
  * 1. {@link ConnectConfig.keyStore}
  * 2. {@link ConnectConfig.keyPath}
+ * 3. {@link ConnectConfig.deps.keyStore} (deprecated, only for use in legacy applications)
  *
  * If all three are passed they are prioritize in that order.
  *
@@ -41,7 +42,7 @@ export interface ConnectConfig extends NearConfig {
  */
 export async function connect(config: ConnectConfig): Promise<Near> {
     // Try to find extra key in `KeyPath` if provided.
-    if (config.keyPath && config.keyStore) {
+    if (config.keyPath && (config.keyStore ||  config.deps?.keyStore)) {
         try {
             const accountKeyFile = await readKeyFile(config.keyPath);
             if (accountKeyFile[0]) {
@@ -54,7 +55,7 @@ export async function connect(config: ConnectConfig): Promise<Near> {
                 }
                 config.keyStore = new MergeKeyStore([
                     keyPathStore,
-                    config.keyStore
+                    config.keyStore || config.deps?.keyStore
                 ], { writeKeyStoreIndex: 1 });
                 if (!process.env['NEAR_NO_LOGS']) {
                     console.log(`Loaded master account ${accountKeyFile[0]} key from ${config.keyPath} with public key = ${keyPair.getPublicKey()}`);

--- a/packages/wallet-account/src/near.ts
+++ b/packages/wallet-account/src/near.ts
@@ -71,6 +71,11 @@ export interface NearConfig {
      * JVSM account ID for NEAR JS SDK
      */
     jsvmAccountId?: string;
+
+    /**
+     * Backward-compatibility for older versions
+     */
+    deps?: { keyStore: KeyStore };
 }
 
 /**
@@ -90,7 +95,7 @@ export class Near {
         this.connection = Connection.fromConfig({
             networkId: config.networkId,
             provider: { type: 'JsonRpcProvider', args: { url: config.nodeUrl, headers: config.headers } },
-            signer: config.signer || { type: 'InMemorySigner', keyStore: config.keyStore },
+            signer: config.signer || { type: 'InMemorySigner', keyStore: config.keyStore || config.deps?.keyStore },
             jsvmAccountId: config.jsvmAccountId || `jsvm.${config.networkId}`
         });
         


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to NEAR JavaScript API here: https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [ ] I have read the [Contributing Guidelines on pull requests](https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md).
- [ ] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [ ] **If this is a code change**: I have written unit tests.
- [ ] **If this changes code in a published package**: I have run `pnpm changeset` to create a `changeset` JSON document appropriate for this change.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

This PR enables the use of a `deps` argument to `NearConfig` instances. This restores legacy usage of passing in `deps.keyStore` instead of passing in `keyStore` as a top level argument to the configuration instance.

NB if both `keyStore` and `deps.keyStore` are passed, `keyStore` will continue to be used.

## Test Plan

The test plan involves updating to the latest `near-api-js` and verifying that signing still works when the `deps` parameter is used. Locally this was tested with `cookbook` examples, verifying that when `deps.keyStore` is used in place of `keyStore` there is no change in functionality.

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
