### PR TITLE
feat: handling null response from navigator.credentials.create

### DIFF
--- a/.changeset/nice-worms-arrive.md
+++ b/.changeset/nice-worms-arrive.md
@@ -1,0 +1,5 @@
+---
+"@near-js/biometric-ed25519": minor
+---
+
+Handing null response on create key flow

--- a/packages/biometric-ed25519/package.json
+++ b/packages/biometric-ed25519/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@near-js/biometric-ed25519",
   "description": "JavaScript library to handle webauthn and biometric keys",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {

--- a/packages/biometric-ed25519/src/index.ts
+++ b/packages/biometric-ed25519/src/index.ts
@@ -34,6 +34,13 @@ function setBufferIfUndefined() {
     }
 }
 
+export class PasskeyProcessCanceled extends Error {
+    constructor(message) {
+        super(message);
+        this.name = "PasskeyProcessCanceled";
+    }
+}
+
 export const createKey = async (username: string): Promise<KeyPair> => {
     const cleanUserName = validateUsername(username);
     if (!f2l.f2l) {
@@ -52,8 +59,7 @@ export const createKey = async (username: string): Promise<KeyPair> => {
     return navigator.credentials.create({ publicKey })
         .then(async (res) => {
             if (!res) {
-                alert('Passkey process was cancelled, retry to continue account setup.');
-                throw new Error('Fail to retrieve respnose from navigator.credentials.create');
+                throw new PasskeyProcessCanceled('Failed to retrieve response from navigator.credentials.create');
             }
 
             const result = await f2l.attestation({

--- a/packages/biometric-ed25519/src/index.ts
+++ b/packages/biometric-ed25519/src/index.ts
@@ -37,7 +37,7 @@ function setBufferIfUndefined() {
 export class PasskeyProcessCanceled extends Error {
     constructor(message) {
         super(message);
-        this.name = "PasskeyProcessCanceled";
+        this.name = 'PasskeyProcessCanceled';
     }
 }
 

--- a/packages/biometric-ed25519/src/index.ts
+++ b/packages/biometric-ed25519/src/index.ts
@@ -51,6 +51,11 @@ export const createKey = async (username: string): Promise<KeyPair> => {
     setBufferIfUndefined();
     return navigator.credentials.create({ publicKey })
         .then(async (res) => {
+            if (!res) {
+                alert('Passkey process was cancelled, retry to continue account setup.');
+                throw new Error('Fail to retrieve respnose from navigator.credentials.create');
+            }
+
             const result = await f2l.attestation({
                 clientAttestationResponse: res,
                 origin,


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md).
- [x] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [ ] **If this is a code change**: I have written unit tests.
- [x] **If this changes code in a published package**: I have run `pnpm changeset` to create a `changeset` JSON document appropriate for this change.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

This PR contains small change on `biometric-ed25519` package where upon creating passkey from the browser, sometimes it is possible that `navigator.credentials.create({ publicKey })` code can return null and it breaks the flow without being handled. 

There was an [issue](https://github.com/near/fast-auth-signer/issues/55) reported and discussed that reflect the outcome of this PR. 

## Test Plan

(I have locally imported this change and run account creation flow on `fast-auth-signer` repo and it shows `alert` as expected)

## Related issues/PRs

[issue](https://github.com/near/fast-auth-signer/issues/55)