### PR TITLE
fix: remove global override of `fetch`

### DIFF
--- a/.changeset/wet-jars-attend.md
+++ b/.changeset/wet-jars-attend.md
@@ -1,0 +1,6 @@
+---
+"near-api-js": patch
+"@near-js/providers": patch
+---
+
+fixes override of global fetch property

--- a/packages/near-api-js/src/connect.ts
+++ b/packages/near-api-js/src/connect.ts
@@ -25,10 +25,7 @@
 import { readKeyFile } from './key_stores/unencrypted_file_system_keystore';
 import { InMemoryKeyStore, MergeKeyStore } from './key_stores';
 import { Near, NearConfig } from './near';
-import fetch from './utils/setup-node-fetch';
 import { logWarning } from './utils';
-
-global.fetch = fetch;
 
 export interface ConnectConfig extends NearConfig {
     /**

--- a/packages/providers/src/fetch_json.ts
+++ b/packages/providers/src/fetch_json.ts
@@ -28,11 +28,8 @@ export async function fetchJson(connectionInfoOrUrl: string | ConnectionInfo, js
 
     const response = await exponentialBackoff(START_WAIT_TIME_MS, RETRY_NUMBER, BACKOFF_MULTIPLIER, async () => {
         try {
-            if (!global.fetch) {
-                global.fetch = (await import('./fetch')).default;
-            }
 
-            const response = await global.fetch(connectionInfo.url, {
+            const response = await (global.fetch ?? (await import('./fetch')).default)(connectionInfo.url, {
                 method: json ? 'POST' : 'GET',
                 body: json ? json : undefined,
                 headers: { ...connectionInfo.headers, 'Content-Type': 'application/json' }


### PR DESCRIPTION
Feel free to help me get tests passing!

Ticket: #1193

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to NEAR JavaScript API here: https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md).
- [x] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [ ] **If this is a code change**: I have written unit tests.
- [x] **If this changes code in a published package**: I have run `pnpm changeset` to create a `changeset` JSON document appropriate for this change.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

Attempting to use the node native fetch API in node >= 18 when the near-api-js is imported directly or by a transitive dependency results in the node global fetch property being overwritten by near-api-js.

These two lines of code [here](https://github.com/near/near-api-js/blob/53ba3f21c6da503e971a251b205bf50ea8b36dd0/packages/near-api-js/src/connect.ts#L31) and [here](https://github.com/near/near-api-js/blob/53ba3f21c6da503e971a251b205bf50ea8b36dd0/packages/providers/src/fetch_json.ts#L32) explicitly override the global fetch property.

They should not do this.

## Test Plan

I am not sure how to test this. Suggestions welcome

## Related issues/PRs

#1193
