### PR TITLE
fix: add check for process global to exist

### DIFF
--- a/.changeset/funny-jars-camp.md
+++ b/.changeset/funny-jars-camp.md
@@ -1,0 +1,8 @@
+---
+"@near-js/accounts": patch
+"near-api-js": patch
+"@near-js/providers": patch
+"@near-js/utils": patch
+---
+
+add check for global 'process' object

--- a/packages/accounts/src/account.ts
+++ b/packages/accounts/src/account.ts
@@ -363,7 +363,7 @@ export class Account {
      * @param beneficiaryId The NEAR account that will receive the remaining Ⓝ balance from the account being deleted
      */
     async deleteAccount(beneficiaryId: string) {
-        if (!process.env['NEAR_NO_LOGS']) {
+        if (!(typeof process === 'object' && process.env['NEAR_NO_LOGS'])) {
             console.log('Deleting an account does not automatically transfer NFTs and FTs to the beneficiary address. Ensure to transfer assets before deleting.');
         }
         return this.signAndSendTransaction({

--- a/packages/near-api-js/src/connect.ts
+++ b/packages/near-api-js/src/connect.ts
@@ -57,7 +57,7 @@ export async function connect(config: ConnectConfig): Promise<Near> {
                     keyPathStore,
                     config.keyStore || config.deps?.keyStore
                 ], { writeKeyStoreIndex: 1 });
-                if (!process.env['NEAR_NO_LOGS']) {
+                if (!(typeof process === 'object' && process.env['NEAR_NO_LOGS'])) {
                     console.log(`Loaded master account ${accountKeyFile[0]} key from ${config.keyPath} with public key = ${keyPair.getPublicKey()}`);
                 }
             }

--- a/packages/providers/src/fetch_json.ts
+++ b/packages/providers/src/fetch_json.ts
@@ -16,7 +16,7 @@ export interface ConnectionInfo {
     headers?: { [key: string]: string | number };
 }
 
-const logWarning = (...args) => !process.env['NEAR_NO_LOGS'] && console.warn(...args);
+const logWarning = (...args) => !(typeof process === 'object' && process.env['NEAR_NO_LOGS']) && console.warn(...args);
 
 export async function fetchJson(connectionInfoOrUrl: string | ConnectionInfo, json?: string): Promise<any> {
     let connectionInfo: ConnectionInfo = { url: null };

--- a/packages/providers/src/json-rpc-provider.ts
+++ b/packages/providers/src/json-rpc-provider.ts
@@ -372,7 +372,7 @@ export class JsonRpcProvider extends Provider {
                 return response;
             } catch (error) {
                 if (error.type === 'TimeoutError') {
-                    if (!process.env['NEAR_NO_LOGS']) {
+                    if (!(typeof process === 'object' && process.env['NEAR_NO_LOGS'])) {
                         console.warn(`Retrying request to ${method} as it has timed out`, params);
                     }
                     return null;

--- a/packages/utils/src/errors/errors.ts
+++ b/packages/utils/src/errors/errors.ts
@@ -1,5 +1,5 @@
 export function logWarning(...args: any[]): void {
-    if (!process.env['NEAR_NO_LOGS']){
+    if (!(typeof process === 'object' && process.env['NEAR_NO_LOGS'])){
         console.warn(...args);
     }
 }

--- a/packages/utils/src/logging.ts
+++ b/packages/utils/src/logging.ts
@@ -2,7 +2,7 @@ import { FinalExecutionOutcome } from '@near-js/types';
 
 import { parseRpcError } from './errors';
 
-const SUPPRESS_LOGGING = !!process.env.NEAR_NO_LOGS;
+const SUPPRESS_LOGGING = !!(typeof process === 'object' && process.env.NEAR_NO_LOGS);
 
 /**
  * Parse and print details from a query execution response


### PR DESCRIPTION
To prevent error 'process undefined' in environments where global process object does not exist

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to NEAR JavaScript API here: https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md).
- [x] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [ ] **If this is a code change**: I have written unit tests.
- [x] **If this changes code in a published package**: I have run `pnpm changeset` to create a `changeset` JSON document appropriate for this change.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

Fixes issue whereby importing module in environments without a global `process` object would throw error `process undefined`.

## Test Plan

1) Wrote small Vitejs app with `"near-api-js": "."` dependency.
2) `vite` threw `process undefined` in browser console
3) Added change, `vite` no longer threw error in browser console

## Related issues/PRs

Closes #737 
