### PR TITLE
Retry RPC requests on 408 HTTP error

### DIFF
--- a/.changeset/healthy-bees-shout.md
+++ b/.changeset/healthy-bees-shout.md
@@ -1,0 +1,5 @@
+---
+"@near-js/providers": patch
+---
+
+retry RPC request on 408 HTTP error

--- a/packages/providers/src/fetch_json.ts
+++ b/packages/providers/src/fetch_json.ts
@@ -38,6 +38,9 @@ export async function fetchJson(connectionInfoOrUrl: string | ConnectionInfo, js
                 if (response.status === 503) {
                     logWarning(`Retrying HTTP request for ${connectionInfo.url} as it's not available now`);
                     return null;
+                } else if (response.status === 408) {
+                    logWarning(`Retrying HTTP request for ${connectionInfo.url} as the previous connection was unused for some time`);
+                    return null;
                 }
                 throw createError(response.status, await response.text());
             }


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md).
- [x] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [ ] **If this is a code change**: I have written unit tests.
- [x] **If this changes code in a published package**: I have run `pnpm changeset` to create a `changeset` JSON document appropriate for this change.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

Non-mainnet networks may experience instability and return 408 HTTP errors, which could delay testing/development. However, this can be fixed by retrying requests.

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->

## Related issues/PRs

made https://github.com/near/near-api-js/pull/989 working without merge conflicts by minor code change

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
