### PR TITLE
fix: allow workflow to write content

### DIFF
--- a/.github/workflows/typedoc-generator.yml
+++ b/.github/workflows/typedoc-generator.yml
@@ -16,6 +16,8 @@ jobs:
   deploy:
     concurrency: ci-${{ github.ref }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to NEAR JavaScript API here: https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md).
- [x] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [ ] **If this is a code change**: I have written unit tests.
- [ ] **If this changes code in a published package**: I have run `pnpm changeset` to create a `changeset` JSON document appropriate for this change.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

The current workflow is not automatically building the docs

## Test Plan

Tested it on a personal repo: https://github.com/gagdiez/near-lake-framework-js/commit/12857a22d526e88703248806947bf98b10e7c1ec