### PR TITLE
Replace and remove dependencies with lighter and audited alternatives

### DIFF
--- a/.changeset/afraid-gorillas-stare.md
+++ b/.changeset/afraid-gorillas-stare.md
@@ -5,6 +5,6 @@
 "@near-js/transactions": minor
 ---
 
-remove buggy depencencies
+remove buggy dependencies
     - replace js-sha256 with noble-hashes
     - replace elliptic with noble-curves

--- a/.changeset/afraid-gorillas-stare.md
+++ b/.changeset/afraid-gorillas-stare.md
@@ -1,0 +1,10 @@
+---
+"@near-js/biometric-ed25519": minor
+"@near-js/crypto": minor
+"@near-js/signers": minor
+"@near-js/transactions": minor
+---
+
+remove buggy depencencies
+    - replace js-sha256 with noble-hashes
+    - replace elliptic with noble-curves

--- a/.changeset/afraid-gorillas-stare.md
+++ b/.changeset/afraid-gorillas-stare.md
@@ -8,3 +8,4 @@
 remove buggy dependencies
     - replace js-sha256 with noble-hashes
     - replace elliptic with noble-curves
+    - remove error-polyfill package

--- a/packages/biometric-ed25519/package.json
+++ b/packages/biometric-ed25519/package.json
@@ -21,7 +21,7 @@
     "bn.js": "5.2.1",
     "borsh": "1.0.0",
     "buffer": "6.0.3",
-    "elliptic": "6.5.4",
+    "@noble/curves": "1.2.0",
     "fido2-lib": "3.4.1"
   },
   "devDependencies": {

--- a/packages/biometric-ed25519/src/index.ts
+++ b/packages/biometric-ed25519/src/index.ts
@@ -1,5 +1,5 @@
 import base64 from '@hexagon/base64';
-import { eddsa as EDDSA } from 'elliptic';
+import { ed25519 } from '@noble/curves/ed25519';
 import { Sha256 } from '@aws-crypto/sha256-js';
 import { Buffer } from 'buffer';
 import asn1 from 'asn1-parser';
@@ -69,11 +69,11 @@ export const createKey = async (username: string): Promise<KeyPair> => {
             });
             const publicKey = result.authnrData.get('credentialPublicKeyPem');
             const publicKeyBytes = get64BytePublicKeyFromPEM(publicKey);
-            const ed = new EDDSA('ed25519');
             const edSha256 = new Sha256();
             edSha256.update(Buffer.from(publicKeyBytes));
-            const key = ed.keyFromSecret(await edSha256.digest());
-            return KeyPair.fromString(baseEncode(new Uint8Array(Buffer.concat([key.getSecret(), Buffer.from(key.getPublic())]))));
+            const secretKey = await edSha256.digest();
+            const pubKey = ed25519.getPublicKey(secretKey);
+            return KeyPair.fromString(baseEncode(new Uint8Array(Buffer.concat([secretKey, Buffer.from(pubKey)]))));
         });
 };
 
@@ -110,16 +110,18 @@ export const getKeys = async (username: string): Promise<[KeyPair, KeyPair]> => 
             const authenticatorAndClientDataJSONHash = Buffer.concat([AuthenticatiorDataJSONHash, clientDataJSONHash]);
 
             const correctPKs = await recoverPublicKey(rAndS.children[0].value, rAndS.children[1].value, authenticatorAndClientDataJSONHash, 0);
-            const ed = new EDDSA('ed25519');
+            
             const firstEdSha256 = new Sha256();
             firstEdSha256.update(Buffer.from(correctPKs[0]));
             const secondEdSha256 = new Sha256();
             secondEdSha256.update(Buffer.from(correctPKs[1]));
 
-            const firstED = ed.keyFromSecret(await firstEdSha256.digest());
-            const secondED = ed.keyFromSecret(await secondEdSha256.digest());
-            const firstKeyPair = KeyPair.fromString(baseEncode(new Uint8Array(Buffer.concat([firstED.getSecret(), Buffer.from(firstED.getPublic())]))));
-            const secondKeyPair = KeyPair.fromString(baseEncode(new Uint8Array(Buffer.concat([secondED.getSecret(), Buffer.from(secondED.getPublic())]))));
+            const firstEDSecret = await firstEdSha256.digest();
+            const firstEDPublic = ed25519.getPublicKey(firstEDSecret);
+            const secondEDSecret = await secondEdSha256.digest();
+            const secondEDPublic = ed25519.getPublicKey(firstEDSecret);
+            const firstKeyPair = KeyPair.fromString(baseEncode(new Uint8Array(Buffer.concat([firstEDSecret, Buffer.from(firstEDPublic)]))));
+            const secondKeyPair = KeyPair.fromString(baseEncode(new Uint8Array(Buffer.concat([secondEDSecret, Buffer.from(secondEDPublic)]))));
             return [firstKeyPair, secondKeyPair];
         });
 };

--- a/packages/biometric-ed25519/src/utils.ts
+++ b/packages/biometric-ed25519/src/utils.ts
@@ -84,7 +84,7 @@ export const recoverPublicKey = async (r, s, message, recovery) => {
     const sigObjQ = new secp256k1.Signature(r, s);
     sigObjQ.addRecoveryBit(0);
     const sigObjP = new secp256k1.Signature(r, s);
-    sigObjQ.addRecoveryBit(1);
+    sigObjP.addRecoveryBit(1);
 
     const h = await hash.digest();
 

--- a/packages/crypto/test/key_pair.test.js
+++ b/packages/crypto/test/key_pair.test.js
@@ -1,26 +1,26 @@
 const { baseEncode } = require('@near-js/utils');
-const { sha256 } = require('js-sha256');
+const { sha256 } = require('@noble/hashes/sha256');
 
 const { KeyPair, KeyPairEd25519, PublicKey } = require('../lib');
 
 test('test sign and verify', async () => {
     const keyPair = new KeyPairEd25519('26x56YPzPDro5t2smQfGcYAPy3j7R2jB2NUb7xKbAGK23B6x4WNQPh3twb6oDksFov5X8ts5CtntUNbpQpAKFdbR');
     expect(keyPair.publicKey.toString()).toEqual('ed25519:AYWv9RAN1hpSQA4p1DLhCNnpnNXwxhfH9qeHN8B4nJ59');
-    const message = new Uint8Array(sha256.array('message'));
+    const message = new Uint8Array(sha256('message'));
     const signature = keyPair.sign(message);
     expect(baseEncode(signature.signature)).toEqual('26gFr4xth7W9K7HPWAxq3BLsua8oTy378mC1MYFiEXHBBpeBjP8WmJEJo8XTBowetvqbRshcQEtBUdwQcAqDyP8T');
 });
 
 test('test sign and verify with random', async () => {
     const keyPair = KeyPairEd25519.fromRandom();
-    const message = new Uint8Array(sha256.array('message'));
+    const message = new Uint8Array(sha256('message'));
     const signature = keyPair.sign(message);
     expect(keyPair.verify(message, signature.signature)).toBeTruthy();
 });
 
 test('test sign and verify with public key', async () => {
     const keyPair = new KeyPairEd25519('5JueXZhEEVqGVT5powZ5twyPP8wrap2K7RdAYGGdjBwiBdd7Hh6aQxMP1u3Ma9Yanq1nEv32EW7u8kUJsZ6f315C');
-    const message = new Uint8Array(sha256.array('message'));
+    const message = new Uint8Array(sha256('message'));
     const signature = keyPair.sign(message);
     const publicKey = PublicKey.from('ed25519:EWrekY1deMND7N3Q7Dixxj12wD7AVjFRt2H9q21QHUSW');
     expect(publicKey.verify(message, signature.signature)).toBeTruthy();

--- a/packages/near-api-js/package.json
+++ b/packages/near-api-js/package.json
@@ -27,7 +27,6 @@
         "bn.js": "5.2.1",
         "borsh": "1.0.0",
         "depd": "2.0.0",
-        "error-polyfill": "0.1.3",
         "http-errors": "1.7.2",
         "near-abi": "0.1.1",
         "node-fetch": "2.6.7",

--- a/packages/near-api-js/src/browser-index.ts
+++ b/packages/near-api-js/src/browser-index.ts
@@ -2,5 +2,3 @@
 export * as keyStores from './key_stores/browser-index';
 export * from './common-index';
 export * from './browser-connect';
-
-import 'error-polyfill';

--- a/packages/signers/package.json
+++ b/packages/signers/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@near-js/crypto": "workspace:*",
     "@near-js/keystores": "workspace:*",
-    "@noble/hashes": "^1.3.3"
+    "@noble/hashes": "1.3.3"
   },
   "devDependencies": {
     "@types/node": "18.11.18",

--- a/packages/signers/package.json
+++ b/packages/signers/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@near-js/crypto": "workspace:*",
     "@near-js/keystores": "workspace:*",
-    "js-sha256": "0.9.0"
+    "@noble/hashes": "^1.3.3"
   },
   "devDependencies": {
     "@types/node": "18.11.18",

--- a/packages/signers/src/in_memory_signer.ts
+++ b/packages/signers/src/in_memory_signer.ts
@@ -1,6 +1,6 @@
 import { KeyPair, PublicKey, Signature } from '@near-js/crypto';
-import { InMemoryKeyStore, KeyStore } from '@near-js/keystores';
-import sha256 from 'js-sha256';
+import { InMemoryKeyStore, KeyStore } from '@near-js/keystores'
+import { sha256 } from '@noble/hashes/sha256';
 
 import { Signer } from './signer';
 
@@ -63,7 +63,7 @@ export class InMemorySigner extends Signer {
      * @returns {Promise<Signature>}
      */
     async signMessage(message: Uint8Array, accountId?: string, networkId?: string): Promise<Signature> {
-        const hash = new Uint8Array(sha256.sha256.array(message));
+        const hash = new Uint8Array(sha256(message));
         if (!accountId) {
             throw new Error('InMemorySigner requires provided account id');
         }

--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -22,7 +22,7 @@
     "@near-js/utils": "workspace:*",
     "bn.js": "5.2.1",
     "borsh": "1.0.0",
-    "@noble/hashes": "^1.3.3"
+    "@noble/hashes": "1.3.3"
   },
   "devDependencies": {
     "@near-js/keystores": "workspace:*",

--- a/packages/transactions/package.json
+++ b/packages/transactions/package.json
@@ -22,7 +22,7 @@
     "@near-js/utils": "workspace:*",
     "bn.js": "5.2.1",
     "borsh": "1.0.0",
-    "js-sha256": "0.9.0"
+    "@noble/hashes": "^1.3.3"
   },
   "devDependencies": {
     "@near-js/keystores": "workspace:*",

--- a/packages/transactions/src/sign.ts
+++ b/packages/transactions/src/sign.ts
@@ -1,6 +1,6 @@
 import { Signer } from '@near-js/signers';
-import sha256 from 'js-sha256';
 import BN from 'bn.js';
+import { sha256 } from '@noble/hashes/sha256';
 
 import { Action, SignedDelegate } from './actions';
 import { createTransaction } from './create_transaction';
@@ -31,7 +31,7 @@ export interface SignedDelegateWithHash {
  */
 async function signTransactionObject(transaction: Transaction, signer: Signer, accountId?: string, networkId?: string): Promise<[Uint8Array, SignedTransaction]> {
     const message = encodeTransaction(transaction);
-    const hash = new Uint8Array(sha256.sha256.array(message));
+    const hash = new Uint8Array(sha256(message));
     const signature = await signer.signMessage(message, accountId, networkId);
     const signedTx = new SignedTransaction({
         transaction,
@@ -72,7 +72,7 @@ export async function signDelegateAction({ delegateAction, signer }: SignDelegat
     });
 
     return {
-        hash: new Uint8Array(sha256.sha256.array(message)),
+        hash: new Uint8Array(sha256(message)),
         signedDelegateAction,
     };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -339,9 +339,6 @@ importers:
       depd:
         specifier: 2.0.0
         version: 2.0.0
-      error-polyfill:
-        specifier: 0.1.3
-        version: 0.1.3
       http-errors:
         specifier: 1.7.2
         version: 1.7.2
@@ -2903,10 +2900,6 @@ packages:
     resolution: {integrity: sha512-0QHgqR+Jv4bxHMp8kZ1Kn8CH55OikjKJ6JmKkZYP1F3D7w+lnFXF70nG5eNfsZS89jadi5Ywy5UCSKLAglIRkg==}
     dev: true
 
-  /capability@0.2.5:
-    resolution: {integrity: sha512-rsJZYVCgXd08sPqwmaIqjAd5SUTfonV0z/gDJ8D6cN8wQphky1kkAYEqQ+hmDxTw7UihvBfjUVUSY+DBEe44jg==}
-    dev: false
-
   /capture-exit@2.0.0:
     resolution: {integrity: sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==}
     engines: {node: 6.* || 8.* || >= 10.*}
@@ -3729,14 +3722,6 @@ packages:
     dependencies:
       is-arrayish: 0.2.1
     dev: true
-
-  /error-polyfill@0.1.3:
-    resolution: {integrity: sha512-XHJk60ufE+TG/ydwp4lilOog549iiQF2OAPhkk9DdiYWMrltz5yhDz/xnKuenNwP7gy3dsibssO5QpVhkrSzzg==}
-    dependencies:
-      capability: 0.2.5
-      o3: 1.0.3
-      u3: 0.1.1
-    dev: false
 
   /es-abstract@1.22.1:
     resolution: {integrity: sha512-ioRRcXMO6OFyRpyzV3kE1IIBd4WG5/kltnzdxSCqoP8CMGs/Li+M1uF5o7lOkZVFjDs+NLesthnF66Pg/0q0Lw==}
@@ -6493,12 +6478,6 @@ packages:
     resolution: {integrity: sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ==}
     dev: true
 
-  /o3@1.0.3:
-    resolution: {integrity: sha512-f+4n+vC6s4ysy7YO7O2gslWZBUu8Qj2i2OUJOvjRxQva7jVjYjB29jrr9NCjmxZQR0gzrOcv1RnqoYOeMs5VRQ==}
-    dependencies:
-      capability: 0.2.5
-    dev: false
-
   /object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -8259,10 +8238,6 @@ packages:
     engines: {node: '>=4.2.0'}
     hasBin: true
     dev: true
-
-  /u3@0.1.1:
-    resolution: {integrity: sha512-+J5D5ir763y+Am/QY6hXNRlwljIeRMZMGs0cT6qqZVVzzT3X3nFPXVyPOFRMOR4kupB0T8JnCdpWdp6Q/iXn3w==}
-    dev: false
 
   /uglifyify@5.0.1:
     resolution: {integrity: sha512-PO44rgExvwj3rkK0UzenHVnPU18drBy9x9HOUmgkuRh6K2KIsDqrB5LqxGtjybgGTOS1JeP8SBc+TN5rhiva6w==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,9 @@ importers:
       '@near-js/utils':
         specifier: workspace:*
         version: link:../utils
+      '@noble/curves':
+        specifier: 1.2.0
+        version: 1.2.0
       asn1-parser:
         specifier: 1.1.8
         version: 1.1.8
@@ -138,9 +141,6 @@ importers:
       buffer:
         specifier: 6.0.3
         version: 6.0.3
-      elliptic:
-        specifier: 6.5.4
-        version: 6.5.4
       fido2-lib:
         specifier: 3.4.1
         version: 3.4.1
@@ -2561,6 +2561,7 @@ packages:
 
   /bn.js@4.12.0:
     resolution: {integrity: sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==}
+    dev: true
 
   /bn.js@5.2.1:
     resolution: {integrity: sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==}
@@ -2615,6 +2616,7 @@ packages:
 
   /brorand@1.1.0:
     resolution: {integrity: sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==}
+    dev: true
 
   /browser-pack@6.1.0:
     resolution: {integrity: sha512-erYug8XoqzU3IfcU8fUgyHqyOXqIE4tUTTQ+7mqUjQlvnXkOO6OlT9c/ZoJVHYoAaqGxr09CN53G7XIsO4KtWA==}
@@ -3685,6 +3687,7 @@ packages:
       inherits: 2.0.4
       minimalistic-assert: 1.0.1
       minimalistic-crypto-utils: 1.0.1
+    dev: true
 
   /emittery@0.7.2:
     resolution: {integrity: sha512-A8OG5SR/ij3SsJdWDJdkkSYUjQdCUx6APQXem0SaEePBSRg4eymGYwBkKo1Y6DU+af/Jn2dBQqDBvjnr9Vi8nQ==}
@@ -4641,6 +4644,7 @@ packages:
     dependencies:
       inherits: 2.0.4
       minimalistic-assert: 1.0.1
+    dev: true
 
   /hasown@2.0.0:
     resolution: {integrity: sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==}
@@ -4660,6 +4664,7 @@ packages:
       hash.js: 1.1.7
       minimalistic-assert: 1.0.1
       minimalistic-crypto-utils: 1.0.1
+    dev: true
 
   /homedir-polyfill@1.0.3:
     resolution: {integrity: sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==}
@@ -4854,6 +4859,7 @@ packages:
 
   /inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+    dev: true
 
   /ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
@@ -6253,9 +6259,11 @@ packages:
 
   /minimalistic-assert@1.0.1:
     resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
+    dev: true
 
   /minimalistic-crypto-utils@1.0.1:
     resolution: {integrity: sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==}
+    dev: true
 
   /minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -450,9 +450,9 @@ importers:
       '@near-js/keystores':
         specifier: workspace:*
         version: link:../keystores
-      js-sha256:
-        specifier: 0.9.0
-        version: 0.9.0
+      '@noble/hashes':
+        specifier: ^1.3.3
+        version: 1.3.3
     devDependencies:
       '@types/node':
         specifier: 18.11.18
@@ -481,15 +481,15 @@ importers:
       '@near-js/utils':
         specifier: workspace:*
         version: link:../utils
+      '@noble/hashes':
+        specifier: ^1.3.3
+        version: 1.3.3
       bn.js:
         specifier: 5.2.1
         version: 5.2.1
       borsh:
         specifier: 1.0.0
         version: 1.0.0
-      js-sha256:
-        specifier: 0.9.0
-        version: 0.9.0
     devDependencies:
       '@near-js/keystores':
         specifier: workspace:*
@@ -1723,6 +1723,11 @@ packages:
 
   /@noble/hashes@1.3.2:
     resolution: {integrity: sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==}
+    engines: {node: '>= 16'}
+    dev: false
+
+  /@noble/hashes@1.3.3:
+    resolution: {integrity: sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==}
     engines: {node: '>= 16'}
     dev: false
 
@@ -5695,10 +5700,6 @@ packages:
 
   /jose@4.14.4:
     resolution: {integrity: sha512-j8GhLiKmUAh+dsFXlX1aJCbt5KMibuKb+d7j1JaOJG6s2UjX1PQlW+OKB/sD4a/5ZYF4RcmYmLSndOoU3Lt/3g==}
-    dev: false
-
-  /js-sha256@0.9.0:
-    resolution: {integrity: sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==}
     dev: false
 
   /js-tokens@4.0.0:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -451,7 +451,7 @@ importers:
         specifier: workspace:*
         version: link:../keystores
       '@noble/hashes':
-        specifier: ^1.3.3
+        specifier: 1.3.3
         version: 1.3.3
     devDependencies:
       '@types/node':
@@ -482,7 +482,7 @@ importers:
         specifier: workspace:*
         version: link:../utils
       '@noble/hashes':
-        specifier: ^1.3.3
+        specifier: 1.3.3
         version: 1.3.3
       bn.js:
         specifier: 5.2.1


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to NEAR JavaScript API here: https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md).
- [x] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [ ] **If this is a code change**: I have written unit tests.
- [x] **If this changes code in a published package**: I have run `pnpm changeset` to create a `changeset` JSON document appropriate for this change.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->
Reuse noble-hashes instead of js-sha256 to reduce the amount of dependencies.
Reuse noble-curves instead of elliptic to reduce the amount of dependencies.
Remove error-polyfill package since it is no longer used explicitly.

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->
All tests pass

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
https://github.com/near/near-api-js/pull/1217
https://github.com/near/near-api-js/issues/1200
