### PR TITLE
Introduce methods to construct URLs to the wallet without instant redirect

### DIFF
--- a/.changeset/twelve-rabbits-cough.md
+++ b/.changeset/twelve-rabbits-cough.md
@@ -1,5 +1,5 @@
 ---
-"@near-js/wallet-account": patch
+"@near-js/wallet-account": minor
 ---
 
 Introduce methods to construct URLs to the wallet without instant redirect

--- a/.changeset/twelve-rabbits-cough.md
+++ b/.changeset/twelve-rabbits-cough.md
@@ -1,0 +1,5 @@
+---
+"@near-js/wallet-account": patch
+---
+
+Introduce methods to construct URLs to the wallet without instant redirect

--- a/packages/wallet-account/src/wallet_account.ts
+++ b/packages/wallet-account/src/wallet_account.ts
@@ -226,9 +226,15 @@ export class WalletConnection {
     }
 
     /**
-     * Requests the user to quickly sign for a transaction or batch of transactions by redirecting to the NEAR wallet.
+     * Constructs string URL to the wallet to sign a transaction or batch of transactions.
+     * 
+     * @param options A required options object
+     * @param options.transactions List of transactions to sign
+     * @param options.callbackUrl URL to redirect upon success. Default: current url
+     * @param options.meta Meta information the wallet will send back to the application. `meta` will be attached to the `callbackUrl` as a url search param
+     * 
      */
-    async requestSignTransactions({ transactions, meta, callbackUrl }: RequestSignTransactionsOptions): Promise<void> {
+    async requestSignTransactionsUrl({ transactions, meta, callbackUrl }: RequestSignTransactionsOptions): Promise<string> {
         const currentUrl = new URL(window.location.href);
         const newUrl = new URL('sign', this._walletBaseUrl);
 
@@ -239,7 +245,22 @@ export class WalletConnection {
         newUrl.searchParams.set('callbackUrl', callbackUrl || currentUrl.href);
         if (meta) newUrl.searchParams.set('meta', meta);
 
-        window.location.assign(newUrl.toString());
+        return newUrl.toString();
+    }
+
+    /**
+     * Requests the user to quickly sign for a transaction or batch of transactions by redirecting to the wallet.
+     * 
+     * @param options A required options object
+     * @param options.transactions List of transactions to sign
+     * @param options.callbackUrl URL to redirect upon success. Default: current url
+     * @param options.meta Meta information the wallet will send back to the application. `meta` will be attached to the `callbackUrl` as a url search param
+     * 
+     */
+    async requestSignTransactions(options: RequestSignTransactionsOptions): Promise<void> {
+        const url = await this.requestSignTransactionsUrl(options);
+
+        window.location.assign(url);
     }
 
     /**

--- a/packages/wallet-account/src/wallet_account.ts
+++ b/packages/wallet-account/src/wallet_account.ts
@@ -234,7 +234,7 @@ export class WalletConnection {
      * @param options.meta Meta information the wallet will send back to the application. `meta` will be attached to the `callbackUrl` as a url search param
      * 
      */
-    async requestSignTransactionsUrl({ transactions, meta, callbackUrl }: RequestSignTransactionsOptions): Promise<string> {
+    requestSignTransactionsUrl({ transactions, meta, callbackUrl }: RequestSignTransactionsOptions): string {
         const currentUrl = new URL(window.location.href);
         const newUrl = new URL('sign', this._walletBaseUrl);
 
@@ -257,8 +257,8 @@ export class WalletConnection {
      * @param options.meta Meta information the wallet will send back to the application. `meta` will be attached to the `callbackUrl` as a url search param
      * 
      */
-    async requestSignTransactions(options: RequestSignTransactionsOptions): Promise<void> {
-        const url = await this.requestSignTransactionsUrl(options);
+    requestSignTransactions(options: RequestSignTransactionsOptions): void {
+        const url = this.requestSignTransactionsUrl(options);
 
         window.location.assign(url);
     }

--- a/packages/wallet-account/src/wallet_account.ts
+++ b/packages/wallet-account/src/wallet_account.ts
@@ -167,7 +167,7 @@ export class WalletConnection {
     }
 
     /**
-     * Redirects current page to the wallet authentication page.
+     * Constructs string URL to the wallet authentication page.
      * @param options An optional options object
      * @param options.contractId The NEAR account where the contract is deployed
      * @param options.successUrl URL to redirect upon success. Default: current url
@@ -176,11 +176,11 @@ export class WalletConnection {
      * @example
      * ```js
      * const wallet = new WalletConnection(near, 'my-app');
-     * // redirects to the NEAR Wallet
-     * wallet.requestSignIn({ contractId: 'account-with-deploy-contract.near' });
+     * // return string URL to the NEAR Wallet
+     * const url = await wallet.requestSignInUrl({ contractId: 'account-with-deploy-contract.near' });
      * ```
      */
-    async requestSignIn({ contractId, methodNames, successUrl, failureUrl }: SignInOptions) {
+    async requestSignInUrl({contractId, methodNames, successUrl, failureUrl}: SignInOptions): Promise<string> {
         const currentUrl = new URL(window.location.href);
         const newUrl = new URL(this._walletBaseUrl + LOGIN_WALLET_URL_SUFFIX);
         newUrl.searchParams.set('success_url', successUrl || currentUrl.href);
@@ -202,7 +202,27 @@ export class WalletConnection {
             });
         }
 
-        window.location.assign(newUrl.toString());
+        return newUrl.toString();
+    }
+
+    /**
+     * Redirects current page to the wallet authentication page.
+     * @param options An optional options object
+     * @param options.contractId The NEAR account where the contract is deployed
+     * @param options.successUrl URL to redirect upon success. Default: current url
+     * @param options.failureUrl URL to redirect upon failure. Default: current url
+     *
+     * @example
+     * ```js
+     * const wallet = new WalletConnection(near, 'my-app');
+     * // redirects to the NEAR Wallet
+     * wallet.requestSignIn({ contractId: 'account-with-deploy-contract.near' });
+     * ```
+     */
+    async requestSignIn(options: SignInOptions) {
+        const url = await this.requestSignInUrl(options);
+
+        window.location.assign(url);
     }
 
     /**

--- a/packages/wallet-account/test/wallet_account.test.js
+++ b/packages/wallet-account/test/wallet_account.test.js
@@ -109,6 +109,9 @@ describe('fails gracefully on the server side (without window)', () => {
     it('throws explicit error when calling other methods on the instance', () => {
         const serverWalletConnection = new WalletConnection(nearFake, '');
         expect(() => serverWalletConnection.requestSignIn('signInContract', 'signInTitle', 'http://example.com/success',  'http://example.com/fail')).toThrow(/please ensure you are using WalletConnection on the browser/);
+        expect(() => serverWalletConnection.requestSignInUrl('signInContract', 'signInTitle', 'http://example.com/success',  'http://example.com/fail')).toThrow(/please ensure you are using WalletConnection on the browser/);
+        expect(() => serverWalletConnection.requestSignTransactions('signInContract', 'signInTitle', 'http://example.com/success',  'http://example.com/fail')).toThrow(/please ensure you are using WalletConnection on the browser/);
+        expect(() => serverWalletConnection.requestSignTransactionsUrl('signInContract', 'signInTitle', 'http://example.com/success',  'http://example.com/fail')).toThrow(/please ensure you are using WalletConnection on the browser/);
     });
 
     it('can access other props on the instance', () => {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to NEAR JavaScript API here: https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md).
- [x] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [ ] **If this is a code change**: I have written unit tests.
- [x] **If this changes code in a published package**: I have run `pnpm changeset` to create a `changeset` JSON document appropriate for this change.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

Some use cases certainly require not redirecting instantly to the Wallet page

The following methods were added to the WalletConnection class that construct URL without calling `window.assign` afterward:
* `requestSignInUrl`
* `requestSignTransactionsUrl`

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->

## Related issues/PRs

Deprecated PR -> https://github.com/near/near-api-js/pull/1025
Issue -> https://github.com/near/near-api-js/issues/1010

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
