### PR TITLE
KeyPairEd25519.fromRandom() fix

### DIFF
--- a/.changeset/silly-queens-dream.md
+++ b/.changeset/silly-queens-dream.md
@@ -1,0 +1,5 @@
+---
+"@near-js/crypto": patch
+---
+
+Pass Uint8Array to getPublicKey method.

--- a/packages/crypto/src/key_pair_ed25519.ts
+++ b/packages/crypto/src/key_pair_ed25519.ts
@@ -42,7 +42,7 @@ export class KeyPairEd25519 extends KeyPairBase {
      */
     static fromRandom() {
         const secretKey = randombytes(KeySize.SECRET_KEY);
-        const publicKey = ed25519.getPublicKey(secretKey);
+        const publicKey = ed25519.getPublicKey(new Uint8Array(secretKey));
         const extendedSecretKey = new Uint8Array([...secretKey, ...publicKey]);
         return new KeyPairEd25519(baseEncode(extendedSecretKey));
     }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to NEAR JavaScript API here: https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md).
- [x] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [ ] **If this is a code change**: I have written unit tests.
- [x] **If this changes code in a published package**: I have run `pnpm changeset` to create a `changeset` JSON document appropriate for this change.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->
In a client-side environment, `KeyPairEd25519.fromRandom()` throws `TypeError: unexpected type, use Uint8Array`. The goal of the PR is to fix this problem by passing the secret key as a Uint8array to the `getPublicKey()` method.

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->
All existing tests pass.

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
