### PR TITLE
Extend Contract class to enable view function calls without Account

### DIFF
--- a/.changeset/little-chefs-decide.md
+++ b/.changeset/little-chefs-decide.md
@@ -1,0 +1,5 @@
+---
+"@near-js/accounts": minor
+---
+
+Extend Contract class to accept Connection object

--- a/packages/accounts/src/connection.ts
+++ b/packages/accounts/src/connection.ts
@@ -1,5 +1,6 @@
 import { Signer, InMemorySigner } from '@near-js/signers';
 import { Provider, JsonRpcProvider } from '@near-js/providers';
+import { IntoConnection } from './interface';
 
 /**
  * @param config Contains connection info details
@@ -32,7 +33,7 @@ function getSigner(config: any): Signer {
 /**
  * Connects an account to a given network via a given provider
  */
-export class Connection {
+export class Connection implements IntoConnection {
     readonly networkId: string;
     readonly provider: Provider;
     readonly signer: Signer;
@@ -43,6 +44,10 @@ export class Connection {
         this.provider = provider;
         this.signer = signer;
         this.jsvmAccountId = jsvmAccountId; 
+    }
+
+    getConnection(): Connection {
+        return this;
     }
 
     /**

--- a/packages/accounts/src/index.ts
+++ b/packages/accounts/src/index.ts
@@ -2,10 +2,7 @@ export {
     Account,
     AccountBalance,
     AccountAuthorizedApp,
-    SignAndSendTransactionOptions,
-    FunctionCallOptions,
-    ChangeFunctionCallOptions,
-    ViewFunctionCallOptions,
+    SignAndSendTransactionOptions
 } from './account';
 export { Account2FA } from './account_2fa';
 export {
@@ -37,3 +34,8 @@ export {
     MultisigDeleteRequestRejectionError,
     MultisigStateStatus,
 } from './types';
+export {    
+    FunctionCallOptions,
+    ChangeFunctionCallOptions,
+    ViewFunctionCallOptions,
+} from './interface';

--- a/packages/accounts/src/interface.ts
+++ b/packages/accounts/src/interface.ts
@@ -1,0 +1,50 @@
+import { BlockReference } from "@near-js/types";
+import type { Connection } from "./connection";
+
+export interface IntoConnection {
+    getConnection(): Connection;
+}
+
+/**
+ * Options used to initiate a function call (especially a change function call)
+ * @see {@link Account#viewFunction | viewFunction} to initiate a view function call
+ */
+export interface FunctionCallOptions {
+    /** The NEAR account id where the contract is deployed */
+    contractId: string;
+    /** The name of the method to invoke */
+    methodName: string;
+    /**
+     * named arguments to pass the method `{ messageText: 'my message' }`
+     */
+    args?: object;
+    /** max amount of gas that method call can use */
+    gas?: bigint;
+    /** amount of NEAR (in yoctoNEAR) to send together with the call */
+    attachedDeposit?: bigint;
+    /**
+     * Convert input arguments into bytes array.
+     */
+    stringify?: (input: any) => Buffer;
+    /**
+     * Is contract from JS SDK, automatically encodes args from JS SDK to binary.
+     */
+    jsContract?: boolean;
+}
+
+export interface ChangeFunctionCallOptions extends FunctionCallOptions {
+    /**
+     * Metadata to send the NEAR Wallet if using it to sign transactions.
+     * @see RequestSignTransactionsOptions
+    */
+    walletMeta?: string;
+    /**
+     * Callback url to send the NEAR Wallet if using it to sign transactions.
+     * @see RequestSignTransactionsOptions
+    */
+    walletCallbackUrl?: string;
+}
+export interface ViewFunctionCallOptions extends FunctionCallOptions {
+    parse?: (response: Uint8Array) => any;
+    blockQuery?: BlockReference;
+}

--- a/packages/accounts/src/utils.ts
+++ b/packages/accounts/src/utils.ts
@@ -1,0 +1,105 @@
+import {
+    ViewStateResult,
+    BlockReference,
+    CodeResult,
+    PositionalArgsError,
+} from '@near-js/types';
+import { Connection } from './connection';
+import { printTxOutcomeLogs } from '@near-js/utils';
+import { ViewFunctionCallOptions } from './interface';
+
+function parseJsonFromRawResponse(response: Uint8Array): any {
+    return JSON.parse(Buffer.from(response).toString());
+}
+
+function bytesJsonStringify(input: any): Buffer {
+    return Buffer.from(JSON.stringify(input));
+}
+
+export function validateArgs(args: any) {
+    const isUint8Array = args.byteLength !== undefined && args.byteLength === args.length;
+    if (isUint8Array) {
+        return;
+    }
+
+    if (Array.isArray(args) || typeof args !== 'object') {
+        throw new PositionalArgsError();
+    }
+}
+
+export function encodeJSContractArgs(contractId: string, method: string, args) {
+    return Buffer.concat([Buffer.from(contractId), Buffer.from([0]), Buffer.from(method), Buffer.from([0]), Buffer.from(args)]);
+}
+
+/**
+ * Returns the state (key value pairs) of account's contract based on the key prefix.
+ * Pass an empty string for prefix if you would like to return the entire state.
+ * @see [https://docs.near.org/api/rpc/contracts#view-contract-state](https://docs.near.org/api/rpc/contracts#view-contract-state)
+ *
+ * @param connection connection to query state from
+ * @param accountId account whose state is viewed
+ * @param prefix allows to filter which keys should be returned. Empty prefix means all keys. String prefix is utf-8 encoded.
+ * @param blockQuery specifies which block to query state at. By default returns last "optimistic" block (i.e. not necessarily finalized).
+ */
+export async function viewState(connection: Connection, accountId: string, prefix: string | Uint8Array, blockQuery: BlockReference = { finality: 'optimistic' }): Promise<Array<{ key: Buffer; value: Buffer }>> {
+    const { values } = await connection.provider.query<ViewStateResult>({
+        request_type: 'view_state',
+        ...blockQuery,
+        account_id: accountId,
+        prefix_base64: Buffer.from(prefix).toString('base64')
+    });
+
+    return values.map(({ key, value }) => ({
+        key: Buffer.from(key, 'base64'),
+        value: Buffer.from(value, 'base64')
+    }));
+}
+
+
+/**
+ * Invoke a contract view function using the RPC API.
+ * @see [https://docs.near.org/api/rpc/contracts#call-a-contract-function](https://docs.near.org/api/rpc/contracts#call-a-contract-function)
+ *
+ * @param options Function call options.
+ * @param options.contractId NEAR account where the contract is deployed
+ * @param options.methodName The view-only method (no state mutations) name on the contract as it is written in the contract code
+ * @param options.args Any arguments to the view contract method, wrapped in JSON
+ * @param options.parse Parse the result of the call. Receives a Buffer (bytes array) and converts it to any object. By default result will be treated as json.
+ * @param options.stringify Convert input arguments into a bytes array. By default the input is treated as a JSON.
+ * @param options.jsContract Is contract from JS SDK, automatically encodes args from JS SDK to binary.
+ * @param options.blockQuery specifies which block to query state at. By default returns last "optimistic" block (i.e. not necessarily finalized).
+ * @returns {Promise<any>}
+ */
+export async function viewFunction(connection: Connection, {
+    contractId,
+    methodName,
+    args = {},
+    parse = parseJsonFromRawResponse,
+    stringify = bytesJsonStringify,
+    jsContract = false,
+    blockQuery = { finality: 'optimistic' }
+}: ViewFunctionCallOptions): Promise<any> {
+    let encodedArgs;
+
+    validateArgs(args);
+
+    if (jsContract) {
+        encodedArgs = encodeJSContractArgs(contractId, methodName, Object.keys(args).length > 0 ? JSON.stringify(args) : '');
+    } else {
+        encodedArgs = stringify(args);
+    }
+
+    const result = await connection.provider.query<CodeResult>({
+        request_type: 'call_function',
+        ...blockQuery,
+        account_id: jsContract ? connection.jsvmAccountId : contractId,
+        method_name: jsContract ? 'view_js_contract' : methodName,
+        args_base64: encodedArgs.toString('base64')
+    });
+
+    if (result.logs) {
+        printTxOutcomeLogs({ contractId, logs: result.logs });
+    }
+
+    return result.result && result.result.length > 0 && parse(Buffer.from(result.result));
+}

--- a/packages/accounts/test/contract.test.js
+++ b/packages/accounts/test/contract.test.js
@@ -1,16 +1,19 @@
 const { PositionalArgsError } = require('@near-js/types');
 
-const { Contract } = require('../lib');
+const { Contract, Account } = require('../lib');
 const testUtils  = require('./test-utils');
 
-const account = {
+const account = Object.setPrototypeOf({
+    getConnection() {
+        return {};
+    },
     viewFunction({ contractId, methodName, args, parse, stringify, jsContract, blockQuery }) {
         return { this: this, contractId, methodName, args, parse, stringify, jsContract, blockQuery };
     },
     functionCall() {
         return this;
     }
-};
+}, Account.prototype);
 
 const contract = new Contract(account, 'contractId', {
     viewMethods: ['viewMethod'],

--- a/packages/accounts/test/contract.test.js
+++ b/packages/accounts/test/contract.test.js
@@ -192,8 +192,12 @@ describe('contract without account', () => {
         contract = new Contract(nearjs.connection, contractId, {
             viewMethods: ['total_messages', 'get_messages'],
             changeMethods: ['add_message'],
-            useLocalViewExecution: false,
         });
+    });
+
+    test('view & change methods work', async () => {
+        const totalMessagesBefore = await contract.total_messages({});
+        expect(totalMessagesBefore).toBe(0);
 
         await contract.add_message({
             signerAccount: workingAccount,
@@ -203,30 +207,19 @@ describe('contract without account', () => {
             signerAccount: workingAccount,
             text: 'second message',
         });
-    });
 
-    afterEach(() => {
-        jest.clearAllMocks();
-    });
+        const totalMessagesAfter = await contract.total_messages({});
+        expect(totalMessagesAfter).toBe(2);
 
-    test('calls total_messages()', async () => {
-        const totalMessages = await contract.total_messages({});
-
-        expect(totalMessages).toBe(2);
-    });
-
-    test('calls get_messages()', async () => {
         const messages = await contract.get_messages({});
-
-        expect(
-            contract.account.connection.provider.query
-        ).not.toHaveBeenCalled();
         expect(messages.length).toBe(2);
         expect(messages[0].text).toEqual('first message');
         expect(messages[1].text).toEqual('second message');
     });
 
     test('fails to call add_message() without signerAccount', async () => {
-        await expect(contract.add_message({ text: 'third message' })).toThrow();
+        await expect(
+            contract.add_message({ text: 'third message' })
+        ).rejects.toThrow(/signerAccount must be specified/);
     });
 });

--- a/packages/accounts/test/contract.test.js
+++ b/packages/accounts/test/contract.test.js
@@ -175,3 +175,58 @@ describe('local view execution', () => {
         }
     }); 
 });
+
+describe('contract without account', () => {
+    let nearjs;
+    let workingAccount;
+    let contract;
+
+    jest.setTimeout(60000);
+
+    beforeAll(async () => {
+        nearjs = await testUtils.setUpTestConnection();
+        workingAccount = await testUtils.createAccount(nearjs);
+        const contractId = testUtils.generateUniqueString('guestbook');
+        await testUtils.deployContractGuestBook(workingAccount, contractId);
+
+        contract = new Contract(nearjs.connection, contractId, {
+            viewMethods: ['total_messages', 'get_messages'],
+            changeMethods: ['add_message'],
+            useLocalViewExecution: false,
+        });
+
+        await contract.add_message({
+            signerAccount: workingAccount,
+            text: 'first message',
+        });
+        await contract.add_message({
+            signerAccount: workingAccount,
+            text: 'second message',
+        });
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('calls total_messages()', async () => {
+        const totalMessages = await contract.total_messages({});
+
+        expect(totalMessages).toBe(2);
+    });
+
+    test('calls get_messages()', async () => {
+        const messages = await contract.get_messages({});
+
+        expect(
+            contract.account.connection.provider.query
+        ).not.toHaveBeenCalled();
+        expect(messages.length).toBe(2);
+        expect(messages[0].text).toEqual('first message');
+        expect(messages[1].text).toEqual('second message');
+    });
+
+    test('fails to call add_message() without signerAccount', async () => {
+        await expect(contract.add_message({ text: 'third message' })).toThrow();
+    });
+});

--- a/packages/accounts/test/contract.test.js
+++ b/packages/accounts/test/contract.test.js
@@ -201,11 +201,15 @@ describe('contract without account', () => {
 
         await contract.add_message({
             signerAccount: workingAccount,
-            text: 'first message',
+            args: {
+                text: 'first message',
+            }
         });
         await contract.add_message({
             signerAccount: workingAccount,
-            text: 'second message',
+            args: {
+                text: 'second message',
+            }
         });
 
         const totalMessagesAfter = await contract.total_messages({});

--- a/packages/accounts/test/contract_abi.test.js
+++ b/packages/accounts/test/contract_abi.test.js
@@ -1,5 +1,4 @@
-const { Contract } = require('../src/contract');
-const { ArgumentSchemaError, UnknownArgumentError, UnsupportedSerializationError } = require('../src/errors');
+const { Account, Contract, ArgumentSchemaError, UnknownArgumentError, UnsupportedSerializationError } = require('../lib');
 
 let rawAbi = `{
   "schema_version": "0.3.0",
@@ -93,14 +92,17 @@ let rawAbi = `{
   }
 }`;
 
-const account = {
+const account = Object.setPrototypeOf({
+    getConnection() {
+        return {};
+    },
     viewFunction({ contractId, methodName, args, parse, stringify, jsContract, blockQuery }) {
         return { this: this, contractId, methodName, args, parse, stringify, jsContract, blockQuery };
     },
     functionCall() {
         return this;
     }
-};
+}, Account.prototype);
 
 const abi = JSON.parse(rawAbi);
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to NEAR JavaScript API here: https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md).
- [x] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [x] **If this is a code change**: I have written unit tests.
- [x] **If this changes code in a published package**: I have run `pnpm changeset` to create a `changeset` JSON document appropriate for this change.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

Many developers complained about the confusing implementation of the Contract class, which requires an Account parameter in the constructor even for view function calls

This PullRequest solves the issue by extending the interface of the first parameter in the constructor and additionally **enables full backward compatibility** with older versions

#### Old implementation
```js
// account is required
const contract = new Contract(account, options);

contract.view_method({});
contract.call_method({});
```

#### New implementation
```js
const contract = new Contract(connection, options);

// no account required
contract.view_method({});

// signerAccount must be specified to sign the transaction
contract.call_method({ signerAccount: account });
```

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
https://github.com/near/near-api-js/pull/1066
https://github.com/near/near-api-js/discussions/1064

