### PR TITLE
biometric-ed25519 update to support BitWarden password manager

### DIFF
--- a/.changeset/mighty-paws-tap.md
+++ b/.changeset/mighty-paws-tap.md
@@ -1,0 +1,5 @@
+---
+"@near-js/biometric-ed25519": minor
+---
+
+Include sanitization on navigator.credentials response to support Bitwarden password manager

--- a/packages/biometric-ed25519/src/index.ts
+++ b/packages/biometric-ed25519/src/index.ts
@@ -12,7 +12,8 @@ import {
     preformatGetAssertReq,
     publicKeyCredentialToJSON,
     recoverPublicKey,
-    uint8ArrayToBigInt
+    uint8ArrayToBigInt,
+    convertUint8ArrayToBuffer
 } from './utils';
 import { Fido2 } from './fido2';
 import { AssertionResponse } from './index.d';
@@ -63,8 +64,10 @@ export const createKey = async (username: string): Promise<KeyPair> => {
                 throw new PasskeyProcessCanceled('Failed to retrieve response from navigator.credentials.create');
             }
 
+            const senitizedResponse = convertUint8ArrayToBuffer(res);
+
             const result = await f2l.attestation({
-                clientAttestationResponse: res,
+                clientAttestationResponse: senitizedResponse,
                 origin,
                 challenge: challengeMakeCred.challenge
             });
@@ -93,7 +96,8 @@ export const getKeys = async (username: string): Promise<[KeyPair, KeyPair]> => 
     setBufferIfUndefined();
     return navigator.credentials.get({ publicKey })
         .then(async (response: Credential) => {
-            const getAssertionResponse: AssertionResponse = publicKeyCredentialToJSON(response);
+            const senitizedResponse = convertUint8ArrayToBuffer(response);
+            const getAssertionResponse: AssertionResponse = publicKeyCredentialToJSON(senitizedResponse);
             const signature = base64.toArrayBuffer(getAssertionResponse.response.signature, true);
 
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/packages/biometric-ed25519/src/index.ts
+++ b/packages/biometric-ed25519/src/index.ts
@@ -13,7 +13,7 @@ import {
     publicKeyCredentialToJSON,
     recoverPublicKey,
     uint8ArrayToBigInt,
-    convertUint8ArrayToBuffer
+    convertToArrayBuffer
 } from './utils';
 import { Fido2 } from './fido2';
 import { AssertionResponse } from './index.d';
@@ -64,10 +64,10 @@ export const createKey = async (username: string): Promise<KeyPair> => {
                 throw new PasskeyProcessCanceled('Failed to retrieve response from navigator.credentials.create');
             }
 
-            const senitizedResponse = convertUint8ArrayToBuffer(res);
+            const sanitizedResponse = convertToArrayBuffer(res);
 
             const result = await f2l.attestation({
-                clientAttestationResponse: senitizedResponse,
+                clientAttestationResponse: sanitizedResponse,
                 origin,
                 challenge: challengeMakeCred.challenge
             });
@@ -96,8 +96,8 @@ export const getKeys = async (username: string): Promise<[KeyPair, KeyPair]> => 
     setBufferIfUndefined();
     return navigator.credentials.get({ publicKey })
         .then(async (response: Credential) => {
-            const senitizedResponse = convertUint8ArrayToBuffer(response);
-            const getAssertionResponse: AssertionResponse = publicKeyCredentialToJSON(senitizedResponse);
+            const sanitizedResponse = convertToArrayBuffer(response);
+            const getAssertionResponse: AssertionResponse = publicKeyCredentialToJSON(sanitizedResponse);
             const signature = base64.toArrayBuffer(getAssertionResponse.response.signature, true);
 
             // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/packages/biometric-ed25519/src/utils.ts
+++ b/packages/biometric-ed25519/src/utils.ts
@@ -93,25 +93,16 @@ export const uint8ArrayToBigInt = (uint8Array: Uint8Array) => {
 };
 
 // This function is design to convert any existing Uint8Array properties inside AuthenticatorAssertionResponse to ArrayBuffer
-export const convertUint8ArrayToBuffer = (obj) => {
-    // Function to handle the conversion of each property
-    function handleConversion(item) {
-        if (item instanceof Uint8Array) {
-            // Convert Uint8Array to ArrayBuffer
-            return item.buffer.slice(item.byteOffset, item.byteOffset + item.byteLength);
-        } else if (Array.isArray(item)) {
-            // Process array items
-            return item.map(handleConversion);
-        } else if (item !== null && typeof item === 'object') {
-            // Process object properties
-            return Object.keys(item).reduce((acc, key) => {
-                acc[key] = handleConversion(item[key]);
-                return acc;
-            }, {});
-        }
-        // Return the item if it's not a Uint8Array or an Object
-        return item;
+export const convertToArrayBuffer = (obj) => {
+    if (obj instanceof Uint8Array) {
+        return obj.buffer.slice(obj.byteOffset, obj.byteOffset + obj.byteLength);
+    } else if (Array.isArray(obj)) {
+        return obj.map(convertToArrayBuffer);
+    } else if (obj !== null && typeof obj === 'object') {
+        return Object.keys(obj).reduce((acc, key) => {
+            acc[key] = convertToArrayBuffer(obj[key]);
+            return acc;
+        }, {});
     }
-
-    return handleConversion(obj);
+    return obj;
 };

--- a/packages/biometric-ed25519/src/utils.ts
+++ b/packages/biometric-ed25519/src/utils.ts
@@ -91,3 +91,27 @@ export const uint8ArrayToBigInt = (uint8Array: Uint8Array) => {
     const array = Array.from(uint8Array);
     return BigInt('0x' + array.map(byte => byte.toString(16).padStart(2, '0')).join(''));
 };
+
+// This function is design to convert any existing Uint8Array properties inside AuthenticatorAssertionResponse to ArrayBuffer
+export const convertUint8ArrayToBuffer = (obj) => {
+    // Function to handle the conversion of each property
+    function handleConversion(item) {
+        if (item instanceof Uint8Array) {
+            // Convert Uint8Array to ArrayBuffer
+            return item.buffer.slice(item.byteOffset, item.byteOffset + item.byteLength);
+        } else if (Array.isArray(item)) {
+            // Process array items
+            return item.map(handleConversion);
+        } else if (item !== null && typeof item === 'object') {
+            // Process object properties
+            return Object.keys(item).reduce((acc, key) => {
+                acc[key] = handleConversion(item[key]);
+                return acc;
+            }, {});
+        }
+        // Return the item if it's not a Uint8Array or an Object
+        return item;
+    }
+
+    return handleConversion(obj);
+};

--- a/packages/biometric-ed25519/src/utils.ts
+++ b/packages/biometric-ed25519/src/utils.ts
@@ -92,7 +92,7 @@ export const uint8ArrayToBigInt = (uint8Array: Uint8Array) => {
     return BigInt('0x' + array.map(byte => byte.toString(16).padStart(2, '0')).join(''));
 };
 
-// This function is design to convert any existing Uint8Array properties inside AuthenticatorAssertionResponse to ArrayBuffer
+// This function is tries converts Uint8Array, Array or object to ArrayBuffer. Returns the original object if it doesn't match any of the aforementioned types.
 export const convertToArrayBuffer = (obj) => {
     if (obj instanceof Uint8Array) {
         return obj.buffer.slice(obj.byteOffset, obj.byteOffset + obj.byteLength);


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to NEAR JavaScript API here: https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md).
- [x] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [ ] **If this is a code change**: I have written unit tests.
- [x] **If this changes code in a published package**: I have run `pnpm changeset` to create a `changeset` JSON document appropriate for this change.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

This PR contains fixes for #1330 issue. The main reason why passkey did not work with BitWarden was because they do not follow standard format for [webauthn credentials](https://www.w3.org/TR/webauthn-2/#iface-pkcredential) in which they used data format of `Uint8Array` instead of `ArrayBuffer`. However they can be easily convert-able so in this PR I have implemented logic to do the conversion.  

## Test Plan
On https://github.com/near/fast-auth-signer/ repo, run it locally with commend `yarn && NETWORK_ID=testnet yarn run start --https` (Bitwarden only works with https)
On new Chrome browser profile, install Bitwarden chrome extension package. 
manually navigate to localhost:3000/create-account and try to create an account.
(At this point, you should be able to replicate the issues)

Apply the above change directly to source code. (There is issues with setting up yarn link/npm link between these two projects)

I have confirm that above change has resolved the issue and was able to conduct create key and get keys without error.

