### PR TITLE
fix: view function use buffer

### DIFF
--- a/packages/accounts/src/utils.ts
+++ b/packages/accounts/src/utils.ts
@@ -12,8 +12,10 @@ function parseJsonFromRawResponse(response: Uint8Array): any {
     return JSON.parse(Buffer.from(response).toString());
 }
 
-function bytesJsonStringify(input: any): Buffer {
-    return Buffer.from(JSON.stringify(input));
+export function stringifyJsonOrBytes(args: any): Buffer {
+    const isUint8Array =
+        args.byteLength !== undefined && args.byteLength === args.length;
+    return isUint8Array ? args : Buffer.from(JSON.stringify(args));
 }
 
 export function validateArgs(args: any) {
@@ -75,7 +77,7 @@ export async function viewFunction(connection: Connection, {
     methodName,
     args = {},
     parse = parseJsonFromRawResponse,
-    stringify = bytesJsonStringify,
+    stringify = stringifyJsonOrBytes,
     jsContract = false,
     blockQuery = { finality: 'optimistic' }
 }: ViewFunctionCallOptions): Promise<any> {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to NEAR JavaScript API here: https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md).
- [x] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [x] **If this is a code change**: I have written unit tests.
- [ ] **If this changes code in a published package**: I have run `pnpm changeset` to create a `changeset` JSON document appropriate for this change.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

Same as call function, view function should also allow `Buffer` as args

