### PR TITLE
feat: update RPC error schema for protocol version 69

### DIFF
--- a/.changeset/fast-books-stare.md
+++ b/.changeset/fast-books-stare.md
@@ -1,0 +1,5 @@
+---
+"@near-js/utils": minor
+---
+
+New transaction submission errors: ShardCongested, ShardStuck, ReceiptSizeExceeded

--- a/packages/utils/src/errors/error_messages.json
+++ b/packages/utils/src/errors/error_messages.json
@@ -63,5 +63,7 @@
     "InvalidReceiver": "Invalid receiver account ID {{receiver_id}} according to requirements",
     "DeleteKeyDoesNotExist": "Account {{account_id}} tries to remove an access key that doesn't exist",
     "Timeout": "Timeout exceeded",
-    "Closed": "Connection closed"
+    "Closed": "Connection closed",
+    "ShardCongested": "Shard {{shard_id}} rejected the transaction due to congestion level {{congestion_level}}, try again later",
+    "ShardStuck": "Shard {{shard_id}} rejected the transaction because it missed {{missed_chunks}} chunks and needs to recover before accepting new transactions, try again later"
 }

--- a/packages/utils/src/errors/rpc_error_schema.json
+++ b/packages/utils/src/errors/rpc_error_schema.json
@@ -132,10 +132,12 @@
       "props": {
         "final_accounts_balance": "",
         "final_postponed_receipts_balance": "",
+        "forwarded_buffered_receipts_balance": "",
         "incoming_receipts_balance": "",
         "incoming_validator_rewards": "",
         "initial_accounts_balance": "",
         "initial_postponed_receipts_balance": "",
+        "new_buffered_receipts_balance": "",
         "new_delayed_receipts_balance": "",
         "other_burnt_amount": "",
         "outgoing_receipts_balance": "",
@@ -562,7 +564,10 @@
         "InvalidChain",
         "Expired",
         "ActionsValidation",
-        "TransactionSizeExceeded"
+        "TransactionSizeExceeded",
+        "StorageError",
+        "ShardCongested",
+        "ShardStuck"
       ],
       "props": {}
     },
@@ -719,6 +724,14 @@
         "method_name": ""
       }
     },
+    "ReceiptSizeExceeded": {
+      "name": "ReceiptSizeExceeded",
+      "subtypes": [],
+      "props": {
+        "limit": "",
+        "size": ""
+      }
+    },
     "ReceiptValidationError": {
       "name": "ReceiptValidationError",
       "subtypes": [
@@ -728,7 +741,8 @@
         "InvalidDataReceiverId",
         "ReturnedValueLengthExceeded",
         "NumberInputDataDependenciesExceeded",
-        "ActionsValidation"
+        "ActionsValidation",
+        "ReceiptSizeExceeded"
       ],
       "props": {}
     },
@@ -757,6 +771,22 @@
       "name": "Serialization",
       "subtypes": [],
       "props": {}
+    },
+    "ShardCongested": {
+      "name": "ShardCongested",
+      "subtypes": [],
+      "props": {
+        "congestion_level": "",
+        "shard_id": ""
+      }
+    },
+    "ShardStuck": {
+      "name": "ShardStuck",
+      "subtypes": [],
+      "props": {
+        "missed_chunks": "",
+        "shard_id": ""
+      }
     },
     "SignerDoesNotExist": {
       "name": "SignerDoesNotExist",

--- a/packages/utils/test/rpc-errors.test.js
+++ b/packages/utils/test/rpc-errors.test.js
@@ -6,7 +6,7 @@ describe('rpc-errors', () => {
             TxExecutionError: {
                 ActionError: {
                     index: 1,
-                    kind: {AccountAlreadyExists: {account_id: 'bob.near'}}
+                    kind: { AccountAlreadyExists: { account_id: 'bob.near' } }
                 }
             }
         };
@@ -39,13 +39,75 @@ describe('rpc-errors', () => {
         );
     });
 
+    test('test ShardCongested error', async () => {
+        let rpc_error = {
+            TxExecutionError: {
+                InvalidTxError: {
+                    ShardCongested: {
+                        shard_id: 2,
+                        congestion_level: 0.4
+                    }
+                }
+            }
+        };
+        let error = parseRpcError(rpc_error);
+        expect(error.type === 'ShardCongested').toBe(true);
+        expect(error.shard_id).toBe(2);
+        expect(error.congestion_level).toBe(0.4);
+        expect(formatError(error.type, error)).toBe(
+            'Shard 2 rejected the transaction due to congestion level 0.4, try again later'
+        );
+    });
+
+    test('test ShardStuck error', async () => {
+        let rpc_error = {
+            TxExecutionError: {
+                InvalidTxError: {
+                    ShardStuck: {
+                        shard_id: 2,
+                        missed_chunks: 5
+                    }
+                }
+            }
+        };
+        let error = parseRpcError(rpc_error);
+        expect(error.type === 'ShardStuck').toBe(true);
+        expect(error.shard_id).toBe(2);
+        expect(error.missed_chunks).toBe(5);
+        expect(formatError(error.type, error)).toBe(
+            'Shard 2 rejected the transaction because it missed 5 chunks and needs to recover before accepting new transactions, try again later'
+        );
+    });
+
+    test('test ReceiptSizeExceeded error', async () => {
+        let rpc_error = {
+            TxExecutionError: {
+                InvalidTxError: {
+                    ReceiptValidationError: {
+                        ReceiptSizeExceeded: {
+                            limit: 100,
+                            size: 101
+                        }
+                    }
+                }
+            }
+        };
+        let error = parseRpcError(rpc_error);
+        expect(error.type === 'ReceiptSizeExceeded').toBe(true);
+        expect(error.limit).toBe(100);
+        expect(error.size).toBe(101);
+        expect(formatError(error.type, error)).toBe(
+            '{\"type\":\"ReceiptSizeExceeded\",\"limit\":100,\"size\":101,\"kind\":{\"limit\":100,\"size\":101}}'
+        );
+    });
+
     test('test InvalidIteratorIndex error', async () => {
         let rpc_error = {
             TxExecutionError: {
                 ActionError: {
                     FunctionCallError: {
                         HostError: {
-                            InvalidIteratorIndex: {iterator_index: 42}
+                            InvalidIteratorIndex: { iterator_index: 42 }
                         }
                     }
                 }


### PR DESCRIPTION
With protocol version 68, cross-shard congestion control is introduced that adds two new errors on the RPC endpoints for submitting transactions. (ShardCongested, ShardStuck)

Protocol version 69 introduces stateless validation and also adds a new error for submitted transactions. (ReceiptSizeExceeded)

Technically, there are additional errors in nearcore's version of the rpc schema. But those are from nightly features that have not been masked properly. (NonRefundableTransferToExistingAccount  and InvalidTransactionVersion are waiting for NEP-491 and NEP-541 respectively.)

Aside from updating the schema, I also added human readable error messages and tests for the new errors.

Closes #1358

<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to NEAR JavaScript API here: https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md).
- [x] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [x] **If this is a code change**: I have written unit tests.
- [x] **If this changes code in a published package**: I have run `pnpm changeset` to create a `changeset` JSON document appropriate for this change.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

See #1358 

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->

Unit tests in `packages/utils/test/rpc-errors.test.js` check that the new error kinds are recognized as expected.

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->

See #1358 