### PR TITLE
Use Own Base58

### DIFF
--- a/.changeset/warm-insects-yell.md
+++ b/.changeset/warm-insects-yell.md
@@ -1,0 +1,5 @@
+---
+"@near-js/utils": patch
+---
+
+use own base58 and depend directly on base-x

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -17,7 +17,7 @@
   "license": "ISC",
   "dependencies": {
     "@near-js/types": "workspace:*",
-    "bs58": "4.0.0",
+    "base-x": "5.0.0",
     "depd": "2.0.0",
     "mustache": "4.0.0"
   },

--- a/packages/utils/src/b58.ts
+++ b/packages/utils/src/b58.ts
@@ -1,0 +1,14 @@
+/**
+ * This code is copied verbatim from 
+ * https://github.com/cryptocoinjs/bs58/blob/master/ts_src/index.ts
+ * because 
+ * 1. Its very minimal middleware.
+ * 2. The latest version (v6.0.0) has an incorrect build.
+ *      https://www.npmjs.com/package/bs58/v/6.0.0
+ * 3. It doesn't doesn't actively update the primary dependency: 
+ *      https://www.npmjs.com/package/base-x
+ */ 
+import basex from "base-x";
+const ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+
+export default basex(ALPHABET);

--- a/packages/utils/src/format.ts
+++ b/packages/utils/src/format.ts
@@ -1,5 +1,4 @@
-import bs58 from "bs58";
-
+import bs58 from "./b58";
 /**
  * Exponent for calculating how many indivisible units are there in one NEAR. See {@link NEAR_NOMINATION}.
  */

--- a/packages/utils/test/base58.test.ts
+++ b/packages/utils/test/base58.test.ts
@@ -2,71 +2,71 @@ import { describe, test, expect } from '@jest/globals';
 import base58 from '../src/b58';
 
 const fixtures = {
-  valid: [
-    { hex: '', string: '' },
-    { hex: '61', string: '2g' },
-    { hex: '626262', string: 'a3gV' },
-    { hex: '636363', string: 'aPEr' },
-    {
-      hex: '73696d706c792061206c6f6e6720737472696e67',
-      string: '2cFupjhnEsSn59qHXstmK2ffpLv2',
-    },
-    {
-      hex: '00eb15231dfceb60925886b67d065299925915aeb172c06647',
-      string: '1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L',
-    },
-    { hex: '516b6fcd0f', string: 'ABnLTmg' },
-    { hex: 'bf4f89001e670274dd', string: '3SEo3LWLoPntC' },
-    { hex: '572e4794', string: '3EFU7m' },
-    { hex: 'ecac89cad93923c02321', string: 'EJDM8drfXA6uyA' },
-    { hex: '10c8511e', string: 'Rt5zm' },
-    { hex: '00000000000000000000', string: '1111111111' },
-    {
-      hex: '801184cd2cdd640ca42cfc3a091c51d549b2f016d454b2774019c2b2d2e08529fd206ec97e',
-      string: '5Hx15HFGyep2CfPxsJKe2fXJsCVn5DEiyoeGGF6JZjGbTRnqfiD',
-    },
-    {
-      hex: '003c176e659bea0f29a3e9bf7880c112b1b31b4dc826268187',
-      string: '16UjcYNBG9GTK4uq2f7yYEbuifqCzoLMGS',
-    },
-  ],
-  invalid: [
-    { description: 'non-base58 string', string: 'invalid' },
-    { description: 'non-base58 alphabet', string: 'c2F0b3NoaQo=' },
-    { description: 'leading whitespace', string: ' 1111111111' },
-    { description: 'trailing whitespace', string: '1111111111 ' },
-    {
-      description: 'unexpected character after whitespace',
-      string: ' \t\n\u000b\f\r skip \r\f\u000b\n\t a',
-    },
-  ],
+    valid: [
+        { hex: '', string: '' },
+        { hex: '61', string: '2g' },
+        { hex: '626262', string: 'a3gV' },
+        { hex: '636363', string: 'aPEr' },
+        {
+            hex: '73696d706c792061206c6f6e6720737472696e67',
+            string: '2cFupjhnEsSn59qHXstmK2ffpLv2',
+        },
+        {
+            hex: '00eb15231dfceb60925886b67d065299925915aeb172c06647',
+            string: '1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L',
+        },
+        { hex: '516b6fcd0f', string: 'ABnLTmg' },
+        { hex: 'bf4f89001e670274dd', string: '3SEo3LWLoPntC' },
+        { hex: '572e4794', string: '3EFU7m' },
+        { hex: 'ecac89cad93923c02321', string: 'EJDM8drfXA6uyA' },
+        { hex: '10c8511e', string: 'Rt5zm' },
+        { hex: '00000000000000000000', string: '1111111111' },
+        {
+            hex: '801184cd2cdd640ca42cfc3a091c51d549b2f016d454b2774019c2b2d2e08529fd206ec97e',
+            string: '5Hx15HFGyep2CfPxsJKe2fXJsCVn5DEiyoeGGF6JZjGbTRnqfiD',
+        },
+        {
+            hex: '003c176e659bea0f29a3e9bf7880c112b1b31b4dc826268187',
+            string: '16UjcYNBG9GTK4uq2f7yYEbuifqCzoLMGS',
+        },
+    ],
+    invalid: [
+        { description: 'non-base58 string', string: 'invalid' },
+        { description: 'non-base58 alphabet', string: 'c2F0b3NoaQo=' },
+        { description: 'leading whitespace', string: ' 1111111111' },
+        { description: 'trailing whitespace', string: '1111111111 ' },
+        {
+            description: 'unexpected character after whitespace',
+            string: ' \t\n\u000b\f\r skip \r\f\u000b\n\t a',
+        },
+    ],
 };
 
 const { encode, decode } = base58;
 const { valid, invalid } = fixtures;
 
 describe('base58', () => {
-  describe('encode', () => {
-    valid.forEach((f) => {
-      test(`can encode ${f.hex}`, () => {
-        const actual = encode(Buffer.from(f.hex, 'hex'));
-        expect(actual).toBe(f.string);
-      });
-    });
-  });
-
-  describe('decode', () => {
-    valid.forEach((f) => {
-      test(`can decode ${f.string}`, () => {
-        const actual = Buffer.from(decode(f.string)).toString('hex');
-        expect(actual).toBe(f.hex);
-      });
+    describe('encode', () => {
+        valid.forEach((f) => {
+            test(`can encode ${f.hex}`, () => {
+                const actual = encode(Buffer.from(f.hex, 'hex'));
+                expect(actual).toBe(f.string);
+            });
+        });
     });
 
-    invalid.forEach((f) => {
-      test(`throws on ${f.description}`, () => {
-        expect(() => decode(f.string)).toThrow("Non-base58 character");
-      });
+    describe('decode', () => {
+        valid.forEach((f) => {
+            test(`can decode ${f.string}`, () => {
+                const actual = Buffer.from(decode(f.string)).toString('hex');
+                expect(actual).toBe(f.hex);
+            });
+        });
+
+        invalid.forEach((f) => {
+            test(`throws on ${f.description}`, () => {
+                expect(() => decode(f.string)).toThrow('Non-base58 character');
+            });
+        });
     });
-  });
 });

--- a/packages/utils/test/base58.test.ts
+++ b/packages/utils/test/base58.test.ts
@@ -1,0 +1,72 @@
+import { describe, test, expect } from '@jest/globals';
+import base58 from '../src/b58';
+
+const fixtures = {
+  valid: [
+    { hex: '', string: '' },
+    { hex: '61', string: '2g' },
+    { hex: '626262', string: 'a3gV' },
+    { hex: '636363', string: 'aPEr' },
+    {
+      hex: '73696d706c792061206c6f6e6720737472696e67',
+      string: '2cFupjhnEsSn59qHXstmK2ffpLv2',
+    },
+    {
+      hex: '00eb15231dfceb60925886b67d065299925915aeb172c06647',
+      string: '1NS17iag9jJgTHD1VXjvLCEnZuQ3rJDE9L',
+    },
+    { hex: '516b6fcd0f', string: 'ABnLTmg' },
+    { hex: 'bf4f89001e670274dd', string: '3SEo3LWLoPntC' },
+    { hex: '572e4794', string: '3EFU7m' },
+    { hex: 'ecac89cad93923c02321', string: 'EJDM8drfXA6uyA' },
+    { hex: '10c8511e', string: 'Rt5zm' },
+    { hex: '00000000000000000000', string: '1111111111' },
+    {
+      hex: '801184cd2cdd640ca42cfc3a091c51d549b2f016d454b2774019c2b2d2e08529fd206ec97e',
+      string: '5Hx15HFGyep2CfPxsJKe2fXJsCVn5DEiyoeGGF6JZjGbTRnqfiD',
+    },
+    {
+      hex: '003c176e659bea0f29a3e9bf7880c112b1b31b4dc826268187',
+      string: '16UjcYNBG9GTK4uq2f7yYEbuifqCzoLMGS',
+    },
+  ],
+  invalid: [
+    { description: 'non-base58 string', string: 'invalid' },
+    { description: 'non-base58 alphabet', string: 'c2F0b3NoaQo=' },
+    { description: 'leading whitespace', string: ' 1111111111' },
+    { description: 'trailing whitespace', string: '1111111111 ' },
+    {
+      description: 'unexpected character after whitespace',
+      string: ' \t\n\u000b\f\r skip \r\f\u000b\n\t a',
+    },
+  ],
+};
+
+const { encode, decode } = base58;
+const { valid, invalid } = fixtures;
+
+describe('base58', () => {
+  describe('encode', () => {
+    valid.forEach((f) => {
+      test(`can encode ${f.hex}`, () => {
+        const actual = encode(Buffer.from(f.hex, 'hex'));
+        expect(actual).toBe(f.string);
+      });
+    });
+  });
+
+  describe('decode', () => {
+    valid.forEach((f) => {
+      test(`can decode ${f.string}`, () => {
+        const actual = Buffer.from(decode(f.string)).toString('hex');
+        expect(actual).toBe(f.hex);
+      });
+    });
+
+    invalid.forEach((f) => {
+      test(`throws on ${f.description}`, () => {
+        expect(() => decode(f.string)).toThrow("Non-base58 character");
+      });
+    });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -619,9 +619,9 @@ importers:
       '@near-js/types':
         specifier: workspace:*
         version: link:../types
-      bs58:
-        specifier: 4.0.0
-        version: 4.0.0
+      base-x:
+        specifier: 5.0.0
+        version: 5.0.0
       depd:
         specifier: 2.0.0
         version: 2.0.0
@@ -1562,6 +1562,9 @@ packages:
 
   base-x@3.0.9:
     resolution: {integrity: sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==}
+
+  base-x@5.0.0:
+    resolution: {integrity: sha512-sMW3VGSX1QWVFA6l8U62MLKz29rRfpTlYdCqLdpLo1/Yd4zZwSbnUaDfciIAowAqvq7YFnWq9hrhdg1KYgc1lQ==}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -5357,6 +5360,8 @@ snapshots:
   base-x@3.0.9:
     dependencies:
       safe-buffer: 5.2.1
+
+  base-x@5.0.0: {}
 
   base64-js@1.5.1: {}
 


### PR DESCRIPTION
## Pre-flight checklist

- [ ] I have read the [Contributing Guidelines on pull requests](https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md).
- [ ] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [ ] **If this is a code change**: I have written unit tests.
- [ ] **If this changes code in a published package**: I have run `pnpm changeset` to create a `changeset` JSON document appropriate for this change.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

I have been getting annoyed by this package resolution warning:

```
warning near-api-js > @near-js/utils > bs58 > base-x@2.0.6: use 3.0.0 instead, safe-buffer has been merged and release for compatability
```

This is caused by a very tiny piece of middleware (bs58) that is not very professionally managed or updated and prevents us from keeping the primary dependency updated.

To solve this, we copy the 3 lines of code coming from that middle ware into an identical file directly into this project and migrate our dependency to `base-x`.

Alternative solution would be to fix the dependency's build issue and re-depend on it.

## Test Plan

Added unit tests transcribed from the former dependency. 
https://github.com/cryptocoinjs/bs58/blob/master/test/index.js

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
