### PR TITLE
fix: resolve broken links in cookbook

### DIFF
--- a/packages/cookbook/README.md
+++ b/packages/cookbook/README.md
@@ -5,18 +5,17 @@ Collection of common use cases for [`near-api-js`](https://github.com/near/near-
 |                                                                 |                                                                                                                  |
 |-----------------------------------------------------------------| ---------------------------------------------------------------------------------------------------------------- |
 | **ACCOUNTS**                                                    |                                                                                                                  |
-| [Create Account](./accounts/create-testnet-account.js)          | Create [NEAR accounts](https://docs.near.org/concepts/basics/account) without using NEAR Wallet.                   |
+| [Create Account](./accounts/create-testnet-account.ts)          | Create [NEAR accounts](https://docs.near.org/concepts/basics/account) without using NEAR Wallet.                   |
 | [Access Key Rotation](./accounts/access-keys/README.md)         | Create and delete [access keys](https://docs.near.org/concepts/basics/account#access-keys) for added security.     |
 | **TRANSACTIONS**                                                |                                                                                                                  |
-| [Get Transaction Status](./transactions/get-tx-status.js)       | Gets transaction status using a tx hash and associated account/contract ID.                                      |
-| [Recent Transaction Details](./transactions/get-tx-detail.js)   | Get recent transaction details without using an [indexing](https://docs.near.org/docs/concepts/indexer) service. |
-| [Batch Transactions](./transactions/batch-transactions.js)      | Sign and send multiple [transactions](https://docs.near.org/docs/concepts/transaction).                          |
+| [Get Transaction Status](./transactions/get-tx-status.ts)       | Gets transaction status using a tx hash and associated account/contract ID.                                      |
+| [Batch Transactions](./transactions/batch-transactions.ts)      | Sign and send multiple [transactions](https://docs.near.org/docs/concepts/transaction).                          |
 | **UTILS**                                                       |                                                                                                                  |
-| [Deploy Contract](./utils/deploy-contract.js)                   | Deploys a contract using a pre-compiled .wasm file                                                               |
-| [Calculate Gas](./utils/calculate-gas.js)                       | Calculate [gas burnt](https://docs.near.org/docs/concepts/gas) from any contract call.                           |
-| [Read State w/o Account](./utils/get-state.js)                  | Read state of a contract without instantiating an account.                                                       |
-| [Wrap](./utils/wrap-near.js) & [Unwrap](./utils/unwrap-near.js)  NEAR | Wrap and unwrap NEAR using the `wrap.near` smart contract.                                                  |
-| [Verify Signature](./utils/verify-signature.js)                 | Verify a key pair signature.                                                                                |
+| [Deploy Contract](./utils/deploy-contract.ts)                   | Deploys a contract using a pre-compiled .wasm file                                                               |
+| [Calculate Gas](./utils/calculate-gas.ts)                       | Calculate [gas burnt](https://docs.near.org/docs/concepts/gas) from any contract call.                           |
+| [Read State w/o Account](./utils/get-state.ts)                  | Read state of a contract without instantiating an account.                                                       |
+| [Wrap](./utils/wrap-near.ts) & [Unwrap](./utils/unwrap-near.ts)  NEAR | Wrap and unwrap NEAR using the `wrap.near` smart contract.                                                  |
+| [Verify Signature](./utils/verify-signature.ts)                 | Verify a key pair signature.                                                                                |
 
 ## Requirements
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to NEAR JavaScript API here: https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md).
- [x] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [x] **If this is a code change**: I have written unit tests.
- [x] **If this changes code in a published package**: I have run `pnpm changeset` to create a `changeset` JSON document appropriate for this change.
- [x] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

Cookbook links in README were all broken due to a file extension mistake (.js instead of .ts)

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
