### PR TITLE
Switch to secure Base58 library

### DIFF
--- a/.changeset/neat-crabs-beam.md
+++ b/.changeset/neat-crabs-beam.md
@@ -1,0 +1,7 @@
+---
+"@near-js/accounts": minor
+"near-api-js": minor
+"@near-js/utils": minor
+---
+
+Update base58 dependency

--- a/packages/accounts/package.json
+++ b/packages/accounts/package.json
@@ -33,9 +33,9 @@
     "devDependencies": {
         "@jest/globals": "^29.7.0",
         "@near-js/keystores": "workspace:*",
+        "@scure/base": "^1.2.0",
         "@types/json-schema": "^7.0.15",
         "@types/node": "20.0.0",
-        "bs58": "4.0.0",
         "build": "workspace:*",
         "jest": "29.7.0",
         "near-hello": "0.5.1",

--- a/packages/accounts/test/account.access_key.test.ts
+++ b/packages/accounts/test/account.access_key.test.ts
@@ -79,8 +79,9 @@ test('view account details after adding access keys', async() => {
         publicKey: keyPair2.getPublicKey().toString(),
     }];
 
-    // @ts-expect-error test input
-    expect(JSON.stringify(details.authorizedApps.toSorted((a, b) => a.amount < b.amount))).toEqual(JSON.stringify(authorizedApps.toSorted((a, b) => a.amount < b.amount)));
+    expect(details.authorizedApps).toEqual(expect.arrayContaining(authorizedApps));
+    expect(authorizedApps).toEqual(expect.arrayContaining(details.authorizedApps));
+    expect(details.authorizedApps).toHaveLength(authorizedApps.length);
 });
 
 test('loading account after adding a full key', async() => {

--- a/packages/accounts/test/providers.test.ts
+++ b/packages/accounts/test/providers.test.ts
@@ -1,7 +1,7 @@
 import { beforeAll, describe, expect, jest, test } from '@jest/globals';
 import { KeyPair } from '@near-js/crypto';
 import { ErrorMessages } from '@near-js/utils';
-import base58 from 'bs58';
+import { base58 } from '@scure/base';
 
 import { createAccount, deployContract, generateUniqueString, setUpTestConnection, sleep, waitFor } from './test-utils';
 

--- a/packages/near-api-js/package.json
+++ b/packages/near-api-js/package.json
@@ -32,7 +32,6 @@
     "devDependencies": {
         "@types/http-errors": "1.6.1",
         "@types/node": "18.11.18",
-        "bs58": "4.0.0",
         "concurrently": "7.3.0",
         "in-publish": "2.0.0",
         "jest": "29.7.0",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -17,7 +17,7 @@
   "license": "ISC",
   "dependencies": {
     "@near-js/types": "workspace:*",
-    "bs58": "4.0.0",
+    "@scure/base": "^1.2.0",
     "depd": "2.0.0",
     "mustache": "4.0.0"
   },

--- a/packages/utils/src/format.ts
+++ b/packages/utils/src/format.ts
@@ -1,4 +1,4 @@
-import bs58 from "bs58";
+import { base58 } from "@scure/base";
 
 /**
  * Exponent for calculating how many indivisible units are there in one NEAR. See {@link NEAR_NOMINATION}.
@@ -133,7 +133,7 @@ export function baseEncode(value: Uint8Array | string): string {
         }
         value = new Uint8Array(bytes);
     }
-    return bs58.encode(value);
+    return base58.encode(value);
 }
 
 /**
@@ -142,5 +142,5 @@ export function baseEncode(value: Uint8Array | string): string {
  * @returns Uint8Array representing the decoded value
  */
 export function baseDecode(value: string): Uint8Array {
-    return new Uint8Array(bs58.decode(value));
+    return base58.decode(value);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,15 +103,15 @@ importers:
       '@near-js/keystores':
         specifier: workspace:*
         version: link:../keystores
+      '@scure/base':
+        specifier: ^1.2.0
+        version: 1.2.0
       '@types/json-schema':
         specifier: ^7.0.15
         version: 7.0.15
       '@types/node':
         specifier: 20.0.0
         version: 20.0.0
-      bs58:
-        specifier: 4.0.0
-        version: 4.0.0
       build:
         specifier: workspace:*
         version: link:../build
@@ -488,9 +488,6 @@ importers:
       '@types/node':
         specifier: 18.11.18
         version: 18.11.18
-      bs58:
-        specifier: 4.0.0
-        version: 4.0.0
       concurrently:
         specifier: 7.3.0
         version: 7.3.0
@@ -674,9 +671,9 @@ importers:
       '@near-js/types':
         specifier: workspace:*
         version: link:../types
-      bs58:
-        specifier: 4.0.0
-        version: 4.0.0
+      '@scure/base':
+        specifier: ^1.2.0
+        version: 1.2.0
       depd:
         specifier: 2.0.0
         version: 2.0.0
@@ -1307,6 +1304,9 @@ packages:
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
+
+  '@scure/base@1.2.0':
+    resolution: {integrity: sha512-iGiGgAXDvDwiaBKbXbDL7hDGhKg9Shhd67GMalE/hkj9Vhf44+LoBNptn25vvw26+gO90rfsjHOuc7f/kGcMfg==}
 
   '@sinclair/typebox@0.27.8':
     resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
@@ -2093,6 +2093,7 @@ packages:
   eslint@8.20.0:
     resolution: {integrity: sha512-d4ixhz5SKCa1D6SCPrivP7yYVi7nyD6A4vs6HIAul9ujBzcEmZVM3/0NN/yu5nKhmO1wjp5xQ46iRfmDGlOviA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
 
   espree@9.6.1:
@@ -5046,6 +5047,8 @@ snapshots:
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
+
+  '@scure/base@1.2.0': {}
 
   '@sinclair/typebox@0.27.8': {}
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to NEAR JavaScript API here: https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md).
- [x] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [ ] **If this is a code change**: I have written unit tests.
- [x] **If this changes code in a published package**: I have run `pnpm changeset` to create a `changeset` JSON document appropriate for this change.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->
This PR switches the Base58 implementation to a [secure, audited & 0-deps implementation](https://github.com/paulmillr/scure-base). The existing `bs58` library is old, poorly maintained, and incompatible with Vite due to its use of Node.js primitives (`Buffer`).

This PR should resolve the following:
* https://github.com/near/near-api-js/issues/1420
* https://github.com/near/near-api-js/issues/1408
* https://github.com/near/near-api-js/pull/1391
* https://github.com/near/near-api-js/pull/1392

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->

## Related issues/PRs

> [!NOTE]  
This project still indirectly relies on `bs58` through `near-workspaces`:
```
near-workspaces 3.5.0
├─┬ borsh 0.5.0
│ └── bs58 4.0.0
├── bs58 4.0.1
```

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
