### PR TITLE
Fix:  Changed encodedTx 

### DIFF
--- a/packages/client/src/transactions/sign_and_send.ts
+++ b/packages/client/src/transactions/sign_and_send.ts
@@ -15,7 +15,7 @@ const DEFAULT_FINALITY: BlockReference = { finality: 'final' };
  * @param signer MessageSigner
  */
 export async function signTransaction({ transaction, deps: { signer } }: SignTransactionParams) {
-  const encodedTx = new Uint8Array(sha256.sha256.array(transaction.encode()));
+  const encodedTx = new Uint8Array(sha256(transaction.encode()));
   const signedTransaction = new SignedTransaction({
     transaction,
     signature: new Signature({

--- a/packages/client/src/transactions/sign_and_send.ts
+++ b/packages/client/src/transactions/sign_and_send.ts
@@ -15,7 +15,7 @@ const DEFAULT_FINALITY: BlockReference = { finality: 'final' };
  * @param signer MessageSigner
  */
 export async function signTransaction({ transaction, deps: { signer } }: SignTransactionParams) {
-  const encodedTx = transaction.encode();
+  const encodedTx = new Uint8Array(sha256.sha256.array(transaction.encode()));
   const signedTransaction = new SignedTransaction({
     transaction,
     signature: new Signature({

--- a/packages/client/src/transactions/sign_and_send.ts
+++ b/packages/client/src/transactions/sign_and_send.ts
@@ -25,7 +25,7 @@ export async function signTransaction({ transaction, deps: { signer } }: SignTra
   });
 
   return {
-    encodedTransactionHash: new Uint8Array(sha256(encodedTx)),
+    encodedTransactionHash: encodedTx,
     signedTransaction,
   };
 }


### PR DESCRIPTION
Resolved issue [#1442](https://github.com/near/near-api-js/issues/1442) .
Changed  `const encodedTx = transaction.encode();` 
to  `const encodedTx = new Uint8Array(sha256.sha256.array(transaction.encode()));`
