### PR TITLE
Remove unfetch

### DIFF
--- a/.changeset/mean-hotels-matter.md
+++ b/.changeset/mean-hotels-matter.md
@@ -1,0 +1,7 @@
+---
+"@near-js/accounts": patch
+"@near-js/client": patch
+"@near-js/providers": patch
+---
+
+drop unfetch polyfill

--- a/package.json
+++ b/package.json
@@ -36,6 +36,5 @@
   "resolutions": {
     "near-sandbox": "0.0.18",
     "near-api-js": "4.0.0"
-  },
-  "packageManager": "pnpm@9.10.0+sha512.73a29afa36a0d092ece5271de5177ecbf8318d454ecd701343131b8ebc0c1a91c487da46ab77c8e596d6acf1461e3594ced4becedf8921b074fbd8653ed7051c"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -36,5 +36,6 @@
   "resolutions": {
     "near-sandbox": "0.0.18",
     "near-api-js": "4.0.0"
-  }
+  },
+  "packageManager": "pnpm@9.10.0+sha512.73a29afa36a0d092ece5271de5177ecbf8318d454ecd701343131b8ebc0c1a91c487da46ab77c8e596d6acf1461e3594ced4becedf8921b074fbd8653ed7051c"
 }

--- a/packages/accounts/package.json
+++ b/packages/accounts/package.json
@@ -26,7 +26,6 @@
         "borsh": "1.0.0",
         "depd": "2.0.0",
         "is-my-json-valid": "^2.20.6",
-        "isomorphic-unfetch": "^3.1.0",
         "lru_map": "0.4.1",
         "near-abi": "0.1.1"
     },
@@ -40,7 +39,6 @@
         "jest": "29.7.0",
         "near-hello": "0.5.1",
         "near-workspaces": "3.5.0",
-        "node-fetch": "2.6.7",
         "semver": "7.1.1",
         "ts-jest": "29.1.5",
         "tsconfig": "workspace:*",

--- a/packages/accounts/src/account_2fa.ts
+++ b/packages/accounts/src/account_2fa.ts
@@ -2,7 +2,6 @@ import { PublicKey } from '@near-js/crypto';
 import { FinalExecutionOutcome, TypedError, FunctionCallPermissionView } from '@near-js/types';
 import { actionCreators } from '@near-js/transactions';
 import { Logger } from '@near-js/utils'
-import unfetch from 'isomorphic-unfetch';
 
 import { SignAndSendTransactionOptions } from './account';
 import { AccountMultisig } from './account_multisig';
@@ -332,7 +331,7 @@ export class Account2FA extends AccountMultisig {
      * @returns {Promise<any>} - A promise that resolves to the response from the helper.
      */
     async postSignedJson(path, body) {
-        return await unfetch(this.helperUrl + path, {
+        return await fetch(this.helperUrl + path, {
             body: JSON.stringify({
                 ...body,
                 ...(await this.signatureFor()),

--- a/packages/accounts/src/account_creator.ts
+++ b/packages/accounts/src/account_creator.ts
@@ -1,5 +1,4 @@
 import { PublicKey } from '@near-js/crypto';
-import unfetch from 'isomorphic-unfetch';
 
 import { Connection } from './connection';
 import { Account } from './account';
@@ -50,7 +49,7 @@ export class UrlAccountCreator extends AccountCreator {
      * @returns {Promise<void>}
      */
     async createAccount(newAccountId: string, publicKey: PublicKey): Promise<void> {
-        await unfetch(`${this.helperUrl}/account`, {
+        await fetch(`${this.helperUrl}/account`, {
             body: JSON.stringify({ newAccountId, newAccountPublicKey: publicKey.toString() }),
             method: 'POST',
         });

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -19,8 +19,7 @@
     "@near-js/transactions": "workspace:*",
     "@near-js/types": "workspace:*",
     "@near-js/utils": "workspace:*",
-    "@noble/hashes": "1.3.3",
-    "isomorphic-fetch": "3.0.0"
+    "@noble/hashes": "1.3.3"
   },
   "keywords": [],
   "author": "",

--- a/packages/client/src/funded_account.ts
+++ b/packages/client/src/funded_account.ts
@@ -1,5 +1,4 @@
 import type { FinalExecutionOutcome } from '@near-js/types';
-import fetch from 'isomorphic-fetch';
 
 import { KITWALLET_FUNDED_TESTNET_ACCOUNT_ENDPOINT } from './constants';
 import { NewAccountParams } from './interfaces';

--- a/packages/providers/jest.config.ts
+++ b/packages/providers/jest.config.ts
@@ -1,13 +1,14 @@
 export default {
-    preset: 'ts-jest',
-    collectCoverage: true,
-    testEnvironment: 'node',
-    testRegex: "(/tests/.*|(\\.|/)(test|spec))\\.[jt]sx?$",
-    transform: {
-        '^.+\\.[tj]s$': ['ts-jest', {
-            tsconfig: {
-               allowJs: true
-            }
-        }]
-    },
+	preset: "ts-jest",
+	collectCoverage: true,
+	testEnvironment: "node",
+	testRegex: "(/tests/.*|(\\.|/)(test|spec))\\.[jt]sx?$",
+	transform: {
+		"^.+\\.[tj]s$": [
+			"ts-jest",
+			{
+				tsconfig: "tsconfig.json",
+			},
+		],
+	},
 };

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -23,13 +23,12 @@
     "exponential-backoff": "^3.1.1"
   },
   "devDependencies": {
-    "@fetch-mock/jest": "^0.2.7",
     "@jest/globals": "^29.7.0",
     "@types/node": "20.0.0",
     "build": "workspace:*",
     "jest": "29.7.0",
     "near-workspaces": "3.5.0",
-    "ts-jest": "29.1.5",
+    "ts-jest": "29.2.5",
     "tsconfig": "workspace:*",
     "typescript": "5.4.5"
   },

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -20,10 +20,10 @@
     "@near-js/types": "workspace:*",
     "@near-js/utils": "workspace:*",
     "borsh": "1.0.0",
-    "exponential-backoff": "^3.1.1",
-    "isomorphic-unfetch": "^3.1.0"
+    "exponential-backoff": "^3.1.1"
   },
   "devDependencies": {
+    "@fetch-mock/jest": "^0.2.7",
     "@jest/globals": "^29.7.0",
     "@types/node": "20.0.0",
     "build": "workspace:*",

--- a/packages/providers/src/fetch_json.ts
+++ b/packages/providers/src/fetch_json.ts
@@ -1,6 +1,5 @@
 import { TypedError } from '@near-js/types';
 import { backOff } from 'exponential-backoff';
-import unfetch from 'isomorphic-unfetch';
 
 const BACKOFF_MULTIPLIER = 1.5;
 const RETRY_NUMBER = 10;
@@ -56,7 +55,7 @@ interface JsonRpcRequest {
  */
 export async function fetchJsonRpc(url: string, json: JsonRpcRequest, headers: object, retryConfig: object): Promise<any> {
     const response = await backOff(async () => {
-        const res = await unfetch(url, {
+        const res = await fetch(url, {
             method: 'POST',
             body: JSON.stringify(json),
             headers: { ...headers, 'Content-Type': 'application/json' }

--- a/packages/providers/test/fetch_json_error.test.ts
+++ b/packages/providers/test/fetch_json_error.test.ts
@@ -1,48 +1,89 @@
-import { describe, expect, test } from '@jest/globals';
+import {
+    describe,
+    expect,
+    test,
+    jest,
+    beforeEach,
+    afterAll,
+} from '@jest/globals';
 import { fetchJsonRpc, retryConfig } from '../src/fetch_json';
-import { ProviderError } from '../src/fetch_json'; 
-import fetchMock from '@fetch-mock/jest';
+import { ProviderError } from '../src/fetch_json';
 
 describe('fetchJsonError', () => {
     const RPC_URL = 'https://rpc.testnet.near.org';
     const statusRequest = {
         jsonrpc: '2.0',
-        id: 'dontcare',
+        id: 1,
         method: 'status',
         params: [],
     };
 
+    // Store original fetch
+    const originalFetch = global.fetch;
+
+    beforeEach(() => {
+        // Reset fetch for each test with proper typing
+        jest
+            .spyOn(global, 'fetch')
+            .mockImplementation(() => Promise.resolve(new Response()));
+    });
+
+    afterAll(() => {
+        // Restore original fetch
+        global.fetch = originalFetch;
+    });
+
     test('handles 500 Internal Server Error', async () => {
-        fetchMock.once(RPC_URL, 500, '');
-    
-        // @ts-expect-error test input
-        await expect(fetchJsonRpc(RPC_URL, statusRequest, undefined, retryConfig()))
-            .rejects
-            .toThrowError(new ProviderError('Internal server error', { cause: 500 }));
+        jest
+            .spyOn(global, 'fetch')
+            .mockImplementation(() =>
+                Promise.resolve(new Response('', { status: 500 })),
+            );
+
+        await expect(
+            fetchJsonRpc(RPC_URL, statusRequest, {}, retryConfig()),
+        ).rejects.toThrowError(
+            new ProviderError('Internal server error', { cause: 500 }),
+        );
     });
+
     test('handles 408 Timeout Error', async () => {
-        fetchMock.once(RPC_URL, 408, '');
-        // @ts-expect-error test input
-        await expect(fetchJsonRpc(RPC_URL, statusRequest, undefined, retryConfig()))
-            .rejects
-            .toThrowError(new ProviderError('Timeout error', { cause: 408 }));
+        jest
+            .spyOn(global, 'fetch')
+            .mockImplementation(() =>
+                Promise.resolve(new Response('', { status: 408 })),
+            );
+
+        await expect(
+            fetchJsonRpc(RPC_URL, statusRequest, {}, retryConfig()),
+        ).rejects.toThrowError(new ProviderError('Timeout error', { cause: 408 }));
     });
-    // });
 
     test('handles 400 Request Validation Error', async () => {
-        fetchMock.once(RPC_URL, 400, '');
-        // @ts-expect-error test input
-        await expect(fetchJsonRpc(RPC_URL, statusRequest, undefined, retryConfig()))
-            .rejects
-            .toThrowError(new ProviderError('Request validation error', { cause: 400 }));
+        jest
+            .spyOn(global, 'fetch')
+            .mockImplementation(() =>
+                Promise.resolve(new Response('', { status: 400 })),
+            );
+
+        await expect(
+            fetchJsonRpc(RPC_URL, statusRequest, {}, retryConfig()),
+        ).rejects.toThrowError(
+            new ProviderError('Request validation error', { cause: 400 }),
+        );
     });
 
     test('handles 503 Service Unavailable', async () => {
-        fetchMock.once(RPC_URL, 503, '');
+        jest
+            .spyOn(global, 'fetch')
+            .mockImplementation(() =>
+                Promise.resolve(new Response('', { status: 503 })),
+            );
 
-        // @ts-expect-error test input
-        await expect(fetchJsonRpc(RPC_URL, statusRequest, undefined, retryConfig()))
-            .rejects
-            .toThrowError(new ProviderError(`${RPC_URL} unavailable`, { cause: 503 }));
+        await expect(
+            fetchJsonRpc(RPC_URL, statusRequest, {}, retryConfig()),
+        ).rejects.toThrowError(
+            new ProviderError(`${RPC_URL} unavailable`, { cause: 503 }),
+        );
     });
 });

--- a/packages/providers/test/fetch_json_error.test.ts
+++ b/packages/providers/test/fetch_json_error.test.ts
@@ -1,9 +1,7 @@
 import { describe, expect, test, jest, afterEach } from '@jest/globals';
 import { fetchJsonRpc, retryConfig } from '../src/fetch_json';
-import unfetch from 'isomorphic-unfetch';
 import { ProviderError } from '../src/fetch_json'; 
-
-jest.mock('isomorphic-unfetch');
+import fetchMock from '@fetch-mock/jest';
 
 describe('fetchJsonError', () => {
     const RPC_URL = 'https://rpc.testnet.near.org';
@@ -14,17 +12,8 @@ describe('fetchJsonError', () => {
         params: [],
     };
 
-    afterEach(() => {
-        jest.clearAllMocks();
-    });
-
     test('handles 500 Internal Server Error', async () => {
-        (unfetch as jest.Mock).mockReturnValue({
-            ok: false,
-            status: 500,
-            text: '',
-            json: {},
-        });
+        fetchMock.once(RPC_URL, 500, '');
     
         // @ts-expect-error test input
         await expect(fetchJsonRpc(RPC_URL, statusRequest, undefined, retryConfig()))
@@ -32,12 +21,7 @@ describe('fetchJsonError', () => {
             .toThrowError(new ProviderError('Internal server error', { cause: 500 }));
     });
     test('handles 408 Timeout Error', async () => {
-        (unfetch as jest.Mock).mockReturnValue({
-            ok: false,
-            status: 408,
-            text: '',
-            json: {},
-        });
+        fetchMock.once(RPC_URL, 408, '')
         // @ts-expect-error test input
         await expect(fetchJsonRpc(RPC_URL, statusRequest, undefined, retryConfig()))
             .rejects
@@ -46,12 +30,7 @@ describe('fetchJsonError', () => {
     // });
 
     test('handles 400 Request Validation Error', async () => {
-        (unfetch as jest.Mock).mockReturnValue({
-            ok: false,
-            status: 400,
-            text: '',
-            json: {},
-        });
+        fetchMock.once(RPC_URL, 400, '')
         // @ts-expect-error test input
         await expect(fetchJsonRpc(RPC_URL, statusRequest, undefined, retryConfig()))
             .rejects
@@ -59,12 +38,7 @@ describe('fetchJsonError', () => {
     });
 
     test('handles 503 Service Unavailable', async () => {
-        (unfetch as jest.Mock).mockReturnValue({
-            ok: false,
-            status: 503,
-            text: '',
-            json: {},
-        });
+        fetchMock.once(RPC_URL, 503, '')
 
         // @ts-expect-error test input
         await expect(fetchJsonRpc(RPC_URL, statusRequest, undefined, retryConfig()))

--- a/packages/providers/test/fetch_json_error.test.ts
+++ b/packages/providers/test/fetch_json_error.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, jest, afterEach } from '@jest/globals';
+import { describe, expect, test } from '@jest/globals';
 import { fetchJsonRpc, retryConfig } from '../src/fetch_json';
 import { ProviderError } from '../src/fetch_json'; 
 import fetchMock from '@fetch-mock/jest';
@@ -21,7 +21,7 @@ describe('fetchJsonError', () => {
             .toThrowError(new ProviderError('Internal server error', { cause: 500 }));
     });
     test('handles 408 Timeout Error', async () => {
-        fetchMock.once(RPC_URL, 408, '')
+        fetchMock.once(RPC_URL, 408, '');
         // @ts-expect-error test input
         await expect(fetchJsonRpc(RPC_URL, statusRequest, undefined, retryConfig()))
             .rejects
@@ -30,7 +30,7 @@ describe('fetchJsonError', () => {
     // });
 
     test('handles 400 Request Validation Error', async () => {
-        fetchMock.once(RPC_URL, 400, '')
+        fetchMock.once(RPC_URL, 400, '');
         // @ts-expect-error test input
         await expect(fetchJsonRpc(RPC_URL, statusRequest, undefined, retryConfig()))
             .rejects
@@ -38,7 +38,7 @@ describe('fetchJsonError', () => {
     });
 
     test('handles 503 Service Unavailable', async () => {
-        fetchMock.once(RPC_URL, 503, '')
+        fetchMock.once(RPC_URL, 503, '');
 
         // @ts-expect-error test input
         await expect(fetchJsonRpc(RPC_URL, statusRequest, undefined, retryConfig()))

--- a/packages/tsconfig/base.json
+++ b/packages/tsconfig/base.json
@@ -5,7 +5,7 @@
     "esModuleInterop": true,
     "module": "es2022",
     "target": "es2022",
-    "lib": ["es2022"],
+    "lib": ["es2022", "DOM"],
     "moduleResolution": "node",
     "alwaysStrict": true,
     "declaration": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -524,14 +524,7 @@ importers:
       exponential-backoff:
         specifier: ^3.1.1
         version: 3.1.1
-    optionalDependencies:
-      node-fetch:
-        specifier: 2.6.7
-        version: 2.6.7(encoding@0.1.13)
     devDependencies:
-      '@fetch-mock/jest':
-        specifier: ^0.2.7
-        version: 0.2.7(@jest/globals@29.7.0)(jest@29.7.0(@types/node@20.0.0)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@20.0.0)(typescript@5.4.5)))
       '@jest/globals':
         specifier: ^29.7.0
         version: 29.7.0
@@ -548,14 +541,18 @@ importers:
         specifier: 3.5.0
         version: 3.5.0(encoding@0.1.13)
       ts-jest:
-        specifier: 29.1.5
-        version: 29.1.5(@babel/core@7.24.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.7))(jest@29.7.0(@types/node@20.0.0)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@20.0.0)(typescript@5.4.5)))(typescript@5.4.5)
+        specifier: 29.2.5
+        version: 29.2.5(@babel/core@7.24.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.7))(jest@29.7.0(@types/node@20.0.0)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@20.0.0)(typescript@5.4.5)))(typescript@5.4.5)
       tsconfig:
         specifier: workspace:*
         version: link:../tsconfig
       typescript:
         specifier: 5.4.5
         version: 5.4.5
+    optionalDependencies:
+      node-fetch:
+        specifier: 2.6.7
+        version: 2.6.7(encoding@0.1.13)
 
   packages/signers:
     dependencies:
@@ -1251,13 +1248,6 @@ packages:
     resolution: {integrity: sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
-  '@fetch-mock/jest@0.2.7':
-    resolution: {integrity: sha512-2YyF8ecqclZQ2LWb9uU0bCbeC06kX3oxXQedaUmr4Og9PI2IKdjA/E+vmAxOzArVTtsx/iBMN5HorjxcIZNNGQ==}
-    engines: {node: '>=18.11.0'}
-    peerDependencies:
-      '@jest/globals': '*'
-      jest: '*'
-
   '@hexagon/base64@1.1.26':
     resolution: {integrity: sha512-9HYANYWJAwBbxjkz5P0ZB+JXX7kH7HhUG0FmIBcF7GUmnl6mXnAHFuGOkssW7v2RLNnVvjcKIeOqywSHfw21Qg==}
 
@@ -1500,9 +1490,6 @@ packages:
   '@types/conventional-commits-parser@5.0.0':
     resolution: {integrity: sha512-loB369iXNmAZglwWATL+WRe+CRMmmBPtpolYzIebFaX4YA3x+BEfLqhUAV9WanycKI3TG1IMr5bMJDajDKLlUQ==}
 
-  '@types/glob-to-regexp@0.4.4':
-    resolution: {integrity: sha512-nDKoaKJYbnn1MZxUY0cA1bPmmgZbg0cTq7Rh13d0KWYNOiKbqoR+2d89SnRPszGh7ROzSwZ/GOjZ4jPbmmZ6Eg==}
-
   '@types/graceful-fs@4.1.9':
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
 
@@ -1725,6 +1712,9 @@ packages:
   asn1js@3.0.5:
     resolution: {integrity: sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ==}
     engines: {node: '>=12.0.0'}
+
+  async@3.2.6:
+    resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
 
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
@@ -2105,10 +2095,6 @@ packages:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
 
-  dequal@2.0.3:
-    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
-    engines: {node: '>=6'}
-
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
     engines: {node: '>=8'}
@@ -2147,6 +2133,11 @@ packages:
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
+  ejs@3.1.10:
+    resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
+    engines: {node: '>=0.10.0'}
+    hasBin: true
 
   electron-to-chromium@1.4.807:
     resolution: {integrity: sha512-kSmJl2ZwhNf/bcIuCH/imtNOKlpkLDn2jqT5FJ+/0CXjhnFaOa9cOe9gHKKy71eM49izwuQjZhKk+lWQ1JxB7A==}
@@ -2327,10 +2318,6 @@ packages:
   fb-watchman@2.0.2:
     resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
 
-  fetch-mock@12.2.0:
-    resolution: {integrity: sha512-XjgxM582kB0SzPOqH2UdGTwSqga8A8aBPjxcYr0wTeOlCWpZoK6zBrPzltECUTu6Zt3VTWafmKF599LN9BRN5Q==}
-    engines: {node: '>=18.11.0'}
-
   fido2-lib@3.4.1:
     resolution: {integrity: sha512-efNrRbckp48AW7Q43o6gcp8/wnoBM7hwKikQntdiR2/NqVMPaCXFQs8kJ9wQqfv5V3PxZdg4kD9DpxdqYl6jxQ==}
     engines: {node: '>=10'}
@@ -2338,6 +2325,9 @@ packages:
   file-entry-cache@6.0.1:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
+
+  filelist@1.0.4:
+    resolution: {integrity: sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -2462,9 +2452,6 @@ packages:
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
-
-  glob-to-regexp@0.4.1:
-    resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
 
   glob@11.0.0:
     resolution: {integrity: sha512-9UiX/Bl6J2yaBbxKoEBRm4Cipxgok8kQYcOPEhScPwebu2I0HoQOuYdIO6S3hLuWoZgpDpwQZMzTFxgpkyT76g==}
@@ -2754,10 +2741,6 @@ packages:
     resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
     engines: {node: '>=4'}
 
-  is-subset-of@3.1.10:
-    resolution: {integrity: sha512-avvaYgVmYWyaZ1NDFiv4y9JGkrE2je3op1Po4VYKKJKR8H2qVPsg1GZuuXl5elCTxTlwAIsrAjWAs4BVrISFRw==}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
-
   is-symbol@1.0.4:
     resolution: {integrity: sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==}
     engines: {node: '>= 0.4'}
@@ -2814,6 +2797,11 @@ packages:
   jackspeak@4.0.1:
     resolution: {integrity: sha512-cub8rahkh0Q/bw1+GxP7aeSe29hHHn2V4m29nnDlvCdlgU+3UGxkZp7Z53jLUdpX3jdTO0nJZUDl3xvbWc2Xog==}
     engines: {node: 20 || >=22}
+
+  jake@10.9.2:
+    resolution: {integrity: sha512-2P4SQ0HrLQ+fw6llpLnOaGAvN2Zu6778SJMrCUwns4fOoG9ayrTiZk3VV8sCPkVZF8ab0zksVpS8FDY5pRCNBA==}
+    engines: {node: '>=10'}
+    hasBin: true
 
   jest-changed-files@29.7.0:
     resolution: {integrity: sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==}
@@ -3180,6 +3168,10 @@ packages:
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
+  minimatch@5.1.6:
+    resolution: {integrity: sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==}
+    engines: {node: '>=10'}
+
   minimatch@9.0.3:
     resolution: {integrity: sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -3537,10 +3529,6 @@ packages:
     resolution: {integrity: sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==}
     engines: {node: '>= 0.4'}
 
-  regexparam@3.0.0:
-    resolution: {integrity: sha512-RSYAtP31mvYLkAHrOlh25pCNQ5hWnT106VukGaaFfuJrZFkGRX5GhUAdPqpSDXxOhA2c4akmRuplv1mRqnBn6Q==}
-    engines: {node: '>=8'}
-
   regexpp@3.2.0:
     resolution: {integrity: sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==}
     engines: {node: '>=8'}
@@ -3642,6 +3630,11 @@ packages:
 
   semver@7.6.2:
     resolution: {integrity: sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  semver@7.7.1:
+    resolution: {integrity: sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -3917,6 +3910,30 @@ packages:
       esbuild:
         optional: true
 
+  ts-jest@29.2.5:
+    resolution: {integrity: sha512-KD8zB2aAZrcKIdGk4OwpJggeLcH1FgrICqDSROWqlnJXGCXK4Mn6FcdK2B6670Xr73lHMG1kHw8R87A0ecZ+vA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@babel/core': '>=7.0.0-beta.0 <8'
+      '@jest/transform': ^29.0.0
+      '@jest/types': ^29.0.0
+      babel-jest: ^29.0.0
+      esbuild: '*'
+      jest: ^29.0.0
+      typescript: '>=4.3 <6'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      '@jest/transform':
+        optional: true
+      '@jest/types':
+        optional: true
+      babel-jest:
+        optional: true
+      esbuild:
+        optional: true
+
   ts-node@10.9.2:
     resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
     hasBin: true
@@ -4061,10 +4078,6 @@ packages:
   typed-array-length@1.0.6:
     resolution: {integrity: sha512-/OxDN6OtAk5KBpGb28T+HZc2M+ADtvRxXrKKbUwtsLgdoxgX13hyy7ek6bFRl5+aBs2yZzB0c4CnQfAtVypW/g==}
     engines: {node: '>= 0.4'}
-
-  typedescriptor@3.0.2:
-    resolution: {integrity: sha512-hyVbaCUd18UiXk656g/imaBLMogpdijIEpnhWYrSda9rhvO4gOU16n2nh7xG5lv/rjumnZzGOdz0CEGTmFe0fQ==}
-    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   typedoc@0.25.13:
     resolution: {integrity: sha512-pQqiwiJ+Z4pigfOnnysObszLiU3mVLWAExSPf+Mu06G/qsc3wzbuM56SZQvONhHLncLUhYzOVkjFFpFfL5AzhQ==}
@@ -4854,12 +4867,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@fetch-mock/jest@0.2.7(@jest/globals@29.7.0)(jest@29.7.0(@types/node@20.0.0)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@20.0.0)(typescript@5.4.5)))':
-    dependencies:
-      '@jest/globals': 29.7.0
-      fetch-mock: 12.2.0
-      jest: 29.7.0(@types/node@20.0.0)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@20.0.0)(typescript@5.4.5))
-
   '@hexagon/base64@1.1.26': {}
 
   '@humanwhocodes/config-array@0.9.5':
@@ -5359,8 +5366,6 @@ snapshots:
     dependencies:
       '@types/node': 20.0.0
 
-  '@types/glob-to-regexp@0.4.4': {}
-
   '@types/graceful-fs@4.1.9':
     dependencies:
       '@types/node': 20.0.0
@@ -5607,6 +5612,8 @@ snapshots:
       pvtsutils: 1.3.5
       pvutils: 1.1.3
       tslib: 2.6.3
+
+  async@3.2.6: {}
 
   available-typed-arrays@1.0.7:
     dependencies:
@@ -6062,8 +6069,6 @@ snapshots:
 
   depd@2.0.0: {}
 
-  dequal@2.0.3: {}
-
   detect-indent@6.1.0: {}
 
   detect-libc@2.0.3:
@@ -6090,6 +6095,10 @@ snapshots:
   dotenv@8.6.0: {}
 
   eastasianwidth@0.2.0: {}
+
+  ejs@3.1.10:
+    dependencies:
+      jake: 10.9.2
 
   electron-to-chromium@1.4.807: {}
 
@@ -6381,14 +6390,6 @@ snapshots:
     dependencies:
       bser: 2.1.1
 
-  fetch-mock@12.2.0:
-    dependencies:
-      '@types/glob-to-regexp': 0.4.4
-      dequal: 2.0.3
-      glob-to-regexp: 0.4.1
-      is-subset-of: 3.1.10
-      regexparam: 3.0.0
-
   fido2-lib@3.4.1:
     dependencies:
       '@hexagon/base64': 1.1.26
@@ -6402,6 +6403,10 @@ snapshots:
   file-entry-cache@6.0.1:
     dependencies:
       flat-cache: 3.2.0
+
+  filelist@1.0.4:
+    dependencies:
+      minimatch: 5.1.6
 
   fill-range@7.1.1:
     dependencies:
@@ -6538,8 +6543,6 @@ snapshots:
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
-
-  glob-to-regexp@0.4.1: {}
 
   glob@11.0.0:
     dependencies:
@@ -6814,10 +6817,6 @@ snapshots:
     dependencies:
       better-path-resolve: 1.0.0
 
-  is-subset-of@3.1.10:
-    dependencies:
-      typedescriptor: 3.0.2
-
   is-symbol@1.0.4:
     dependencies:
       has-symbols: 1.0.3
@@ -6891,6 +6890,13 @@ snapshots:
       '@isaacs/cliui': 8.0.2
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
+
+  jake@10.9.2:
+    dependencies:
+      async: 3.2.6
+      chalk: 4.1.1
+      filelist: 1.0.4
+      minimatch: 3.1.2
 
   jest-changed-files@29.7.0:
     dependencies:
@@ -7588,6 +7594,10 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.11
 
+  minimatch@5.1.6:
+    dependencies:
+      brace-expansion: 2.0.1
+
   minimatch@9.0.3:
     dependencies:
       brace-expansion: 2.0.1
@@ -7706,7 +7716,7 @@ snapshots:
     dependencies:
       growly: 1.3.0
       is-wsl: 2.2.0
-      semver: 7.6.2
+      semver: 7.7.1
       shellwords: 0.1.1
       uuid: 8.3.2
       which: 2.0.2
@@ -7954,8 +7964,6 @@ snapshots:
       es-errors: 1.3.0
       set-function-name: 2.0.2
 
-  regexparam@3.0.0: {}
-
   regexpp@3.2.0: {}
 
   require-directory@2.1.1: {}
@@ -8039,6 +8047,8 @@ snapshots:
   semver@7.1.1: {}
 
   semver@7.6.2: {}
+
+  semver@7.7.1: {}
 
   set-blocking@2.0.0: {}
 
@@ -8333,6 +8343,25 @@ snapshots:
       '@jest/types': 29.6.3
       babel-jest: 29.7.0(@babel/core@7.24.7)
 
+  ts-jest@29.2.5(@babel/core@7.24.7)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.24.7))(jest@29.7.0(@types/node@20.0.0)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@20.0.0)(typescript@5.4.5)))(typescript@5.4.5):
+    dependencies:
+      bs-logger: 0.2.6
+      ejs: 3.1.10
+      fast-json-stable-stringify: 2.1.0
+      jest: 29.7.0(@types/node@20.0.0)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@20.0.0)(typescript@5.4.5))
+      jest-util: 29.7.0
+      json5: 2.2.3
+      lodash.memoize: 4.1.2
+      make-error: 1.3.6
+      semver: 7.7.1
+      typescript: 5.4.5
+      yargs-parser: 21.1.1
+    optionalDependencies:
+      '@babel/core': 7.24.7
+      '@jest/transform': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.24.7)
+
   ts-node@10.9.2(@types/node@18.11.18)(typescript@5.4.5):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -8514,8 +8543,6 @@ snapshots:
       has-proto: 1.0.3
       is-typed-array: 1.1.13
       possible-typed-array-names: 1.0.0
-
-  typedescriptor@3.0.2: {}
 
   typedoc@0.25.13(typescript@5.4.5):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,9 +87,6 @@ importers:
       is-my-json-valid:
         specifier: ^2.20.6
         version: 2.20.6
-      isomorphic-unfetch:
-        specifier: ^3.1.0
-        version: 3.1.0(encoding@0.1.13)
       lru_map:
         specifier: 0.4.1
         version: 0.4.1
@@ -124,9 +121,6 @@ importers:
       near-workspaces:
         specifier: 3.5.0
         version: 3.5.0(encoding@0.1.13)
-      node-fetch:
-        specifier: 2.6.7
-        version: 2.6.7(encoding@0.1.13)
       semver:
         specifier: 7.1.1
         version: 7.1.1
@@ -217,9 +211,6 @@ importers:
       '@noble/hashes':
         specifier: 1.3.3
         version: 1.3.3
-      isomorphic-fetch:
-        specifier: 3.0.0
-        version: 3.0.0(encoding@0.1.13)
     devDependencies:
       '@types/node':
         specifier: 20.0.0
@@ -533,14 +524,14 @@ importers:
       exponential-backoff:
         specifier: ^3.1.1
         version: 3.1.1
-      isomorphic-unfetch:
-        specifier: ^3.1.0
-        version: 3.1.0(encoding@0.1.13)
     optionalDependencies:
       node-fetch:
         specifier: 2.6.7
         version: 2.6.7(encoding@0.1.13)
     devDependencies:
+      '@fetch-mock/jest':
+        specifier: ^0.2.7
+        version: 0.2.7(@jest/globals@29.7.0)(jest@29.7.0(@types/node@20.0.0)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@20.0.0)(typescript@5.4.5)))
       '@jest/globals':
         specifier: ^29.7.0
         version: 29.7.0
@@ -1260,6 +1251,13 @@ packages:
     resolution: {integrity: sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  '@fetch-mock/jest@0.2.7':
+    resolution: {integrity: sha512-2YyF8ecqclZQ2LWb9uU0bCbeC06kX3oxXQedaUmr4Og9PI2IKdjA/E+vmAxOzArVTtsx/iBMN5HorjxcIZNNGQ==}
+    engines: {node: '>=18.11.0'}
+    peerDependencies:
+      '@jest/globals': '*'
+      jest: '*'
+
   '@hexagon/base64@1.1.26':
     resolution: {integrity: sha512-9HYANYWJAwBbxjkz5P0ZB+JXX7kH7HhUG0FmIBcF7GUmnl6mXnAHFuGOkssW7v2RLNnVvjcKIeOqywSHfw21Qg==}
 
@@ -1501,6 +1499,9 @@ packages:
 
   '@types/conventional-commits-parser@5.0.0':
     resolution: {integrity: sha512-loB369iXNmAZglwWATL+WRe+CRMmmBPtpolYzIebFaX4YA3x+BEfLqhUAV9WanycKI3TG1IMr5bMJDajDKLlUQ==}
+
+  '@types/glob-to-regexp@0.4.4':
+    resolution: {integrity: sha512-nDKoaKJYbnn1MZxUY0cA1bPmmgZbg0cTq7Rh13d0KWYNOiKbqoR+2d89SnRPszGh7ROzSwZ/GOjZ4jPbmmZ6Eg==}
 
   '@types/graceful-fs@4.1.9':
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
@@ -2104,6 +2105,10 @@ packages:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
     engines: {node: '>=8'}
@@ -2322,6 +2327,10 @@ packages:
   fb-watchman@2.0.2:
     resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
 
+  fetch-mock@12.2.0:
+    resolution: {integrity: sha512-XjgxM582kB0SzPOqH2UdGTwSqga8A8aBPjxcYr0wTeOlCWpZoK6zBrPzltECUTu6Zt3VTWafmKF599LN9BRN5Q==}
+    engines: {node: '>=18.11.0'}
+
   fido2-lib@3.4.1:
     resolution: {integrity: sha512-efNrRbckp48AW7Q43o6gcp8/wnoBM7hwKikQntdiR2/NqVMPaCXFQs8kJ9wQqfv5V3PxZdg4kD9DpxdqYl6jxQ==}
     engines: {node: '>=10'}
@@ -2453,6 +2462,9 @@ packages:
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
+
+  glob-to-regexp@0.4.1:
+    resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
 
   glob@11.0.0:
     resolution: {integrity: sha512-9UiX/Bl6J2yaBbxKoEBRm4Cipxgok8kQYcOPEhScPwebu2I0HoQOuYdIO6S3hLuWoZgpDpwQZMzTFxgpkyT76g==}
@@ -2742,6 +2754,10 @@ packages:
     resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
     engines: {node: '>=4'}
 
+  is-subset-of@3.1.10:
+    resolution: {integrity: sha512-avvaYgVmYWyaZ1NDFiv4y9JGkrE2je3op1Po4VYKKJKR8H2qVPsg1GZuuXl5elCTxTlwAIsrAjWAs4BVrISFRw==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+
   is-symbol@1.0.4:
     resolution: {integrity: sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==}
     engines: {node: '>= 0.4'}
@@ -2770,12 +2786,6 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
-
-  isomorphic-fetch@3.0.0:
-    resolution: {integrity: sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==}
-
-  isomorphic-unfetch@3.1.0:
-    resolution: {integrity: sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==}
 
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
@@ -3527,6 +3537,10 @@ packages:
     resolution: {integrity: sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==}
     engines: {node: '>= 0.4'}
 
+  regexparam@3.0.0:
+    resolution: {integrity: sha512-RSYAtP31mvYLkAHrOlh25pCNQ5hWnT106VukGaaFfuJrZFkGRX5GhUAdPqpSDXxOhA2c4akmRuplv1mRqnBn6Q==}
+    engines: {node: '>=8'}
+
   regexpp@3.2.0:
     resolution: {integrity: sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==}
     engines: {node: '>=8'}
@@ -4048,6 +4062,10 @@ packages:
     resolution: {integrity: sha512-/OxDN6OtAk5KBpGb28T+HZc2M+ADtvRxXrKKbUwtsLgdoxgX13hyy7ek6bFRl5+aBs2yZzB0c4CnQfAtVypW/g==}
     engines: {node: '>= 0.4'}
 
+  typedescriptor@3.0.2:
+    resolution: {integrity: sha512-hyVbaCUd18UiXk656g/imaBLMogpdijIEpnhWYrSda9rhvO4gOU16n2nh7xG5lv/rjumnZzGOdz0CEGTmFe0fQ==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+
   typedoc@0.25.13:
     resolution: {integrity: sha512-pQqiwiJ+Z4pigfOnnysObszLiU3mVLWAExSPf+Mu06G/qsc3wzbuM56SZQvONhHLncLUhYzOVkjFFpFfL5AzhQ==}
     engines: {node: '>= 16'}
@@ -4065,9 +4083,6 @@ packages:
 
   undici-types@6.19.8:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
-
-  unfetch@4.2.0:
-    resolution: {integrity: sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==}
 
   unicorn-magic@0.1.0:
     resolution: {integrity: sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==}
@@ -4124,9 +4139,6 @@ packages:
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
-
-  whatwg-fetch@3.6.20:
-    resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -4842,6 +4854,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@fetch-mock/jest@0.2.7(@jest/globals@29.7.0)(jest@29.7.0(@types/node@20.0.0)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@20.0.0)(typescript@5.4.5)))':
+    dependencies:
+      '@jest/globals': 29.7.0
+      fetch-mock: 12.2.0
+      jest: 29.7.0(@types/node@20.0.0)(node-notifier@8.0.2)(ts-node@10.9.2(@types/node@20.0.0)(typescript@5.4.5))
+
   '@hexagon/base64@1.1.26': {}
 
   '@humanwhocodes/config-array@0.9.5':
@@ -5340,6 +5358,8 @@ snapshots:
   '@types/conventional-commits-parser@5.0.0':
     dependencies:
       '@types/node': 20.0.0
+
+  '@types/glob-to-regexp@0.4.4': {}
 
   '@types/graceful-fs@4.1.9':
     dependencies:
@@ -6042,6 +6062,8 @@ snapshots:
 
   depd@2.0.0: {}
 
+  dequal@2.0.3: {}
+
   detect-indent@6.1.0: {}
 
   detect-libc@2.0.3:
@@ -6359,6 +6381,14 @@ snapshots:
     dependencies:
       bser: 2.1.1
 
+  fetch-mock@12.2.0:
+    dependencies:
+      '@types/glob-to-regexp': 0.4.4
+      dequal: 2.0.3
+      glob-to-regexp: 0.4.1
+      is-subset-of: 3.1.10
+      regexparam: 3.0.0
+
   fido2-lib@3.4.1:
     dependencies:
       '@hexagon/base64': 1.1.26
@@ -6508,6 +6538,8 @@ snapshots:
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
+
+  glob-to-regexp@0.4.1: {}
 
   glob@11.0.0:
     dependencies:
@@ -6782,6 +6814,10 @@ snapshots:
     dependencies:
       better-path-resolve: 1.0.0
 
+  is-subset-of@3.1.10:
+    dependencies:
+      typedescriptor: 3.0.2
+
   is-symbol@1.0.4:
     dependencies:
       has-symbols: 1.0.3
@@ -6808,20 +6844,6 @@ snapshots:
   isarray@2.0.5: {}
 
   isexe@2.0.0: {}
-
-  isomorphic-fetch@3.0.0(encoding@0.1.13):
-    dependencies:
-      node-fetch: 2.6.7(encoding@0.1.13)
-      whatwg-fetch: 3.6.20
-    transitivePeerDependencies:
-      - encoding
-
-  isomorphic-unfetch@3.1.0(encoding@0.1.13):
-    dependencies:
-      node-fetch: 2.6.7(encoding@0.1.13)
-      unfetch: 4.2.0
-    transitivePeerDependencies:
-      - encoding
 
   istanbul-lib-coverage@3.2.2: {}
 
@@ -7932,6 +7954,8 @@ snapshots:
       es-errors: 1.3.0
       set-function-name: 2.0.2
 
+  regexparam@3.0.0: {}
+
   regexpp@3.2.0: {}
 
   require-directory@2.1.1: {}
@@ -8491,6 +8515,8 @@ snapshots:
       is-typed-array: 1.1.13
       possible-typed-array-names: 1.0.0
 
+  typedescriptor@3.0.2: {}
+
   typedoc@0.25.13(typescript@5.4.5):
     dependencies:
       lunr: 2.3.9
@@ -8509,8 +8535,6 @@ snapshots:
       which-boxed-primitive: 1.0.2
 
   undici-types@6.19.8: {}
-
-  unfetch@4.2.0: {}
 
   unicorn-magic@0.1.0: {}
 
@@ -8567,8 +8591,6 @@ snapshots:
       tslib: 2.6.3
 
   webidl-conversions@3.0.1: {}
-
-  whatwg-fetch@3.6.20: {}
 
   whatwg-url@5.0.0:
     dependencies:


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to NEAR JavaScript API here: https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md).
- [x] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [x] **If this is a code change**: I have written unit tests.
- [x] **If this changes code in a published package**: I have run `pnpm changeset` to create a `changeset` JSON document appropriate for this change.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

since near-js least supported node version is v20, the polyfill could be safely dropped. React Native, and all edge runtimes all support fetch. There is no need to keep the polyfill anymore.

## Test Plan

unit tests

## Related issues/PRs

none
