### PR TITLE
feat(ci): update turbo, add caching

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-.github/workflows/ @morgsmccauley @andy-haynes
+.github/workflows/ @morgsmccauley @andy-haynes @r-near @frol

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -15,17 +15,26 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
+
+
+    - name: Cache turbo build setup
+      uses: actions/cache@v4
+      with: 
+        path: .turbo
+        key: ${{ runner.os }}-turbo-${{ github.sha }}
+        restore-keys: |
+          ${{ runner.os }}-turbo-
 
     - name: Setup pnpm
-      uses: pnpm/action-setup@v4.0.0
+      uses: pnpm/action-setup@v4
       with:
-        version: 9.4.0
+        version: 10.4.1
 
     - name: Setup Node
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v4
       with:
-        node-version: 20.15.0
+        node-version: 20.18.3
         cache: pnpm
 
     - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -1,40 +1,41 @@
 {
-  "name": "@near-js/monorepo",
-  "private": true,
-  "engines": {
-    "node": ">=20.15.0",
-    "pnpm": ">=9.4.0"
-  },
-  "scripts": {
-    "preinstall": "npx only-allow pnpm",
-    "build": "turbo run build",
-    "clean": "turbo run clean",
-    "lint": "turbo run lint",
-    "lint:fix": "turbo run lint:fix",
-    "autoclave": "rimraf packages/**/dist && rimraf packages/**/lib && rimraf packages/**/node_modules && rimraf packages/**/coverage && rimraf packages/**/.turbo && rm -rf node_modules",
-    "test": "turbo run test",
-    "release": "changeset publish",
-    "prepare": "husky install",
-    "docs:generate": "typedoc"
-  },
-  "devDependencies": {
-    "@changesets/changelog-github": "0.4.6",
-    "@changesets/cli": "2.24.4",
-    "@commitlint/cli": "19.3.0",
-    "@commitlint/config-conventional": "19.7.1",
-    "@typescript-eslint/eslint-plugin": "6.21.0",
-    "@typescript-eslint/parser": "6.21.0",
-    "commitlint": "19.3.0",
-    "eslint": "8.20.0",
-    "husky": "7.0.4",
-    "rimraf": "6.0.1",
-    "turbo": "1.4.5",
-    "typedoc": "0.27.7",
-    "tsconfig": "workspace:*",
-    "typescript": "5.4.5"
-  },
-  "resolutions": {
-    "near-sandbox": "0.0.18",
-    "near-api-js": "4.0.0"
-  }
+	"name": "@near-js/monorepo",
+	"private": true,
+	"engines": {
+		"node": ">=20.18.3",
+		"pnpm": ">=10.4.1"
+	},
+	"packageManager": "pnpm@10.4.1",
+	"scripts": {
+		"preinstall": "npx only-allow pnpm",
+		"build": "turbo run build",
+		"clean": "turbo run clean",
+		"lint": "turbo run lint",
+		"lint:fix": "turbo run lint:fix",
+		"autoclave": "rimraf packages/**/dist && rimraf packages/**/lib && rimraf packages/**/node_modules && rimraf packages/**/coverage && rimraf packages/**/.turbo && rm -rf node_modules",
+		"test": "turbo run test",
+		"release": "changeset publish",
+		"prepare": "husky install",
+		"docs:generate": "typedoc"
+	},
+	"devDependencies": {
+		"@changesets/changelog-github": "0.4.6",
+		"@changesets/cli": "2.24.4",
+		"@commitlint/cli": "19.3.0",
+		"@commitlint/config-conventional": "19.7.1",
+		"@typescript-eslint/eslint-plugin": "6.21.0",
+		"@typescript-eslint/parser": "6.21.0",
+		"commitlint": "19.3.0",
+		"eslint": "8.20.0",
+		"husky": "7.0.4",
+		"rimraf": "6.0.1",
+		"tsconfig": "workspace:*",
+		"turbo": "2.4.2",
+		"typedoc": "0.27.7",
+		"typescript": "5.4.5"
+	},
+	"resolutions": {
+		"near-sandbox": "0.0.18",
+		"near-api-js": "4.0.0"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -1,41 +1,41 @@
 {
-	"name": "@near-js/monorepo",
-	"private": true,
-	"engines": {
-		"node": ">=20.18.3",
-		"pnpm": ">=10.4.1"
-	},
-	"packageManager": "pnpm@10.4.1",
-	"scripts": {
-		"preinstall": "npx only-allow pnpm",
-		"build": "turbo run build",
-		"clean": "turbo run clean",
-		"lint": "turbo run lint",
-		"lint:fix": "turbo run lint:fix",
-		"autoclave": "rimraf packages/**/dist && rimraf packages/**/lib && rimraf packages/**/node_modules && rimraf packages/**/coverage && rimraf packages/**/.turbo && rm -rf node_modules",
-		"test": "turbo run test",
-		"release": "changeset publish",
-		"prepare": "husky install",
-		"docs:generate": "typedoc"
-	},
-	"devDependencies": {
-		"@changesets/changelog-github": "0.4.6",
-		"@changesets/cli": "2.24.4",
-		"@commitlint/cli": "19.3.0",
-		"@commitlint/config-conventional": "19.7.1",
-		"@typescript-eslint/eslint-plugin": "6.21.0",
-		"@typescript-eslint/parser": "6.21.0",
-		"commitlint": "19.3.0",
-		"eslint": "8.20.0",
-		"husky": "7.0.4",
-		"rimraf": "6.0.1",
-		"tsconfig": "workspace:*",
-		"turbo": "2.4.2",
-		"typedoc": "0.27.7",
-		"typescript": "5.4.5"
-	},
-	"resolutions": {
-		"near-sandbox": "0.0.18",
-		"near-api-js": "4.0.0"
-	}
+  "name": "@near-js/monorepo",
+  "private": true,
+  "engines": {
+    "node": ">=20.18.3",
+    "pnpm": ">=10.4.1"
+  },
+  "packageManager": "pnpm@10.4.1",
+  "scripts": {
+    "preinstall": "npx only-allow pnpm",
+    "build": "turbo run build",
+    "clean": "turbo run clean",
+    "lint": "turbo run lint",
+    "lint:fix": "turbo run lint:fix",
+    "autoclave": "rimraf packages/**/dist && rimraf packages/**/lib && rimraf packages/**/node_modules && rimraf packages/**/coverage && rimraf packages/**/.turbo && rm -rf node_modules",
+    "test": "turbo run test",
+    "release": "changeset publish",
+    "prepare": "husky install",
+    "docs:generate": "typedoc"
+  },
+  "devDependencies": {
+    "@changesets/changelog-github": "0.4.6",
+    "@changesets/cli": "2.24.4",
+    "@commitlint/cli": "19.3.0",
+    "@commitlint/config-conventional": "19.7.1",
+    "@typescript-eslint/eslint-plugin": "6.21.0",
+    "@typescript-eslint/parser": "6.21.0",
+    "commitlint": "19.3.0",
+    "eslint": "8.20.0",
+    "husky": "7.0.4",
+    "rimraf": "6.0.1",
+    "tsconfig": "workspace:*",
+    "turbo": "2.4.2",
+    "typedoc": "0.27.7",
+    "typescript": "5.4.5"
+  },
+  "resolutions": {
+    "near-sandbox": "0.0.18",
+    "near-api-js": "4.0.0"
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         specifier: workspace:*
         version: link:packages/tsconfig
       turbo:
-        specifier: 1.4.5
-        version: 1.4.5
+        specifier: 2.4.2
+        version: 2.4.2
       typedoc:
         specifier: 0.27.7
         version: 0.27.7(typescript@5.4.5)
@@ -524,10 +524,6 @@ importers:
       exponential-backoff:
         specifier: ^3.1.1
         version: 3.1.1
-    optionalDependencies:
-      node-fetch:
-        specifier: 2.6.7
-        version: 2.6.7(encoding@0.1.13)
     devDependencies:
       '@jest/globals':
         specifier: ^29.7.0
@@ -553,6 +549,10 @@ importers:
       typescript:
         specifier: 5.4.5
         version: 5.4.5
+    optionalDependencies:
+      node-fetch:
+        specifier: 2.6.7
+        version: 2.6.7(encoding@0.1.13)
 
   packages/signers:
     dependencies:
@@ -3971,78 +3971,38 @@ packages:
     engines: {node: '>=8.0.0'}
     hasBin: true
 
-  turbo-android-arm64@1.4.5:
-    resolution: {integrity: sha512-cKPJVyS1A2BBVbcH8XVeBArtEjHxioEm9zQa3Hv68usQOOFW+KOjH+0fGvjqMrWztLVFhE+npeVsnyu/6AmRew==}
-    cpu: [arm64]
-    os: [android]
-
-  turbo-darwin-64@1.4.5:
-    resolution: {integrity: sha512-cK6LjkziSfopTznpfx3EdW/C11xFlK01tYxNj0XPoBW4vNb1zLsfrI/HIwp0SzdNLqzCBwOJBK0VB07Q1MmlxQ==}
+  turbo-darwin-64@2.4.2:
+    resolution: {integrity: sha512-HFfemyWB60CJtEvVQj9yby5rkkWw9fLAdLtAPGtPQoU3tKh8t/uzCAZKso2aPVbib9vGUuGbPGoGpaRXdVhj5g==}
     cpu: [x64]
     os: [darwin]
 
-  turbo-darwin-arm64@1.4.5:
-    resolution: {integrity: sha512-hnixteVmfllup0//mGr2AZOff8oJ9dEydRU/EvbyIJ7PdkSct8758YnP5l2yMyxxipHHALSwchOKcySoaPBLRw==}
+  turbo-darwin-arm64@2.4.2:
+    resolution: {integrity: sha512-uwSx1dsBSSFeEC0nxyx2O219FEsS/haiESaWwE9JI8mHkQK61s6w6fN2G586krKxyNam4AIxRltleL+O2Em94g==}
     cpu: [arm64]
     os: [darwin]
 
-  turbo-freebsd-64@1.4.5:
-    resolution: {integrity: sha512-DDNSDiKJF/F1qbSNlvRs2UO79iMPlKFw/ZcVCDKXRjMI5uMRujMIfNnoStAg6kifYZJ0KIxnzdsbbJFtCTgPhQ==}
-    cpu: [x64]
-    os: [freebsd]
-
-  turbo-freebsd-arm64@1.4.5:
-    resolution: {integrity: sha512-pFU8ujUp7XU527NM04P4foDjOKfi8f0rNJqREU6AMxawiMI6y0oyHc3W4VNKm0Y9IsjcfguZKZRMPeQ0n7LgJA==}
-    cpu: [arm64]
-    os: [freebsd]
-
-  turbo-linux-32@1.4.5:
-    resolution: {integrity: sha512-Y5pnIetm4CwxbG1YQbvnTmjROPjQjX03ktHvmoekBleU1coYGShGPd9iarQZ96XkeaRevfwfSJ90AnDGwc3/QQ==}
-    cpu: [ia32]
-    os: [linux]
-
-  turbo-linux-64@1.4.5:
-    resolution: {integrity: sha512-tiTusM7mYib3iLmVOWmxhsg6xU3EArjOL4l3yh9rYBdArhDJk+DrhXkbJkYOYgNSWUEfPeBs0lzSkfTIQ2H21g==}
+  turbo-linux-64@2.4.2:
+    resolution: {integrity: sha512-Fy/uL8z/LAYcPbm7a1LwFnTY9pIi5FAi12iuHsgB7zHjdh4eeIKS2NIg4nroAmTcUTUZ0/cVTo4bDOCUcS3aKw==}
     cpu: [x64]
     os: [linux]
 
-  turbo-linux-arm64@1.4.5:
-    resolution: {integrity: sha512-R03HPqb0tJtqsGF4P3oPWsggdpTe9CZiBEtzATFpL7WVzm/Dsimy1Wcj07v6gCWdgi/mWmRt+OcZfGhnf7mibQ==}
+  turbo-linux-arm64@2.4.2:
+    resolution: {integrity: sha512-AEA0d8h5W/K6iiXfEgiNwWt0yqRL1NpBs8zQCLdc4/L7WeYeJW3sORWX8zt7xhutF/KW9gTm8ehKpiK6cCIsAA==}
     cpu: [arm64]
     os: [linux]
 
-  turbo-linux-arm@1.4.5:
-    resolution: {integrity: sha512-5BsTRsoZeUWXWau4t4CNdL6NjlDdXrh8suhj5YolXUVCe039A5IutS7Dgd4i8dV1BovFCU3bz38dqQI2Qst5eQ==}
-    cpu: [arm]
-    os: [linux]
-
-  turbo-linux-mips64le@1.4.5:
-    resolution: {integrity: sha512-08+WhWCx2Bp6wKH8im4Z2iEBCgiWJLZbNbZ8YHxamwlIk1JsklyCCMikMSWb0GmpKi7EIjdmtPRQY2CyoBefpg==}
-    cpu: [mipsel]
-    os: [linux]
-
-  turbo-linux-ppc64le@1.4.5:
-    resolution: {integrity: sha512-feGjTOYcCbg12Y6JzL8nxaUOzjqqYtO6vtxrJy16yVCd2k2htd18iZ1kLjWKDZA94vdyW5lfyAGsAQik2eAC4A==}
-    cpu: [ppc64]
-    os: [linux]
-
-  turbo-windows-32@1.4.5:
-    resolution: {integrity: sha512-O4tOnGmVJrR1JOKepuUvx/kqgaU6eMEjYUihJlvQmz9pTA/ecs8HrTGyXrabbmp5YdUmF2qsXaAcOvEuJaNPmQ==}
-    cpu: [ia32]
-    os: [win32]
-
-  turbo-windows-64@1.4.5:
-    resolution: {integrity: sha512-3W9gGq9h2szhestsoA1XqN9hV0wCRpGCEV6fbb3q9EaJY8K9Tff8By0mi+fE31OKHY4om+PHg595q7kybcyG/Q==}
+  turbo-windows-64@2.4.2:
+    resolution: {integrity: sha512-CybtIZ9wRgnnNFVN9En9G+rxsO+mwU81fvW4RpE8BWyNEkhQ8J28qYf4PaimueMxGHHp/28i/G7Kcdn2GAWG0g==}
     cpu: [x64]
     os: [win32]
 
-  turbo-windows-arm64@1.4.5:
-    resolution: {integrity: sha512-/77f6OJM/4MqYEoCMER5MZTbfJZuVN22R9mc7iJDFOrNJrwvAWiAx98Fvo7WEVpMjGFUEq4Wi0UV5SpMAGU3bA==}
+  turbo-windows-arm64@2.4.2:
+    resolution: {integrity: sha512-7V0yneVPL8Y3TgrkUIjw7Odmwu1tHnyIiPHFM7eFcA7U+H6hPXyCxge7nC3wOKfjhKCQqUm+Vf/k6kjmLz5G4g==}
     cpu: [arm64]
     os: [win32]
 
-  turbo@1.4.5:
-    resolution: {integrity: sha512-imAyc1kZusjzMWY4RO572FWws8x6CoM5mX7D3qtMjdGuqOBNBhPTIaJ0LmQLu+xzuKIOlJ5m/2587CsHOJTdgw==}
+  turbo@2.4.2:
+    resolution: {integrity: sha512-Qxi0ioQCxMRUCcHKHZkTnYH8e7XCpNfg9QiJcyfWIc+ZXeaCjzV5rCGlbQlTXMAtI8qgfP8fZADv3CFtPwqdPQ==}
     hasBin: true
 
   type-check@0.4.0:
@@ -8480,64 +8440,32 @@ snapshots:
       wcwidth: 1.0.1
       yargs: 17.7.2
 
-  turbo-android-arm64@1.4.5:
+  turbo-darwin-64@2.4.2:
     optional: true
 
-  turbo-darwin-64@1.4.5:
+  turbo-darwin-arm64@2.4.2:
     optional: true
 
-  turbo-darwin-arm64@1.4.5:
+  turbo-linux-64@2.4.2:
     optional: true
 
-  turbo-freebsd-64@1.4.5:
+  turbo-linux-arm64@2.4.2:
     optional: true
 
-  turbo-freebsd-arm64@1.4.5:
+  turbo-windows-64@2.4.2:
     optional: true
 
-  turbo-linux-32@1.4.5:
+  turbo-windows-arm64@2.4.2:
     optional: true
 
-  turbo-linux-64@1.4.5:
-    optional: true
-
-  turbo-linux-arm64@1.4.5:
-    optional: true
-
-  turbo-linux-arm@1.4.5:
-    optional: true
-
-  turbo-linux-mips64le@1.4.5:
-    optional: true
-
-  turbo-linux-ppc64le@1.4.5:
-    optional: true
-
-  turbo-windows-32@1.4.5:
-    optional: true
-
-  turbo-windows-64@1.4.5:
-    optional: true
-
-  turbo-windows-arm64@1.4.5:
-    optional: true
-
-  turbo@1.4.5:
+  turbo@2.4.2:
     optionalDependencies:
-      turbo-android-arm64: 1.4.5
-      turbo-darwin-64: 1.4.5
-      turbo-darwin-arm64: 1.4.5
-      turbo-freebsd-64: 1.4.5
-      turbo-freebsd-arm64: 1.4.5
-      turbo-linux-32: 1.4.5
-      turbo-linux-64: 1.4.5
-      turbo-linux-arm: 1.4.5
-      turbo-linux-arm64: 1.4.5
-      turbo-linux-mips64le: 1.4.5
-      turbo-linux-ppc64le: 1.4.5
-      turbo-windows-32: 1.4.5
-      turbo-windows-64: 1.4.5
-      turbo-windows-arm64: 1.4.5
+      turbo-darwin-64: 2.4.2
+      turbo-darwin-arm64: 2.4.2
+      turbo-linux-64: 2.4.2
+      turbo-linux-arm64: 2.4.2
+      turbo-windows-64: 2.4.2
+      turbo-windows-arm64: 2.4.2
 
   type-check@0.4.0:
     dependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -1,28 +1,28 @@
 {
-	"$schema": "https://turborepo.org/schema.json",
-	"tasks": {
-		"build": {
-			"dependsOn": ["^build"],
-			"outputs": ["dist/**", "lib/**"]
-		},
-		"test": {
-			"dependsOn": ["^transit"],
-			"outputs": []
-		},
-		"lint": {
-			"dependsOn": ["^transit"],
-			"outputs": []
-		},
-		"lint:fix": {
-			"dependsOn": ["^transit"],
-			"outputs": []
-		},
-		"transit": {
-			"dependsOn": ["^transit"]
-		},
-		"clean": {
-			"outputs": [],
-			"cache": false
-		}
-	}
+  "$schema": "https://turborepo.org/schema.json",
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**", "lib/**"]
+    },
+    "test": {
+      "dependsOn": ["^transit"],
+      "outputs": []
+    },
+    "lint": {
+      "dependsOn": ["^transit"],
+      "outputs": []
+    },
+    "lint:fix": {
+      "dependsOn": ["^transit"],
+      "outputs": []
+    },
+    "transit": {
+      "dependsOn": ["^transit"]
+    },
+    "clean": {
+      "outputs": [],
+      "cache": false
+    }
+  }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -1,26 +1,28 @@
 {
-  "$schema": "https://turborepo.org/schema.json",
-  "pipeline": {
-    "build": {
-      "dependsOn": ["^build"],
-      "inputs": ["src/**/*.ts", "test/**/*.js", "tsconfig.json"],
-      "outputs": ["dist/**", "lib/**"]
-    },
-    "test": {
-      "dependsOn": [],
-      "inputs": ["src/**/*.ts", "test/**/*.js"]
-    },
-    "lint": {
-      "inputs": ["src/**/*.ts", "test/**/*.ts"],
-      "outputs": []
-    },
-    "lint:fix": {
-      "inputs": ["src/**/*.ts", "test/**/*.ts"],
-      "outputs": []
-    },
-    "clean": {
-      "outputs": [],
-      "cache": false
-    }
-  }
+	"$schema": "https://turborepo.org/schema.json",
+	"tasks": {
+		"build": {
+			"dependsOn": ["^build"],
+			"outputs": ["dist/**", "lib/**"]
+		},
+		"test": {
+			"dependsOn": ["^transit"],
+			"outputs": []
+		},
+		"lint": {
+			"dependsOn": ["^transit"],
+			"outputs": []
+		},
+		"lint:fix": {
+			"dependsOn": ["^transit"],
+			"outputs": []
+		},
+		"transit": {
+			"dependsOn": ["^transit"]
+		},
+		"clean": {
+			"outputs": [],
+			"cache": false
+		}
+	}
 }


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to NEAR JavaScript API here: https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md).
- [x] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [ ] **If this is a code change**: I have written unit tests.
- [ ] **If this changes code in a published package**: I have run `pnpm changeset` to create a `changeset` JSON document appropriate for this change.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation
Improved turbo caching and task configuration

Updated our turbo.json configuration to be more robust and enable better caching:

- Added transit pattern so test/lint tasks properly track dependency changes
- Removed overly restrictive input globs that were skipping important files (package.json, lockfile)
- Added proper caching setup in CI with actions/cache@v4

Also upgraded our toolchain:
- turbo 1.4.5 -> 2.4.2 
- pnpm 9.4.0 -> 10.4.1
- node 20.15.0 -> 20.18.3
- Various GitHub Actions to their v4 versions

The main win here is proper caching - our previous input globs were too restrictive and could miss important dependency changes. As a bonus, the transit pattern makes it safer to run tasks in parallel if needed.