### PR TITLE
fix: "Cannot mix BigInt and other types" for signing transaction with explicitly provided nonce

### DIFF
--- a/.changeset/weak-adults-love.md
+++ b/.changeset/weak-adults-love.md
@@ -1,0 +1,5 @@
+---
+"@near-js/client": patch
+---
+
+Fixed "Cannot mix BigInt and other types" error when signing transactions with explicitly provided nonce

--- a/packages/client/src/signing/signers.ts
+++ b/packages/client/src/signing/signers.ts
@@ -66,7 +66,7 @@ export function getSignerFromKeystore(account: string, network: string, keyStore
  */
 export function getAccessKeySigner({ account, blockReference, deps: { rpcProvider, signer } }: ViewAccountParams & SignerDependency): AccessKeySigner {
   let accessKey: FullAccessKey | FunctionCallAccessKey;
-  let nonce: bigint;
+  let nonce: bigint | undefined;
 
   return {
     async getAccessKey(ignoreCache = false) {
@@ -97,7 +97,11 @@ export function getAccessKeySigner({ account, blockReference, deps: { rpcProvide
       return account;
     },
     signMessage(m: Uint8Array) {
-      nonce += 1n;
+      // Nonce can be uninitialized here if it is provided explicitly by developer (see toSignedDelegateAction),
+      // we don't need to track it here in that case.
+      if (nonce) {
+        nonce += 1n;
+      }
       return signer.signMessage(m);
     }
   };


### PR DESCRIPTION


<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to NEAR JavaScript API here: https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md).
- [x] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [ ] **If this is a code change**: I have written unit tests.
- [x] **If this changes code in a published package**: I have run `pnpm changeset` to create a `changeset` JSON document appropriate for this change.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
