### PR TITLE
fix: Wrong payload being signed

### DIFF
--- a/.changeset/poor-items-study.md
+++ b/.changeset/poor-items-study.md
@@ -1,0 +1,8 @@
+---
+"@near-js/client": patch
+"@near-js/transactions": patch
+---
+
+client: The signer implementation was incorrectly handling transactions by not hashing the encoded transaction before signing
+
+transactions: Non trivial arguments given to the test so people could use them as an example.

--- a/packages/client/src/signing/signers.ts
+++ b/packages/client/src/signing/signers.ts
@@ -14,6 +14,7 @@ import type {
   ViewAccountParams,
 } from '../interfaces';
 import { getAccessKey } from '../view';
+import { sha256 } from '@noble/hashes/sha256';
 
 /**
  * Initialize a message signer from a KeyPair
@@ -25,7 +26,8 @@ export function getSignerFromKeyPair(keyPair: KeyPair): MessageSigner {
       return keyPair.getPublicKey();
     },
     async signMessage(m) {
-      return keyPair.sign(m).signature;
+      const hashedMessage  = new Uint8Array(sha256(m));
+      return keyPair.sign(hashedMessage).signature;
     }
   };
 }

--- a/packages/transactions/test/transaction.test.ts
+++ b/packages/transactions/test/transaction.test.ts
@@ -4,7 +4,7 @@ import { actionCreators } from '../src';
 const { functionCall } = actionCreators;
 
 test('functionCall with already serialized args', () => {
-    const serializedArgs = Buffer.from('{}');
+    const serializedArgs = Buffer.from('{key: value}');
     const action = functionCall('methodName', serializedArgs, 1n, 2n);    
     expect(action).toMatchObject({ 
         functionCall: {
@@ -17,8 +17,8 @@ test('functionCall with already serialized args', () => {
 });
 
 test('functionCall with non-serialized args', () => {
-    const serializedArgs = Buffer.from('{}');
-    const action = functionCall('methodName', {}, 1n, 2n);    
+    const serializedArgs = Buffer.from(JSON.stringify({ key: 'value' }));
+    const action = functionCall('methodName', { key: 'value' }, 1n, 2n);
     expect(action).toMatchObject({ 
         functionCall: {
             methodName: 'methodName',


### PR DESCRIPTION
This PR fixes issues in getSignerFromKeyPair and getSignerFromPrivateKey, where the signer was incorrectly passing a non-hashed encoded transaction to sign().
It also adds non-trivial arguments to the test cases, providing clearer examples for others to reference. (https://github.com/near/near-api-js/issues/1432) 