### PR TITLE
fix: fix bug with `Account.getBalance` of FungibleToken always throwing an error

### DIFF
--- a/.changeset/easy-areas-hug.md
+++ b/.changeset/easy-areas-hug.md
@@ -1,0 +1,5 @@
+---
+"@near-js/tokens": patch
+---
+
+Fix the bug with `ft_balance_of` always returning `undefined` for FungibleToken

--- a/packages/tokens/src/ft/index.ts
+++ b/packages/tokens/src/ft/index.ts
@@ -97,7 +97,7 @@ export class FungibleToken extends BaseFT {
     }
 
     public async getBalance(account: AccountLike): Promise<bigint> {
-        const { result: balance } = await account.provider.callFunction(
+        const balance = await account.provider.callFunction(
             this.accountId,
             'ft_balance_of',
             {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to NEAR JavaScript API here: https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [ ] I have read the [Contributing Guidelines on pull requests](https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md).
- [ ] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [ ] **If this is a code change**: I have written unit tests.
- [ ] **If this changes code in a published package**: I have run `pnpm changeset` to create a `changeset` JSON document appropriate for this change.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
