### PR TITLE
Fix changesets config

### DIFF
--- a/.changeset/all-lions-happen.md
+++ b/.changeset/all-lions-happen.md
@@ -1,5 +1,6 @@
 ---
 "@near-js/accounts": minor
+"near-api-js": minor
 ---
 
 Rename `createTopLevelAccount` back to `createAccount` for the sake of better naming

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,6 @@
   "access": "public",
   "baseBranch": "master",
   "updateInternalDependencies": "patch",
+  "bumpVersionsWithWorkspaceProtocolOnly": true,
   "ignore": []
 }

--- a/.changeset/easy-areas-hug.md
+++ b/.changeset/easy-areas-hug.md
@@ -1,5 +1,6 @@
 ---
 "@near-js/tokens": patch
+"near-api-js": patch
 ---
 
 Fix the bug with `ft_balance_of` always returning `undefined` for FungibleToken

--- a/.changeset/real-llamas-smile.md
+++ b/.changeset/real-llamas-smile.md
@@ -12,7 +12,6 @@
 "@near-js/signers": patch
 "@near-js/tokens": patch
 "@near-js/transactions": patch
-"tsconfig": patch
 "@near-js/types": patch
 ---
 


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to NEAR JavaScript API here: https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [ ] I have read the [Contributing Guidelines on pull requests](https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md).
- [ ] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [ ] **If this is a code change**: I have written unit tests.
- [ ] **If this changes code in a published package**: I have run `pnpm changeset` to create a `changeset` JSON document appropriate for this change.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

This change is meant to fix the issue with `changeset` unnecessarily upgrading all the packages to `major` version, even though they are `minor` changes

This must return the behaviour to expected, which is
- `@near-js/*` goes from `2.0.1` to `2.1.0`
- `near-api-js` goes from `6.0.1` to `6.1.0`

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
