### PR TITLE
fix: separate runtime and type exports for esbuild compatibility

### DIFF
--- a/packages/accounts/src/index.ts
+++ b/packages/accounts/src/index.ts
@@ -1,5 +1,7 @@
 export {
-    Account,
+    Account
+} from './account';
+export type {
     AccountBalance,
     AccountAuthorizedApp,
     SignAndSendTransactionOptions
@@ -19,9 +21,9 @@ export {
     MULTISIG_CONFIRM_METHODS,
 } from './constants';
 export {
-    Contract,
-    ContractMethods,
+    Contract
 } from './contract';
+export type { ContractMethods } from './contract';
 export {
     ArgumentSchemaError,
     ConflictingOptions,
@@ -32,7 +34,7 @@ export {
     MultisigDeleteRequestRejectionError,
     MultisigStateStatus,
 } from './types';
-export {    
+export type {    
     FunctionCallOptions,
     ChangeFunctionCallOptions,
     ViewFunctionCallOptions,

--- a/packages/crypto/src/index.ts
+++ b/packages/crypto/src/index.ts
@@ -1,6 +1,7 @@
-export { CurveType, KeyPairString, KeyType } from './constants';
+export { KeyType } from './constants';
+export type { CurveType, KeyPairString } from './constants';
 export { KeyPair } from './key_pair';
-export { Signature } from './key_pair_base';
+export type { Signature } from './key_pair_base';
 export { KeyPairEd25519 } from './key_pair_ed25519';
 export { KeyPairSecp256k1 } from './key_pair_secp256k1';
 export { PublicKey } from './public_key';

--- a/packages/providers/src/index.ts
+++ b/packages/providers/src/index.ts
@@ -1,4 +1,4 @@
 export { exponentialBackoff } from './exponential-backoff';
 export { JsonRpcProvider } from './json-rpc-provider';
 export { FailoverRpcProvider } from './failover-rpc-provider';
-export { Provider } from './provider';
+export type { Provider } from './provider';

--- a/packages/signers/src/index.ts
+++ b/packages/signers/src/index.ts
@@ -1,2 +1,3 @@
 export { KeyPairSigner } from './key_pair_signer';
-export { Signer, SignedMessage } from './signer';
+export { Signer } from './signer';
+export type { SignedMessage } from './signer';

--- a/packages/tsconfig/base.json
+++ b/packages/tsconfig/base.json
@@ -3,12 +3,17 @@
 	"display": "Default",
 	"compilerOptions": {
 		"paths": {
-			"@near-js/*": ["../packages/*"]
+			"@near-js/*": [
+				"../packages/*"
+			]
 		},
 		"esModuleInterop": true,
 		"module": "es2022",
 		"target": "es2022",
-		"lib": ["es2022", "DOM"],
+		"lib": [
+			"es2022",
+			"DOM"
+		],
 		"moduleResolution": "node",
 		"alwaysStrict": true,
 		"declaration": true,
@@ -22,7 +27,10 @@
 		"noImplicitReturns": true,
 		"noUnusedLocals": true,
 		"experimentalDecorators": true,
-		"resolveJsonModule": true
+		"resolveJsonModule": true,
+		"isolatedModules": true,
 	},
-	"exclude": ["node_modules"]
+	"exclude": [
+		"node_modules"
+	]
 }

--- a/packages/types/src/provider/index.ts
+++ b/packages/types/src/provider/index.ts
@@ -1,13 +1,15 @@
 
 export {
-    IdType,
+    IdType
+} from './light_client';
+export type {
     LightClientBlockLiteView,
     LightClientProof,
     LightClientProofRequest,
     NextLightClientBlockRequest,
-    NextLightClientBlockResponse,
+    NextLightClientBlockResponse
 } from './light_client';
-export {
+export type {
     AccessKeyWithPublicKey,
     BlockHash,
     BlockChange,
@@ -39,7 +41,7 @@ export {
     Transaction as ProviderTransaction,
     TxExecutionStatus,
 } from './protocol';
-export {
+export type {
     CallFunctionRequest,
     RpcQueryRequest,
     ViewAccessKeyListRequest,
@@ -49,6 +51,9 @@ export {
     ViewStateRequest,
 } from './request';
 export {
+    ExecutionStatusBasic, FinalExecutionStatusBasic
+} from './response';
+export type {
     AccessKeyInfoView,
     AccessKeyList,
     AccessKeyView,
@@ -63,20 +68,16 @@ export {
     ExecutionOutcome,
     ExecutionOutcomeWithId,
     ExecutionOutcomeWithIdView,
-    ExecutionStatus,
-    ExecutionStatusBasic,
-    FinalExecutionOutcome,
-    FinalExecutionStatus,
-    FinalExecutionStatusBasic,
-    FunctionCallPermissionView,
+    ExecutionStatus, FinalExecutionOutcome,
+    FinalExecutionStatus, FunctionCallPermissionView,
     QueryResponseKind,
     SerializedReturnValue,
     ViewStateResult,
     ExecutionOutcomeReceiptDetail,
     ContractStateView,
-    CallContractViewFunctionResultRaw,
+    CallContractViewFunctionResultRaw
 } from './response';
-export {
+export type {
     CurrentEpochValidatorInfo,
     EpochValidatorInfo,
     NextEpochValidatorInfo,


### PR DESCRIPTION
## Problem

The current codebase uses mixed export statements that re-export both runtime values (classes, enums) and TypeScript types (interfaces, type aliases) using the same `export { ... }` syntax. This causes compilation errors when using esbuild/tsup because:

1. esbuild treats each file independently and doesn't perform cross-file type analysis
2. Interface exports get stripped at runtime, causing "no matching export" errors
3. esbuild expects explicit separation between runtime and type-only exports

**Error example:**
```
SyntaxError: The requested module './response.js' does not provide an export named 'AccessKeyInfoView'
```

## Solution

This PR separates runtime exports from type-only exports across all packages:

- **Runtime exports** (`export { ... }`): Classes, enums, functions, and other values that exist at runtime
- **Type exports** (`export type { ... }`): Interfaces, type aliases, and other compile-time-only constructs

### Key Changes

1. **`packages/types/src/provider/index.ts`**: Major refactor to properly separate:
   - Runtime: `IdType`, `ExecutionStatusBasic`, `FinalExecutionStatusBasic` (enums)
   - Types: All interfaces and type aliases

2. **Other packages**: Similar separation applied to:
   - `@near-js/accounts`: `Account`/`Contract` (runtime) vs interfaces (types)
   - `@near-js/crypto`: `KeyType` (runtime enum) vs type definitions
   - `@near-js/providers`: `Provider` interface moved to type export
   - `@near-js/signers`: `Signer` class vs `SignedMessage` interface

3. **`packages/tsconfig/base.json`**: Added `isolatedModules: true` to enforce this pattern and prevent future regressions

## Testing

- [x] Builds successfully with tsup/esbuild
- [x] Type checking passes with `tsc --noEmit`
- [x] No breaking changes to public API (same exports, just properly categorized)

## Benefits

- ✅ Fixes esbuild compilation errors
- ✅ Improves build tool compatibility (Vite, SWC, Babel)
- ✅ Makes export intentions explicit
- ✅ Prevents future similar issues via TypeScript config

## Breaking Changes

None - this is purely a build-time fix that doesn't affect the runtime API.
