### PR TITLE
Fix instanceof check for SignedTransaction to prevent cross-package errors

### DIFF
--- a/.changeset/fix-instanceof-signetransaction.md
+++ b/.changeset/fix-instanceof-signetransaction.md
@@ -3,5 +3,3 @@
 ---
 
 Fix instanceof check for SignedTransaction to prevent cross-package version errors
-
-Replace instanceof check with duck typing to avoid failures when different package versions are used across dependencies. The change from `transaction instanceof SignedTransaction` to `'signature' in transaction` maintains the same functionality while being more robust against version mismatches.

--- a/.changeset/fix-instanceof-signetransaction.md
+++ b/.changeset/fix-instanceof-signetransaction.md
@@ -1,0 +1,7 @@
+---
+"@near-js/transactions": patch
+---
+
+Fix instanceof check for SignedTransaction to prevent cross-package version errors
+
+Replace instanceof check with duck typing to avoid failures when different package versions are used across dependencies. The change from `transaction instanceof SignedTransaction` to `'signature' in transaction` maintains the same functionality while being more robust against version mismatches.

--- a/packages/transactions/src/schema.ts
+++ b/packages/transactions/src/schema.ts
@@ -36,7 +36,7 @@ export function encodeSignedDelegate(signedDelegate: SignedDelegate) {
  * @returns A serialized representation of the input transaction.
  */
 export function encodeTransaction(transaction: Transaction | SignedTransaction) {
-    const schema: Schema = transaction instanceof SignedTransaction ? SCHEMA.SignedTransaction : SCHEMA.Transaction;
+    const schema: Schema = 'signature' in transaction ? SCHEMA.SignedTransaction : SCHEMA.Transaction;
     return serialize(schema, transaction);
 }
 


### PR DESCRIPTION
## Summary
- Replaced `instanceof SignedTransaction` check with duck typing using `'signature' in transaction`
- Prevents failures when different package versions are used across dependencies
- Maintains same functionality while being more robust

## Test plan
- [x] All existing tests pass
- [x] Linting passes
- [x] Verified the fix addresses the root cause of cross-package instanceof failures

Fixes #1569