### PR TITLE
Add optional waitUntil parameter to callFunction method

### DIFF
--- a/.changeset/add-waituntil-to-callfunction.md
+++ b/.changeset/add-waituntil-to-callfunction.md
@@ -1,0 +1,5 @@
+---
+"@near-js/accounts": minor
+---
+
+Add optional waitUntil parameter to callFunction method

--- a/packages/accounts/src/account.ts
+++ b/packages/accounts/src/account.ts
@@ -607,6 +607,7 @@ export class Account {
      * @param options.args Arguments, either as a valid JSON Object or a raw Uint8Array
      * @param options.deposit (optional) Amount of NEAR Tokens to attach to the call (default 0)
      * @param options.gas (optional) Amount of GAS to use attach to the call (default 30TGas)
+     * @param options.waitUntil (optional) Transaction finality to wait for (default INCLUDED_FINAL)
      * @returns
      */
     public async callFunction({
@@ -615,18 +616,21 @@ export class Account {
         args = {},
         deposit = "0",
         gas = DEFAULT_FUNCTION_CALL_GAS,
+        waitUntil = DEFAULT_WAIT_STATUS,
     }: {
         contractId: string;
         methodName: string;
         args: Uint8Array | Record<string, any>;
         deposit?: bigint | string | number;
         gas?: bigint | string | number;
+        waitUntil?: TxExecutionStatus;
     }): Promise<object | string | number> {
         const result = await this.signAndSendTransaction({
             receiverId: contractId,
             actions: [
                 functionCall(methodName, args, BigInt(gas), BigInt(deposit)),
             ],
+            waitUntil,
         });
 
         return getTransactionLastResult(result);


### PR DESCRIPTION
## Summary
- Add optional `waitUntil` parameter to `callFunction()` method in `@near-js/accounts`
- Allow users to configure transaction finality when calling smart contract functions
- Fully backward compatible - parameter is optional and defaults to `INCLUDED_FINAL`

## Changes
- Updated `callFunction()` method signature to include `waitUntil?: TxExecutionStatus`
- Pass `waitUntil` parameter through to `signAndSendTransaction()`
- Added JSDoc documentation for the new parameter

## Test plan
- [x] All existing tests pass
- [x] Linting passes  
- [x] Backward compatibility maintained (existing code works unchanged)
- [x] New parameter works as expected when provided

## Usage
```typescript
// Before (still works)
await account.callFunction({
  contractId: 'contract.near',
  methodName: 'my_method',
  args: {}
});

// After (new capability)
await account.callFunction({
  contractId: 'contract.near', 
  methodName: 'my_method',
  args: {},
  waitUntil: 'INCLUDED' // Configure transaction finality
});
```

Fixes #1575