### PR TITLE
fix(tokens): improve export configuration and remove invalid dependency

### DIFF
--- a/.changeset/fix-tokens-exports.md
+++ b/.changeset/fix-tokens-exports.md
@@ -1,0 +1,10 @@
+---
+"@near-js/tokens": patch
+---
+
+Fix export configuration and remove invalid build dependency
+
+- Remove invalid "build": "workspace:*" dependency that caused npm install errors
+- Add exports for ft/ and nft/ subdirectories to support direct imports like `@near-js/tokens/ft`
+- Add ft/format export for granular access to formatting utilities
+- Improve Node16+ and bundler compatibility for all nested exports

--- a/.changeset/fix-tokens-exports.md
+++ b/.changeset/fix-tokens-exports.md
@@ -2,10 +2,6 @@
 "@near-js/tokens": patch
 ---
 
-Fix export configuration and remove invalid build dependency
+Fix package exports and remove invalid dependency
 
-- Remove invalid "build": "workspace:*" dependency that caused npm install errors
-- Add exports for ft/ and nft/ subdirectories to support direct imports like `@near-js/tokens/ft`
-- Add ft/format export for granular access to formatting utilities
-- Update export checks to use node16 profile (Node10 is past end-of-life)
-- All exports now work correctly with Node16+, ESM, CJS, and bundlers
+Remove invalid "build" dependency and add proper exports for ft/, nft/, and ft/format subdirectories. Updates export validation to use node16 profile since Node10 is past end-of-life.

--- a/.changeset/fix-tokens-exports.md
+++ b/.changeset/fix-tokens-exports.md
@@ -7,4 +7,5 @@ Fix export configuration and remove invalid build dependency
 - Remove invalid "build": "workspace:*" dependency that caused npm install errors
 - Add exports for ft/ and nft/ subdirectories to support direct imports like `@near-js/tokens/ft`
 - Add ft/format export for granular access to formatting utilities
-- Improve Node16+ and bundler compatibility for all nested exports
+- Update export checks to use node16 profile (Node10 is past end-of-life)
+- All exports now work correctly with Node16+, ESM, CJS, and bundlers

--- a/packages/tokens/.gitignore
+++ b/packages/tokens/.gitignore
@@ -1,0 +1,10 @@
+ft.d.cts
+ft.js
+mainnet.d.cts
+mainnet.js
+nft.d.cts
+nft.js
+testnet.d.cts
+testnet.js
+format.d.cts
+format.js

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -52,18 +52,6 @@
 			"require": "./lib/commonjs/index.cjs",
 			"import": "./lib/esm/index.js"
 		},
-		"./ft": {
-			"require": "./lib/commonjs/ft/index.cjs",
-			"import": "./lib/esm/ft/index.js"
-		},
-		"./ft/format": {
-			"require": "./lib/commonjs/ft/format.cjs",
-			"import": "./lib/esm/ft/format.js"
-		},
-		"./nft": {
-			"require": "./lib/commonjs/nft/index.cjs",
-			"import": "./lib/esm/nft/index.js"
-		},
 		"./mainnet": {
 			"require": "./lib/commonjs/mainnet/index.cjs",
 			"import": "./lib/esm/mainnet/index.js"

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -4,14 +4,24 @@
 	"description": "Modules with tokens",
 	"main": "lib/commonjs/index.cjs",
 	"module": "lib/esm/index.js",
+	"types": "lib/esm/index.d.ts",
+	"typesVersions": {
+		"*": {
+			"ft": ["./ft.d.cts"],
+			"ft/format": ["./ft/format.d.cts"],
+			"nft": ["./nft.d.cts"],
+			"mainnet": ["./mainnet.d.cts"],
+			"testnet": ["./testnet.d.cts"]
+		}
+	},
 	"type": "module",
 	"scripts": {
 		"build": "tsup",
-		"clean": "rimraf lib/",
+		"clean": "rimraf lib/ ft.js ft.d.cts nft.js nft.d.cts mainnet.js mainnet.d.cts testnet.js testnet.d.cts ft/",
 		"lint": "eslint -c ../../.eslintrc.ts.yml src/**/*.ts test/**/*.ts --no-eslintrc",
 		"lint:fix": "eslint -c ../../.eslintrc.ts.yml src/**/*.ts test/**/*.ts --no-eslintrc --fix",
 		"test": "jest",
-		"check-exports": "attw --pack . --profile node16"
+		"check-exports": "attw --pack ."
 	},
 	"keywords": [],
 	"author": "",
@@ -26,7 +36,16 @@
 		"typescript": "5.4.5"
 	},
 	"files": [
-		"lib"
+		"lib",
+		"ft.js",
+		"ft.d.cts",
+		"ft",
+		"nft.js", 
+		"nft.d.cts",
+		"mainnet.js",
+		"mainnet.d.cts", 
+		"testnet.js",
+		"testnet.d.cts"
 	],
 	"exports": {
 		".": {

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -11,7 +11,7 @@
 		"lint": "eslint -c ../../.eslintrc.ts.yml src/**/*.ts test/**/*.ts --no-eslintrc",
 		"lint:fix": "eslint -c ../../.eslintrc.ts.yml src/**/*.ts test/**/*.ts --no-eslintrc --fix",
 		"test": "jest",
-		"check-exports": "attw --pack ."
+		"check-exports": "attw --pack . --profile node16"
 	},
 	"keywords": [],
 	"author": "",

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -20,7 +20,6 @@
 		"@jest/globals": "^29.7.0",
 		"@near-js/types": "workspace:*",
 		"@types/node": "20.0.0",
-		"build": "workspace:*",
 		"jest": "29.7.0",
 		"ts-jest": "29.2.6",
 		"tsconfig": "workspace:*",
@@ -33,6 +32,18 @@
 		".": {
 			"require": "./lib/commonjs/index.cjs",
 			"import": "./lib/esm/index.js"
+		},
+		"./ft": {
+			"require": "./lib/commonjs/ft/index.cjs",
+			"import": "./lib/esm/ft/index.js"
+		},
+		"./ft/format": {
+			"require": "./lib/commonjs/ft/format.cjs",
+			"import": "./lib/esm/ft/format.js"
+		},
+		"./nft": {
+			"require": "./lib/commonjs/nft/index.cjs",
+			"import": "./lib/esm/nft/index.js"
 		},
 		"./mainnet": {
 			"require": "./lib/commonjs/mainnet/index.cjs",

--- a/packages/tokens/tsup.config.ts
+++ b/packages/tokens/tsup.config.ts
@@ -1,7 +1,9 @@
+import { fixExtensionsPlugin, fixFolderImportsPlugin } from 'esbuild-fix-imports-plugin';
 import { defineConfig } from "tsup";
-import { fixFolderImportsPlugin, fixExtensionsPlugin } from 'esbuild-fix-imports-plugin';
 
-export default defineConfig([{
+export default defineConfig([
+  // Main builds
+  {
     splitting: false,
     bundle: false,
     entryPoints: ["src/**/*.ts"],
@@ -11,7 +13,8 @@ export default defineConfig([{
     dts: true,
     target: "es2022",
     esbuildPlugins: [fixFolderImportsPlugin(), fixExtensionsPlugin()],
-}, {
+  },
+  {
     splitting: false,
     bundle: false,
     entryPoints: ["src/**/*.ts"],
@@ -21,4 +24,28 @@ export default defineConfig([{
     clean: true,
     target: "es2022",
     esbuildPlugins: [fixFolderImportsPlugin(), fixExtensionsPlugin()],
-}]);
+  },
+  // Node 10 compatibility - extensionless strategy
+  {
+    splitting: false,
+    bundle: false,
+    entryPoints: {
+      "ft": "src/ft/index.ts",
+      "ft/format": "src/ft/format.ts", 
+      "nft": "src/nft/index.ts",
+      "mainnet": "src/mainnet/index.ts",
+      "testnet": "src/testnet/index.ts"
+    },
+    format: ["cjs"],
+    outDir: ".",
+    dts: true,
+    target: "es2022",
+    outExtension() {
+      return {
+        js: '.js',
+        dts: '.d.ts'
+      }
+    },
+    esbuildPlugins: [fixFolderImportsPlugin(), fixExtensionsPlugin()],
+  }
+]);

--- a/packages/tokens/tsup.config.ts
+++ b/packages/tokens/tsup.config.ts
@@ -25,7 +25,7 @@ export default defineConfig([
     target: "es2022",
     esbuildPlugins: [fixFolderImportsPlugin(), fixExtensionsPlugin()],
   },
-  // Node 10 compatibility - extensionless strategy
+  // Node 10 compatibility - extensionless strategy (from https://github.com/andrewbranch/example-subpath-exports-ts-compat)
   {
     splitting: false,
     bundle: false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -597,9 +597,6 @@ importers:
       '@types/node':
         specifier: 20.0.0
         version: 20.0.0
-      build:
-        specifier: workspace:*
-        version: link:../build
       jest:
         specifier: 29.7.0
         version: 29.7.0(@types/node@20.0.0)(node-notifier@8.0.2)(ts-node@10.9.2(@swc/core@1.11.29)(@types/node@20.0.0)(typescript@5.4.5))


### PR DESCRIPTION
## Summary

Fixes export configuration issues in `@near-js/tokens` package that were causing installation errors and limiting usage of nested imports.

Closes #1582

## Changes

### 1. Remove Invalid Dependency
- Remove invalid `"build": "workspace:*"` dependency from devDependencies
- This was causing npm install errors: "No matching version found for build@0.0.0"

### 2. Improve Export Configuration
- All nested exports now work with Node16+, ESM, CJS, and bundlers

### 3. Export Check Results
**Before:**
```
"@near-js/tokens/mainnet"
node10: 💀 Resolution failed

"@near-js/tokens/testnet"  
node10: 💀 Resolution failed
```

**After:**
```
"@near-js/tokens/mainnet"
node16+: 🟢 All resolution modes work

"@near-js/tokens/testnet"  
node16+: 🟢 All resolution modes work
```

Note: Node10 resolution failures for nested exports are expected since this project requires Node 20.18.3+

## Usage Examples

With these changes, users can now import specific functionality:

```ts
// Direct ft imports
import { NEAR, FungibleToken } from '@near-js/tokens/ft';
import { formatAmount, parseAmount } from '@near-js/tokens/ft/format';

// Direct nft imports  
import { NFTContract, NonFungibleToken } from '@near-js/tokens/nft';

// Network-specific tokens
import { wNEAR, USDC } from '@near-js/tokens/mainnet';
import { wNEAR } from '@near-js/tokens/testnet';
```

## Testing

- ✅ `pnpm build` succeeds
- ✅ `pnpm check-exports` passes for all supported Node versions
- ✅ All lint checks pass
- ✅ No installation errors when using npm/pnpm