### PR TITLE
Set default `waitUntil` value back to `EXECUTED_OPTIMISTIC`

### DIFF
--- a/.changeset/cool-buses-wonder.md
+++ b/.changeset/cool-buses-wonder.md
@@ -1,0 +1,5 @@
+---
+"@near-js/accounts": patch
+---
+
+Set default `waitUntil` value to `EXECUTED_OPTIMISTIC`

--- a/packages/accounts/src/account.ts
+++ b/packages/accounts/src/account.ts
@@ -66,7 +66,7 @@ const {
 
 // Environment value is used in tests since near-sandbox runs old version of nearcore that doesn't work with near-final finality
 const DEFAULT_FINALITY = process.env.DEFAULT_FINALITY as Finality || "near-final";
-export const DEFAULT_WAIT_STATUS: TxExecutionStatus = "INCLUDED_FINAL";
+export const DEFAULT_WAIT_STATUS: TxExecutionStatus = "EXECUTED_OPTIMISTIC";
 
 export interface AccountState {
     balance: {


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to NEAR JavaScript API here: https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md).
- [x] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [ ] **If this is a code change**: I have written unit tests.
- [x] **If this changes code in a published package**: I have run `pnpm changeset` to create a `changeset` JSON document appropriate for this change.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
