### PR TITLE
fix: meta transaction was signing the incorrect payload

### DIFF
--- a/.changeset/big-tables-itch.md
+++ b/.changeset/big-tables-itch.md
@@ -1,0 +1,5 @@
+---
+"@near-js/signers": patch
+---
+
+Fix meta transaction is not signing correctly

--- a/packages/signers/src/key_pair_signer.ts
+++ b/packages/signers/src/key_pair_signer.ts
@@ -116,7 +116,7 @@ export class KeyPairSigner extends Signer {
         const message = encodeDelegateAction(delegateAction);
         const hash = new Uint8Array(sha256(message));
 
-        const { signature } = this.key.sign(message);
+        const { signature } = this.key.sign(hash);
         const signedDelegate = new SignedDelegate({
             delegateAction,
             signature: new Signature({


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to NEAR JavaScript API here: https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md).
- [x] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [ ] **If this is a code change**: I have written unit tests.
- [x] **If this changes code in a published package**: I have run `pnpm changeset` to create a `changeset` JSON document appropriate for this change.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Details
`signDelegateAction` was signing incorrect payload and making meta transaction failing in latest version.
