### PR TITLE
Fix interface misalignment between `Provider` and `JsonRpcProvider`

### DIFF
--- a/.changeset/angry-buttons-search.md
+++ b/.changeset/angry-buttons-search.md
@@ -1,0 +1,6 @@
+---
+"@near-js/providers": patch
+"near-api-js": patch
+---
+
+Provide default value `{}` for headers as `connection.headers` could be `undefined` in some cases

--- a/.changeset/cute-tires-fall.md
+++ b/.changeset/cute-tires-fall.md
@@ -1,0 +1,6 @@
+---
+"@near-js/providers": patch
+"near-api-js": patch
+---
+
+Update interfaces of `JsonRpcProvider` and `FailoverRpcProvider` to be aligned with `Provider`

--- a/.changeset/easy-trains-serve.md
+++ b/.changeset/easy-trains-serve.md
@@ -1,0 +1,6 @@
+---
+"@near-js/providers": patch
+"near-api-js": patch
+---
+
+Make parameter type of function `Provider.gasPrice` nullable (to be aligned with actual implemention in `JsonRpcProvider`)

--- a/packages/providers/src/failover-rpc-provider.ts
+++ b/packages/providers/src/failover-rpc-provider.ts
@@ -148,7 +148,7 @@ export class FailoverRpcProvider implements Provider {
         return this.withBackoff((currentProvider) => currentProvider.viewContractState(accountId, prefix, blockQuery));
     }
 
-    public async callFunction<T extends SerializedReturnValue>(accountId: string, method: string, args: Record<string, unknown>, blockQuery?: BlockReference): Promise<T> {
+    public async callFunction<T extends SerializedReturnValue>(accountId: string, method: string, args: Record<string, unknown>, blockQuery?: BlockReference): Promise<T | undefined> {
         return this.withBackoff((currentProvider) => currentProvider.callFunction<T>(accountId, method, args, blockQuery));
     }
 

--- a/packages/providers/src/json-rpc-provider.ts
+++ b/packages/providers/src/json-rpc-provider.ts
@@ -616,7 +616,7 @@ export class JsonRpcProvider implements Provider {
             id: (_nextId++),
             jsonrpc: '2.0'
         };
-        const response = await fetchJsonRpc(this.connection.url, request, this.connection.headers, retryConfig(this.options.retries, this.options.backoff, this.options.wait));
+        const response = await fetchJsonRpc(this.connection.url, request, this.connection.headers || {}, retryConfig(this.options.retries, this.options.backoff, this.options.wait));
         if (response.error) {
             if (typeof response.error.data === 'object') {
                 if (typeof response.error.data.error_message === 'string' && typeof response.error.data.error_type === 'string') {

--- a/packages/providers/src/provider.ts
+++ b/packages/providers/src/provider.ts
@@ -88,7 +88,7 @@ export interface Provider {
     lightClientProof(request: LightClientProofRequest): Promise<LightClientProof>;
     nextLightClientBlock(request: NextLightClientBlockRequest): Promise<NextLightClientBlockResponse>;
     /** @deprecated use {@link viewGasPrice} */
-    gasPrice(blockId: BlockId): Promise<GasPrice>;
+    gasPrice(blockId: BlockId | null): Promise<GasPrice>;
     accessKeyChanges(accountIdArray: string[], BlockQuery: BlockId | BlockReference): Promise<ChangeResult>;
     singleAccessKeyChanges(accessKeyArray: AccessKeyWithPublicKey[], BlockQuery: BlockId | BlockReference): Promise<ChangeResult>;
     accountChanges(accountIdArray: string[], BlockQuery: BlockId | BlockReference): Promise<ChangeResult>;

--- a/packages/providers/src/provider.ts
+++ b/packages/providers/src/provider.ts
@@ -50,7 +50,7 @@ export interface Provider {
     viewAccount(accountId: string, blockQuery?: BlockReference): Promise<AccountView>;
     viewContractCode(contractId: string, blockQuery?: BlockReference): Promise<ContractCodeView>;
     viewContractState(contractId: string, prefix?: string, blockQuery?: BlockReference): Promise<ContractStateView>;
-    callFunction<T extends SerializedReturnValue>(contractId: string, method: string, args: Record<string, unknown>, blockQuery?: BlockReference): Promise<T>;
+    callFunction<T extends SerializedReturnValue>(contractId: string, method: string, args: Record<string, unknown>, blockQuery?: BlockReference): Promise<T | undefined>;
     callFunctionRaw(contractId: string, method: string, args: Record<string, unknown>, blockQuery?: BlockReference): Promise<CallContractViewFunctionResultRaw>;
 
     viewBlock(blockQuery: BlockReference): Promise<BlockResult>;


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to NEAR JavaScript API here: https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md).
- [x] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [ ] **If this is a code change**: I have written unit tests.
- [x] **If this changes code in a published package**: I have run `pnpm changeset` to create a `changeset` JSON document appropriate for this change.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

Fixes the issue reported by the community of interface misalignment

```
Type 'JsonRpcProvider' is not assignable to type 'Provider'.
  The types returned by 'callFunction(...)' are incompatible between these types.
    Type 'Promise<T | undefined>' is not assignable to type 'Promise<T>'.
      Type 'T | undefined' is not assignable to type 'T'.
        'T' could be instantiated with an arbitrary type which could be unrelated to 'T | undefined'.
```

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
