### PR TITLE
feat: add optional `precision` param to control digits after decimal point

### DIFF
--- a/.changeset/angry-planets-send.md
+++ b/.changeset/angry-planets-send.md
@@ -1,0 +1,6 @@
+---
+"@near-js/tokens": patch
+---
+
+Add optional 'precision' param in 'toDecimal' method to limit digits after the decimal point (rounded down), and add unit tests for it
+

--- a/packages/tokens/src/ft/format.ts
+++ b/packages/tokens/src/ft/format.ts
@@ -16,7 +16,7 @@ export function formatAmount(
         .substring(0, fracDigits)
         .padStart(fracDigits, '0');
 
-    fractionStr = fractionStr.substring(0, Number(precision));
+    fractionStr = fractionStr.substring(0, precision);
 
     return trimTrailingZeroes(`${wholeStr}.${fractionStr}`);
 }

--- a/packages/tokens/src/ft/format.ts
+++ b/packages/tokens/src/ft/format.ts
@@ -6,7 +6,7 @@ export const MAX_NOMINATION_EXP = 24;
 export function formatAmount(
     units: string | number | bigint,
     fracDigits: number,
-    precision: bigint | string | number = fracDigits
+    precision: number = fracDigits
 ): string {
     units = cleanupUnits(units);
 

--- a/packages/tokens/src/ft/format.ts
+++ b/packages/tokens/src/ft/format.ts
@@ -5,15 +5,18 @@ export const MAX_NOMINATION_EXP = 24;
  */
 export function formatAmount(
     units: string | number | bigint,
-    fracDigits: number
+    fracDigits: number,
+    precision: bigint | string | number = fracDigits
 ): string {
     units = cleanupUnits(units);
 
     const wholeStr = units.substring(0, units.length - fracDigits) || '0';
-    const fractionStr = units
+    let fractionStr = units
         .substring(units.length - fracDigits)
         .substring(0, fracDigits)
         .padStart(fracDigits, '0');
+
+    fractionStr = fractionStr.substring(0, Number(precision));
 
     return trimTrailingZeroes(`${wholeStr}.${fractionStr}`);
 }

--- a/packages/tokens/src/ft/index.ts
+++ b/packages/tokens/src/ft/index.ts
@@ -31,7 +31,7 @@ abstract class BaseFT {
      * Converts indivisible units to a decimal number (represented as a string)
      * 
      * @param units The amount in indivisible units (e.g. "1234")
-     * @param precision Optional number of digits shown to the right of the decimal point
+     * @param precision (optional) number of digits shown to the right of the decimal point - rounded down
      * @returns The amount as a decimal string (e.g. "1.234")
      */
     public toDecimal(amount: bigint | string | number, precision?: bigint | string | number): string {

--- a/packages/tokens/src/ft/index.ts
+++ b/packages/tokens/src/ft/index.ts
@@ -34,7 +34,7 @@ abstract class BaseFT {
      * @param precision (optional) number of digits shown to the right of the decimal point - rounded down
      * @returns The amount as a decimal string (e.g. "1.234")
      */
-    public toDecimal(amount: bigint | string | number, precision?: bigint | string | number): string {
+    public toDecimal(amount: bigint | string | number, precision?: number): string {
         return formatAmount(amount, this.metadata.decimals, precision);
     }
 

--- a/packages/tokens/src/ft/index.ts
+++ b/packages/tokens/src/ft/index.ts
@@ -31,10 +31,11 @@ abstract class BaseFT {
      * Converts indivisible units to a decimal number (represented as a string)
      * 
      * @param units The amount in indivisible units (e.g. "1234")
+     * @param precision Optional number of digits shown to the right of the decimal point
      * @returns The amount as a decimal string (e.g. "1.234")
      */
-    public toDecimal(amount: bigint | string | number): string {
-        return formatAmount(amount, this.metadata.decimals);
+    public toDecimal(amount: bigint | string | number, precision?: bigint | string | number): string {
+        return formatAmount(amount, this.metadata.decimals, precision);
     }
 
     /**

--- a/packages/tokens/test/fungible_token.test.ts
+++ b/packages/tokens/test/fungible_token.test.ts
@@ -67,17 +67,18 @@ test('test toDecimal formats units', () => {
     expect(FT.toDecimal('1000000')).toBe('1');
     expect(FT.toDecimal(1_000_000)).toBe('1');
     expect(FT.toDecimal(BigInt(1_000_000))).toBe('1');
-    expect(FT.toDecimal('1000000', 2)).toBe('1');
+    expect(FT.toDecimal('1000000', '2')).toBe('1');
 
     expect(FT.toDecimal('1000001')).toBe('1.000001');
     expect(FT.toDecimal(1_000_001)).toBe('1.000001');
     expect(FT.toDecimal(BigInt(1_000_001))).toBe('1.000001');
-    expect(FT.toDecimal('1000001',2)).toBe('1');
+    expect(FT.toDecimal('1000001', '2')).toBe('1');
 
     expect(FT.toDecimal('1234567')).toBe('1.234567');
     expect(FT.toDecimal(1_234_567)).toBe('1.234567');
     expect(FT.toDecimal(BigInt(1_234_567))).toBe('1.234567');
     expect(FT.toDecimal('1234567', 2)).toBe('1.23');
+    expect(FT.toDecimal('1234567', 0)).toBe('1');
 
     expect(FT.toDecimal('12345678')).toBe('12.345678');
     expect(FT.toDecimal(12_345_678)).toBe('12.345678');
@@ -87,8 +88,8 @@ test('test toDecimal formats units', () => {
     expect(FT.toDecimal(12_345_678, 2)).toBe('12.34');
     expect(FT.toDecimal(BigInt(12_345_678), 2)).toBe('12.34');
 
-    expect(FT.toDecimal('710', 2)).toBe('0');
-    expect(FT.toDecimal(710, 2)).toBe('0');
+    expect(FT.toDecimal('710', '2')).toBe('0');
+    expect(FT.toDecimal(710, 0)).toBe('0');
     expect(FT.toDecimal(BigInt(710), 2)).toBe('0');
 
     expect(FT.toDecimal('0', 2)).toBe('0');

--- a/packages/tokens/test/fungible_token.test.ts
+++ b/packages/tokens/test/fungible_token.test.ts
@@ -67,18 +67,33 @@ test('test toDecimal formats units', () => {
     expect(FT.toDecimal('1000000')).toBe('1');
     expect(FT.toDecimal(1_000_000)).toBe('1');
     expect(FT.toDecimal(BigInt(1_000_000))).toBe('1');
+    expect(FT.toDecimal('1000000', 2)).toBe('1');
 
     expect(FT.toDecimal('1000001')).toBe('1.000001');
     expect(FT.toDecimal(1_000_001)).toBe('1.000001');
     expect(FT.toDecimal(BigInt(1_000_001))).toBe('1.000001');
+    expect(FT.toDecimal('1000001',2)).toBe('1');
 
     expect(FT.toDecimal('1234567')).toBe('1.234567');
     expect(FT.toDecimal(1_234_567)).toBe('1.234567');
     expect(FT.toDecimal(BigInt(1_234_567))).toBe('1.234567');
+    expect(FT.toDecimal('1234567', 2)).toBe('1.23');
 
     expect(FT.toDecimal('12345678')).toBe('12.345678');
     expect(FT.toDecimal(12_345_678)).toBe('12.345678');
     expect(FT.toDecimal(BigInt(12_345_678))).toBe('12.345678');
+    expect(FT.toDecimal('12345678', 4)).toBe('12.3456');
+
+    expect(FT.toDecimal(12_345_678, 2)).toBe('12.34');
+    expect(FT.toDecimal(BigInt(12_345_678), 2)).toBe('12.34');
+
+    expect(FT.toDecimal('710', 2)).toBe('0');
+    expect(FT.toDecimal(710, 2)).toBe('0');
+    expect(FT.toDecimal(BigInt(710), 2)).toBe('0');
+
+    expect(FT.toDecimal('0', 2)).toBe('0');
+    expect(FT.toDecimal(0, 2)).toBe('0');
+    expect(FT.toDecimal(BigInt(0), 2)).toBe('0');
 
     expect(FT.toDecimal('710')).toBe('0.00071');
     expect(FT.toDecimal(710)).toBe('0.00071');

--- a/packages/tokens/test/fungible_token.test.ts
+++ b/packages/tokens/test/fungible_token.test.ts
@@ -92,9 +92,10 @@ test('test toDecimal formats units', () => {
     expect(FT.toDecimal(710, 0)).toBe('0');
     expect(FT.toDecimal(BigInt(710), 2)).toBe('0');
 
-    expect(FT.toDecimal('0', 2)).toBe('0');
-    expect(FT.toDecimal(0, 2)).toBe('0');
-    expect(FT.toDecimal(BigInt(0), 2)).toBe('0');
+    expect(FT.toDecimal(123_456, '2')).toBe('0.12');
+    expect(FT.toDecimal(123_456, '4')).toBe('0.1234');
+    expect(FT.toDecimal(1999, '4')).toBe('0.0019');
+    expect(FT.toDecimal(1234, '6')).toBe('0.001234');
 
     expect(FT.toDecimal('710')).toBe('0.00071');
     expect(FT.toDecimal(710)).toBe('0.00071');
@@ -107,6 +108,8 @@ test('test toDecimal formats units', () => {
     expect(FT.toDecimal('0')).toBe('0');
     expect(FT.toDecimal(0)).toBe('0');
     expect(FT.toDecimal(BigInt(0))).toBe('0');
+    expect(FT.toDecimal(0, 2)).toBe('0');
+
 });
 
 test('test toDecimal fails on non-integer units', () => {

--- a/packages/tokens/test/fungible_token.test.ts
+++ b/packages/tokens/test/fungible_token.test.ts
@@ -67,12 +67,12 @@ test('test toDecimal formats units', () => {
     expect(FT.toDecimal('1000000')).toBe('1');
     expect(FT.toDecimal(1_000_000)).toBe('1');
     expect(FT.toDecimal(BigInt(1_000_000))).toBe('1');
-    expect(FT.toDecimal('1000000', '2')).toBe('1');
+    expect(FT.toDecimal('1000000', 2)).toBe('1');
 
     expect(FT.toDecimal('1000001')).toBe('1.000001');
     expect(FT.toDecimal(1_000_001)).toBe('1.000001');
     expect(FT.toDecimal(BigInt(1_000_001))).toBe('1.000001');
-    expect(FT.toDecimal('1000001', '2')).toBe('1');
+    expect(FT.toDecimal('1000001', 2)).toBe('1');
 
     expect(FT.toDecimal('1234567')).toBe('1.234567');
     expect(FT.toDecimal(1_234_567)).toBe('1.234567');
@@ -88,14 +88,14 @@ test('test toDecimal formats units', () => {
     expect(FT.toDecimal(12_345_678, 2)).toBe('12.34');
     expect(FT.toDecimal(BigInt(12_345_678), 2)).toBe('12.34');
 
-    expect(FT.toDecimal('710', '2')).toBe('0');
+    expect(FT.toDecimal('710', 2)).toBe('0');
     expect(FT.toDecimal(710, 0)).toBe('0');
     expect(FT.toDecimal(BigInt(710), 2)).toBe('0');
 
-    expect(FT.toDecimal(123_456, '2')).toBe('0.12');
-    expect(FT.toDecimal(123_456, '4')).toBe('0.1234');
-    expect(FT.toDecimal(1999, '4')).toBe('0.0019');
-    expect(FT.toDecimal(1234, '6')).toBe('0.001234');
+    expect(FT.toDecimal(123_456, 2)).toBe('0.12');
+    expect(FT.toDecimal(123_456, 4)).toBe('0.1234');
+    expect(FT.toDecimal(1999, 4)).toBe('0.0019');
+    expect(FT.toDecimal(1234, 6)).toBe('0.001234');
 
     expect(FT.toDecimal('710')).toBe('0.00071');
     expect(FT.toDecimal(710)).toBe('0.00071');


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to NEAR JavaScript API here: https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md).
- [x] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [x] **If this is a code change**: I have written unit tests.
- [ ] **If this changes code in a published package**: I have run `pnpm changeset` to create a `changeset` JSON document appropriate for this change.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

## Test Plan
Default `toDemical` should keep the same logic. If user provide value he is responsible for result, like if value smaller that decimals after point it will return 0.
<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->

## Related issues/PRs
Close https://github.com/near/near-api-js/issues/1615
<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
