### PR TITLE
Fix: Ensure passkey-derived keys are prefixed with ed25519: and add regression test

### DIFF
--- a/.changeset/wise-mangos-push.md
+++ b/.changeset/wise-mangos-push.md
@@ -1,0 +1,5 @@
+---
+"@near-js/biometric-ed25519": patch
+---
+
+Ensure passkey-derived keys are prefixed with ed25519

--- a/packages/biometric-ed25519/test/keys.test.ts
+++ b/packages/biometric-ed25519/test/keys.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from '@jest/globals';
+import { KeyPair, KeyPairEd25519 } from '@near-js/crypto';
+import { baseEncode } from '@near-js/utils';
+import { makeEd25519KeyString } from '../src';
+
+describe('makeEd25519KeyString regression', () => {
+    const secretKey = Buffer.from(new Array(32).fill(1));
+    const pubKey = Buffer.from(new Array(32).fill(2));
+
+    it('should fail without the ed25519 prefix', () => {
+        const bareKey = Buffer.concat([secretKey, pubKey]);
+        const bareKeyString = baseEncode(bareKey);
+        console.log('bareKeyString', bareKeyString);
+        // @ts-expect-error testing invalid input
+        expect(() => KeyPair.fromString(bareKeyString)).toThrow(
+            'Invalid encoded key format, must be <curve>:<encoded key>'
+        );
+    });
+
+    it('should return a string parsable by KeyPair.fromString', () => {
+        const keyString = makeEd25519KeyString(secretKey, pubKey);
+        const keyPair = KeyPair.fromString(keyString) as KeyPairEd25519;
+
+        expect(keyPair).toBeInstanceOf(KeyPairEd25519);
+        expect(keyPair.toString().startsWith('ed25519:')).toBe(true);
+    });
+});


### PR DESCRIPTION
This PR addresses a bug in `@near-js/biometric-ed25519` where passkey-derived key strings were not prefixed with `ed25519:`, causing `KeyPair.fromString` to throw errors:

```
Invalid encoded key format, must be <curve>:<encoded key>
```

The change ensures that all passkey-derived keys are properly prefixed, and adds a regression test to prevent future regressions.


<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to NEAR JavaScript API here: https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [ ] I have read the [Contributing Guidelines on pull requests](https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md).
- [ ] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [ ] **If this is a code change**: I have written unit tests.
- [ ] **If this changes code in a published package**: I have run `pnpm changeset` to create a `changeset` JSON document appropriate for this change.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

The bug was caused by legacy behavior in `@near-js/biometric-ed25519` where KeyPair.fromString was sometimes called with a raw base-encoded secret+public key string.

Legacy behavior (pre-fix) allowed KeyPairEd25519 to be constructed from a single-part string:

```
const parts = encodedKey.split(':');
if (parts.length === 1) {
    return new KeyPairEd25519(parts[0]);
}
```
See [pre-fix state](https://github.com/near/near-api-js/blame/b61b66d271146f0a1b5b88e75da06dffc354860e/packages/crypto/src/key_pair.ts#L24) for reference.

The update introduced in https://github.com/near/near-api-js/pull/1355 made param to be `KeyPairString`, assuming there is always a prefix.

The update introduced in this PR enforces the prefix explicitly, ensuring compatibility with `KeyPair.fromString` and making the behavior consistent and predictable.

## Test Plan

The regression tests were added, making sure that the call to `KeyPair.fromString` will fail without the ed25519 prefix, while the one with the prefix will work.

## Related issues/PRs

https://github.com/near/near-api-js/pull/1355
