### PR TITLE
feat(providers): allow `Uint8Array` as args input for `callFunctionRaw` and `callFunction`

### DIFF
--- a/.changeset/tired-rooms-cheat.md
+++ b/.changeset/tired-rooms-cheat.md
@@ -1,0 +1,6 @@
+---
+"@near-js/providers": minor
+"near-api-js": minor
+---
+
+Allow `Uint8Array` as args input for `callFunctionRaw` and `callFunction`

--- a/packages/providers/src/json-rpc-provider.ts
+++ b/packages/providers/src/json-rpc-provider.ts
@@ -226,7 +226,7 @@ export class JsonRpcProvider implements Provider {
     public async callFunction<T extends SerializedReturnValue>(
         contractId: string,
         method: string,
-        args: Record<string, unknown>,
+        args: Record<string, unknown> | Uint8Array,
         blockQuery: BlockReference = { finality: DEFAULT_FINALITY }
     ): Promise<T | undefined> {
         const { result } = await this.callFunctionRaw(
@@ -250,10 +250,11 @@ export class JsonRpcProvider implements Provider {
     public async callFunctionRaw(
         contractId: string,
         method: string,
-        args: Record<string, unknown>,
+        args: Record<string, unknown> | Uint8Array,
         blockQuery: BlockReference = { finality: DEFAULT_FINALITY }
     ): Promise<CallContractViewFunctionResultRaw> {
-        const argsBase64 = Buffer.from(JSON.stringify(args)).toString('base64');
+        const argsBuffer = ArrayBuffer.isView(args) ? Buffer.from(args) : Buffer.from(JSON.stringify(args));
+        const argsBase64 = argsBuffer.toString('base64');
 
         return await (
             this as Provider


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to NEAR JavaScript API here: https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md).
- [x] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [ ] **If this is a code change**: I have written unit tests.
- [x] **If this changes code in a published package**: I have run `pnpm changeset` to create a `changeset` JSON document appropriate for this change.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

Adds support for binary arguments in `callFunctionRaw`, allowing you to pass a `Uint8Array` directly instead of only JSON-serializable objects.

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->

## Related issues/PRs

https://t.me/neardev/74289

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
