### PR TITLE
fix(utils): extend input type for `formatNearAmount` function

### DIFF
--- a/.changeset/nice-nails-remain.md
+++ b/.changeset/nice-nails-remain.md
@@ -1,0 +1,6 @@
+---
+"@near-js/utils": patch
+"near-api-js": patch
+---
+
+Extend input type for `formatNearAmount` function

--- a/packages/utils/src/format.ts
+++ b/packages/utils/src/format.ts
@@ -30,7 +30,7 @@ for (
  * @returns Value in Ⓝ
  */
 export function formatNearAmount(
-    balance: string,
+    balance: string | number | bigint,
     fracDigits: number = NEAR_NOMINATION_EXP
 ): string {
     let balanceBN = BigInt(balance);


### PR DESCRIPTION
<!--
Thank you for sending the PR! We appreciate you spending the time to work on these changes.
You can learn more about contributing to NEAR JavaScript API here: https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md
Happy contributing!
-->

## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md).
- [x] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [ ] **If this is a code change**: I have written unit tests.
- [x] **If this changes code in a published package**: I have run `pnpm changeset` to create a `changeset` JSON document appropriate for this change.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan.

## Motivation

Allow `bigint` and `number` to be passed over right to `formatNearAmount`

<!-- Help us understand your motivation by explaining why you decided to make this change. Does this fix a bug? Does it close an issue? -->

## Test Plan

<!-- Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. -->

## Related issues/PRs

<!-- If you haven't already, link to issues/PRs that are related to this change. This helps us develop the context and keep a rich repo history. If this PR is a continuation of a past PR's work, link to that PR. If the PR addresses part of the problem in a meta-issue, mention that issue. -->
