### PR TITLE
Inline borsh, make is-my-json-valid optional

### DIFF
--- a/.changeset/inline-borsh-serializer.md
+++ b/.changeset/inline-borsh-serializer.md
@@ -1,0 +1,5 @@
+---
+"near-api-js": minor
+---
+
+Inline borsh serializer: replace the `borsh` npm dependency with a lean 289-line zero-dep serializer/deserializer tailored to NEAR's schema needs. The `serialize` and `deserialize` functions maintain the same API. This eliminates a transitive dependency tree and reduces install footprint.

--- a/.changeset/optional-json-validator.md
+++ b/.changeset/optional-json-validator.md
@@ -1,0 +1,5 @@
+---
+"near-api-js": minor
+---
+
+Make `is-my-json-valid` an optional dependency: ABI schema validation via `validateArguments` is now async and dynamically imports `is-my-json-valid` with a try/catch fallback. Environments without it installed will skip validation silently. The `ValidationError` type is inlined in `src/accounts/errors.ts`. Consumers using typed contracts with ABI validation should add `is-my-json-valid` to their own dependencies.

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 #IDE
 .idea
 .vscode
+.claude/
 
 storage
 node_modules

--- a/package.json
+++ b/package.json
@@ -47,9 +47,10 @@
         "@noble/curves": "2.0.1",
         "@noble/hashes": "2.0.1",
         "@scure/base": "2.0.0",
-        "borsh": "2.0.0",
-        "is-my-json-valid": "2.20.6",
         "near-seed-phrase": "0.2.1"
+    },
+    "optionalDependencies": {
+        "is-my-json-valid": "2.20.6"
     },
     "devDependencies": {
         "@arethetypeswrong/cli": "0.18.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,12 +20,6 @@ importers:
       '@scure/base':
         specifier: 2.0.0
         version: 2.0.0
-      borsh:
-        specifier: 2.0.0
-        version: 2.0.0
-      is-my-json-valid:
-        specifier: 2.20.6
-        version: 2.20.6
       near-seed-phrase:
         specifier: 0.2.1
         version: 0.2.1
@@ -90,6 +84,10 @@ importers:
       vitest:
         specifier: 4.0.17
         version: 4.0.17(@types/node@25.0.9)(@vitest/ui@4.0.17)(jiti@2.6.1)(yaml@2.8.1)
+    optionalDependencies:
+      is-my-json-valid:
+        specifier: 2.20.6
+        version: 2.20.6
 
   e2e:
     dependencies:

--- a/src/accounts/errors.ts
+++ b/src/accounts/errors.ts
@@ -1,4 +1,10 @@
-import type { ValidationError } from 'is-my-json-valid';
+/** Validation error shape from is-my-json-valid (optional dependency). */
+export interface ValidationError {
+    field: string;
+    message: string;
+    value: unknown;
+    type: string;
+}
 
 export class UnsupportedSerializationError extends Error {
     constructor(methodName: string, serializationType: string) {

--- a/src/accounts/typed_contract.ts
+++ b/src/accounts/typed_contract.ts
@@ -2,7 +2,6 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-type-constraint */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
-import validator from 'is-my-json-valid';
 import type { Provider } from '../providers/index.js';
 import type { BlockReference, TxExecutionStatus } from '../types/index.js';
 import type {
@@ -16,7 +15,7 @@ import type {
     SchemaObject,
 } from './abi_types.js';
 import type { Account } from './account.js';
-import { ArgumentSchemaError, UnknownArgumentError } from './errors.js';
+import { ArgumentSchemaError, UnknownArgumentError, type ValidationError } from './errors.js';
 
 type IsNullable<T> = [null] extends [T] ? true : false;
 
@@ -333,7 +332,7 @@ class RawContract<const abi extends AbiRoot, contractId extends string> {
                             const args = params.args ?? {};
 
                             if (abiFunction && abi) {
-                                validateArguments(args, abiFunction, abi);
+                                await validateArguments(args, abiFunction, abi);
                             }
 
                             return provider.callFunction({
@@ -365,7 +364,7 @@ class RawContract<const abi extends AbiRoot, contractId extends string> {
                             const args = params.args ?? {};
 
                             if (abiFunction && abi) {
-                                validateArguments(args, abiFunction, abi);
+                                await validateArguments(args, abiFunction, abi);
                             }
 
                             return params.account.callFunction({
@@ -390,11 +389,18 @@ class RawContract<const abi extends AbiRoot, contractId extends string> {
 
 export const Contract = RawContract as ContractConstructor;
 
-function validateArguments(args: object, abiFunction: AbiFunction, abiRoot: AbiRoot) {
+async function validateArguments(args: object, abiFunction: AbiFunction, abiRoot: AbiRoot) {
     if (typeof args !== 'object' || typeof abiFunction.params !== 'object') return;
 
     if (abiFunction.params.serialization_type === 'json') {
         const params = abiFunction.params.args;
+        let validator: (schema: unknown) => ((value: unknown) => boolean) & { errors: ValidationError[] };
+        try {
+            ({ default: validator } = await import('is-my-json-valid'));
+        } catch {
+            // is-my-json-valid is an optional dependency; skip validation if not installed
+            return;
+        }
         for (const p of params) {
             const arg = args[p.name];
             const typeSchema = p.type_schema;

--- a/src/borsh.ts
+++ b/src/borsh.ts
@@ -1,0 +1,289 @@
+/**
+ * Lean Borsh serializer/deserializer for NEAR Protocol.
+ * Supports: u8, u16, u32, u64, u128, string, struct, enum, array (fixed + dynamic), option.
+ */
+
+type SchemaScalar = 'u8' | 'u16' | 'u32' | 'u64' | 'u128' | 'string';
+type SchemaOption = { option: Schema };
+type SchemaArray = { array: { type: Schema; len?: number } };
+type SchemaStruct = { struct: Record<string, Schema> };
+type SchemaEnum = { enum: SchemaStruct[] };
+export type Schema = SchemaScalar | SchemaOption | SchemaArray | SchemaStruct | SchemaEnum;
+
+class EncodeBuffer {
+    offset = 0;
+    bufferSize = 256;
+    buffer = new ArrayBuffer(this.bufferSize);
+    view = new DataView(this.buffer);
+
+    resize(needed: number) {
+        if (this.bufferSize - this.offset < needed) {
+            this.bufferSize = Math.max(this.bufferSize * 2, this.bufferSize + needed);
+            const next = new ArrayBuffer(this.bufferSize);
+            new Uint8Array(next).set(new Uint8Array(this.buffer));
+            this.buffer = next;
+            this.view = new DataView(next);
+        }
+    }
+    storeU8(v: number) {
+        this.resize(1);
+        this.view.setUint8(this.offset, v);
+        this.offset += 1;
+    }
+    storeU16(v: number) {
+        this.resize(2);
+        this.view.setUint16(this.offset, v, true);
+        this.offset += 2;
+    }
+    storeU32(v: number) {
+        this.resize(4);
+        this.view.setUint32(this.offset, v, true);
+        this.offset += 4;
+    }
+    storeBytes(from: Uint8Array) {
+        this.resize(from.length);
+        new Uint8Array(this.buffer).set(from, this.offset);
+        this.offset += from.length;
+    }
+    result() {
+        return new Uint8Array(this.buffer).slice(0, this.offset);
+    }
+}
+
+class DecodeBuffer {
+    offset = 0;
+    view: DataView;
+    bytes: Uint8Array;
+
+    constructor(buf: Uint8Array) {
+        const ab = new ArrayBuffer(buf.length);
+        new Uint8Array(ab).set(buf);
+        this.view = new DataView(ab);
+        this.bytes = new Uint8Array(ab);
+    }
+    assert(size: number) {
+        if (this.offset + size > this.bytes.length) {
+            throw new Error('Borsh: buffer overrun');
+        }
+    }
+    readU8() {
+        this.assert(1);
+        const v = this.view.getUint8(this.offset);
+        this.offset += 1;
+        return v;
+    }
+    readU16() {
+        this.assert(2);
+        const v = this.view.getUint16(this.offset, true);
+        this.offset += 2;
+        return v;
+    }
+    readU32() {
+        this.assert(4);
+        const v = this.view.getUint32(this.offset, true);
+        this.offset += 4;
+        return v;
+    }
+    readBytes(len: number) {
+        this.assert(len);
+        const slice = this.bytes.slice(this.offset, this.offset + len);
+        this.offset += len;
+        return slice;
+    }
+}
+
+function encodeBigint(buf: EncodeBuffer, value: bigint, byteLen: number) {
+    const out = new Uint8Array(byteLen);
+    let v = value;
+    for (let i = 0; i < byteLen; i++) {
+        out[i] = Number(v & 0xffn);
+        v >>= 8n;
+    }
+    buf.storeBytes(out);
+}
+
+function decodeBigint(buf: DecodeBuffer, byteLen: number) {
+    const bytes = buf.readBytes(byteLen);
+    const hex = bytes.reduceRight((r, x) => r + x.toString(16).padStart(2, '0'), '');
+    return BigInt(`0x${hex}`);
+}
+
+function utf8Encode(str: string) {
+    const bytes: number[] = [];
+    for (let i = 0; i < str.length; i++) {
+        let c = str.charCodeAt(i);
+        if (c < 0x80) {
+            bytes.push(c);
+        } else if (c < 0x800) {
+            bytes.push(0xc0 | (c >> 6), 0x80 | (c & 0x3f));
+        } else if (c < 0xd800 || c >= 0xe000) {
+            bytes.push(0xe0 | (c >> 12), 0x80 | ((c >> 6) & 0x3f), 0x80 | (c & 0x3f));
+        } else {
+            i++;
+            c = 0x10000 + (((c & 0x3ff) << 10) | (str.charCodeAt(i) & 0x3ff));
+            bytes.push(0xf0 | (c >> 18), 0x80 | ((c >> 12) & 0x3f), 0x80 | ((c >> 6) & 0x3f), 0x80 | (c & 0x3f));
+        }
+    }
+    return new Uint8Array(bytes);
+}
+
+function utf8Decode(bytes: Uint8Array) {
+    const codePoints: number[] = [];
+    for (let i = 0; i < bytes.length; i++) {
+        const b = bytes[i]!;
+        if (b < 0x80) {
+            codePoints.push(b);
+        } else if (b < 0xe0) {
+            codePoints.push(((b & 0x1f) << 6) | (bytes[++i]! & 0x3f));
+        } else if (b < 0xf0) {
+            codePoints.push(((b & 0x0f) << 12) | ((bytes[++i]! & 0x3f) << 6) | (bytes[++i]! & 0x3f));
+        } else {
+            codePoints.push(
+                ((b & 0x07) << 18) | ((bytes[++i]! & 0x3f) << 12) | ((bytes[++i]! & 0x3f) << 6) | (bytes[++i]! & 0x3f)
+            );
+        }
+    }
+    return String.fromCodePoint(...codePoints);
+}
+
+function encodeValue(buf: EncodeBuffer, value: unknown, schema: Schema): void {
+    if (typeof schema === 'string') {
+        switch (schema) {
+            case 'u8':
+                buf.storeU8(value as number);
+                return;
+            case 'u16':
+                buf.storeU16(value as number);
+                return;
+            case 'u32':
+                buf.storeU32(value as number);
+                return;
+            case 'u64':
+                encodeBigint(buf, BigInt(value as number | bigint), 8);
+                return;
+            case 'u128':
+                encodeBigint(buf, BigInt(value as number | bigint), 16);
+                return;
+            case 'string': {
+                const encoded = utf8Encode(value as string);
+                buf.storeU32(encoded.length);
+                buf.storeBytes(encoded);
+                return;
+            }
+        }
+    }
+    if (typeof schema === 'object') {
+        if ('option' in schema) {
+            if (value === null || value === undefined) {
+                buf.storeU8(0);
+            } else {
+                buf.storeU8(1);
+                encodeValue(buf, value, schema.option);
+            }
+            return;
+        }
+        if ('enum' in schema) {
+            const obj = value as Record<string, unknown>;
+            const valueKey = Object.keys(obj)[0];
+            const variants = schema.enum;
+            for (let i = 0; i < variants.length; i++) {
+                const variant = variants[i]!;
+                const variantKey = Object.keys(variant.struct)[0];
+                if (valueKey === variantKey) {
+                    buf.storeU8(i);
+                    encodeStruct(buf, obj, variant);
+                    return;
+                }
+            }
+            throw new Error(`Borsh: enum key "${valueKey}" not found in schema`);
+        }
+        if ('array' in schema) {
+            const arr = value as unknown[];
+            if (schema.array.len == null) {
+                buf.storeU32(arr.length);
+            }
+            for (let i = 0; i < arr.length; i++) {
+                encodeValue(buf, arr[i], schema.array.type);
+            }
+            return;
+        }
+        if ('struct' in schema) {
+            encodeStruct(buf, value as Record<string, unknown>, schema);
+            return;
+        }
+    }
+}
+
+function encodeStruct(buf: EncodeBuffer, value: Record<string, unknown>, schema: SchemaStruct) {
+    for (const key of Object.keys(schema.struct)) {
+        encodeValue(buf, value[key], schema.struct[key]!);
+    }
+}
+
+function decodeValue(buf: DecodeBuffer, schema: Schema): unknown {
+    if (typeof schema === 'string') {
+        switch (schema) {
+            case 'u8':
+                return buf.readU8();
+            case 'u16':
+                return buf.readU16();
+            case 'u32':
+                return buf.readU32();
+            case 'u64':
+                return decodeBigint(buf, 8);
+            case 'u128':
+                return decodeBigint(buf, 16);
+            case 'string': {
+                const len = buf.readU32();
+                return utf8Decode(buf.readBytes(len));
+            }
+        }
+    }
+    if (typeof schema === 'object') {
+        if ('option' in schema) {
+            const flag = buf.readU8();
+            if (flag === 1) return decodeValue(buf, schema.option);
+            if (flag === 0) return null;
+            throw new Error(`Borsh: invalid option flag ${flag}`);
+        }
+        if ('enum' in schema) {
+            const idx = buf.readU8();
+            if (idx >= schema.enum.length) {
+                throw new Error(`Borsh: enum index ${idx} out of range`);
+            }
+            const variant = schema.enum[idx]!;
+            const result: Record<string, unknown> = {};
+            for (const key of Object.keys(variant.struct)) {
+                result[key] = decodeValue(buf, variant.struct[key]!);
+            }
+            return result;
+        }
+        if ('array' in schema) {
+            const len = schema.array.len ?? buf.readU32();
+            const result: unknown[] = [];
+            for (let i = 0; i < len; i++) {
+                result.push(decodeValue(buf, schema.array.type));
+            }
+            return result;
+        }
+        if ('struct' in schema) {
+            const result: Record<string, unknown> = {};
+            for (const key in schema.struct) {
+                result[key] = decodeValue(buf, schema.struct[key]!);
+            }
+            return result;
+        }
+    }
+    throw new Error(`Borsh: unsupported schema: ${JSON.stringify(schema)}`);
+}
+
+export function serialize(schema: Schema, value: unknown): Uint8Array {
+    const buf = new EncodeBuffer();
+    encodeValue(buf, value, schema);
+    return buf.result();
+}
+
+export function deserialize(schema: Schema, buffer: Uint8Array): unknown {
+    const buf = new DecodeBuffer(buffer);
+    return decodeValue(buf, schema);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,10 @@ export * from './transactions/index.js';
 export * from './types/index.js';
 export { gigaToGas, nearToYocto, teraToGas, yoctoToNear } from './units/index.js';
 // ============================================================================
+// Serialization (Borsh)
+// ============================================================================
+export { serialize, deserialize, type Schema } from './borsh.js';
+// ============================================================================
 // Utilities
 // ============================================================================
 export * from './utils/index.js';

--- a/src/nep413/schema.ts
+++ b/src/nep413/schema.ts
@@ -1,5 +1,5 @@
 import { sha256 } from '@noble/hashes/sha2.js';
-import { type Schema, serialize } from 'borsh';
+import { type Schema, serialize } from '../borsh.js';
 
 export interface MessagePayload {
     message: string; // The message that wants to be transmitted.

--- a/src/transactions/schema.ts
+++ b/src/transactions/schema.ts
@@ -1,4 +1,4 @@
-import { deserialize, type Schema, serialize } from 'borsh';
+import { deserialize, type Schema, serialize } from '../borsh.js';
 import { PublicKey } from '../crypto/index.js';
 
 import type { Action, SignedDelegate } from './actions.js';

--- a/test/unit/signers/key_pair_signer.test.ts
+++ b/test/unit/signers/key_pair_signer.test.ts
@@ -1,6 +1,6 @@
 import { sha256 } from '@noble/hashes/sha2.js';
-import { serialize } from 'borsh';
 import { expect, test } from 'vitest';
+import { serialize } from '../../../src/borsh.js';
 import {
     actions as actionCreators,
     buildDelegateAction,

--- a/test/unit/transactions/serialize.test.ts
+++ b/test/unit/transactions/serialize.test.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs';
 import { sha256 } from '@noble/hashes/sha2.js';
-import { deserialize, serialize } from 'borsh';
 import { describe, expect, test } from 'vitest';
+import { deserialize, serialize } from '../../../src/borsh.js';
 
 import {
     actions,


### PR DESCRIPTION
Toward the goal described in #1876 
I've tried to create a couple PRs for ease of review, and this is the first one. It's making some efficiency gains that will be used and leveraged in the two PRs following this. (those have linked to these with decent explanation)

This is the first one that's best to review and consider.

Sidenote, it's interesting that the npm package for borsh is so good it can be serialization for just about anything. What we found here was that it can be much smaller if it's just for the NEAR Protocol side, so that's the idea.

## Summary

- **Inline borsh serializer** — Replace the `borsh` npm dependency with a lean 289-line zero-dep serializer/deserializer tailored to NEAR's schema needs. Eliminates a transitive dependency tree.
- **Make is-my-json-valid optional** — Move `is-my-json-valid` to `optionalDependencies` and dynamically import it with try/catch fallback. Environments without it still work; ABI schema validation is skipped gracefully.
- **Add `.claude/` to `.gitignore`**

## Changes

| File | Change |
|------|--------|
| `src/borsh.ts` | New — 289-line zero-dep borsh serializer/deserializer |
| `src/transactions/schema.ts` | `import from 'borsh'` → `import from '../borsh.js'` |
| `src/nep413/schema.ts` | `import from 'borsh'` → `import from '../borsh.js'` |
| `test/unit/signers/key_pair_signer.test.ts` | `import from 'borsh'` → `import from '../../../src/borsh.js'` |
| `test/unit/transactions/serialize.test.ts` | `import from 'borsh'` → `import from '../../../src/borsh.js'` |
| `src/accounts/errors.ts` | Inline `ValidationError` type (was imported from is-my-json-valid) |
| `src/accounts/typed_contract.ts` | Dynamic `import('is-my-json-valid')` with try/catch; `validateArguments` → async |
| `package.json` | Remove `borsh` from deps; move `is-my-json-valid` to `optionalDependencies` |

## Test plan

- [x] `pnpm compile` (tsc) — no errors
- [x] `pnpm test` — all 27 test files, 346 tests pass
- [x] Borsh round-trip coverage: serialize/deserialize for all NEAR transaction types

🤖 Generated with [Claude Code](https://claude.com/claude-code)