### PR TITLE
Add standalone crypto utils and plain transaction builder

### DIFF
--- a/.changeset/inline-borsh-serializer.md
+++ b/.changeset/inline-borsh-serializer.md
@@ -1,0 +1,5 @@
+---
+"near-api-js": minor
+---
+
+Inline borsh serializer: replace the `borsh` npm dependency with a lean 289-line zero-dep serializer/deserializer tailored to NEAR's schema needs. The `serialize` and `deserialize` functions maintain the same API. This eliminates a transitive dependency tree and reduces install footprint.

--- a/.changeset/optional-json-validator.md
+++ b/.changeset/optional-json-validator.md
@@ -1,0 +1,5 @@
+---
+"near-api-js": minor
+---
+
+Make `is-my-json-valid` an optional dependency: ABI schema validation via `validateArguments` is now async and dynamically imports `is-my-json-valid` with a try/catch fallback. Environments without it installed will skip validation silently. The `ValidationError` type is inlined in `src/accounts/errors.ts`. Consumers using typed contracts with ABI validation should add `is-my-json-valid` to their own dependencies.

--- a/.changeset/plain-transaction-builder.md
+++ b/.changeset/plain-transaction-builder.md
@@ -1,0 +1,5 @@
+---
+"near-api-js": minor
+---
+
+Add plain transaction builder types and mappers: `PlainTransaction`, `PlainAction`, `PlainAccessKey`, `PlainSignedTransaction` interfaces for JSON-friendly transaction construction, plus `mapTransaction`, `mapAction`, and `mapSignedTransaction` functions to convert them into borsh-serializable format. This enables wallet implementations to build and serialize transactions without importing class-based APIs.

--- a/.changeset/standalone-crypto-utils.md
+++ b/.changeset/standalone-crypto-utils.md
@@ -1,0 +1,5 @@
+---
+"near-api-js": minor
+---
+
+Add standalone crypto utilities: `sha256`, `curveFromKey`, `keyFromString`, `keyToString`, `publicKeyFromPrivate`, `privateKeyFromRandom`, `signHash`, `signBytes`, and the `KeyCurve` type. These are exported from the top-level `near-api-js` entry point, enabling downstream consumers to use lightweight crypto helpers without constructing `KeyPair` class instances. Also adds `parseRpcError` re-export from providers and `actionCreators` alias for backwards compatibility with `@near-js/transactions`.

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 #IDE
 .idea
 .vscode
+.claude/
 
 storage
 node_modules

--- a/package.json
+++ b/package.json
@@ -47,9 +47,10 @@
         "@noble/curves": "2.0.1",
         "@noble/hashes": "2.0.1",
         "@scure/base": "2.0.0",
-        "borsh": "2.0.0",
-        "is-my-json-valid": "2.20.6",
         "near-seed-phrase": "0.2.1"
+    },
+    "optionalDependencies": {
+        "is-my-json-valid": "2.20.6"
     },
     "devDependencies": {
         "@arethetypeswrong/cli": "0.18.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,12 +20,6 @@ importers:
       '@scure/base':
         specifier: 2.0.0
         version: 2.0.0
-      borsh:
-        specifier: 2.0.0
-        version: 2.0.0
-      is-my-json-valid:
-        specifier: 2.20.6
-        version: 2.20.6
       near-seed-phrase:
         specifier: 0.2.1
         version: 0.2.1
@@ -90,6 +84,10 @@ importers:
       vitest:
         specifier: 4.0.17
         version: 4.0.17(@types/node@25.0.9)(@vitest/ui@4.0.17)(jiti@2.6.1)(yaml@2.8.1)
+    optionalDependencies:
+      is-my-json-valid:
+        specifier: 2.20.6
+        version: 2.20.6
 
   e2e:
     dependencies:

--- a/src/accounts/errors.ts
+++ b/src/accounts/errors.ts
@@ -1,4 +1,10 @@
-import type { ValidationError } from 'is-my-json-valid';
+/** Validation error shape from is-my-json-valid (optional dependency). */
+export interface ValidationError {
+    field: string;
+    message: string;
+    value: unknown;
+    type: string;
+}
 
 export class UnsupportedSerializationError extends Error {
     constructor(methodName: string, serializationType: string) {

--- a/src/accounts/typed_contract.ts
+++ b/src/accounts/typed_contract.ts
@@ -2,7 +2,6 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-type-constraint */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
-import validator from 'is-my-json-valid';
 import type { Provider } from '../providers/index.js';
 import type { BlockReference, TxExecutionStatus } from '../types/index.js';
 import type {
@@ -16,7 +15,7 @@ import type {
     SchemaObject,
 } from './abi_types.js';
 import type { Account } from './account.js';
-import { ArgumentSchemaError, UnknownArgumentError } from './errors.js';
+import { ArgumentSchemaError, UnknownArgumentError, type ValidationError } from './errors.js';
 
 type IsNullable<T> = [null] extends [T] ? true : false;
 
@@ -333,7 +332,7 @@ class RawContract<const abi extends AbiRoot, contractId extends string> {
                             const args = params.args ?? {};
 
                             if (abiFunction && abi) {
-                                validateArguments(args, abiFunction, abi);
+                                await validateArguments(args, abiFunction, abi);
                             }
 
                             return provider.callFunction({
@@ -365,7 +364,7 @@ class RawContract<const abi extends AbiRoot, contractId extends string> {
                             const args = params.args ?? {};
 
                             if (abiFunction && abi) {
-                                validateArguments(args, abiFunction, abi);
+                                await validateArguments(args, abiFunction, abi);
                             }
 
                             return params.account.callFunction({
@@ -390,11 +389,18 @@ class RawContract<const abi extends AbiRoot, contractId extends string> {
 
 export const Contract = RawContract as ContractConstructor;
 
-function validateArguments(args: object, abiFunction: AbiFunction, abiRoot: AbiRoot) {
+async function validateArguments(args: object, abiFunction: AbiFunction, abiRoot: AbiRoot) {
     if (typeof args !== 'object' || typeof abiFunction.params !== 'object') return;
 
     if (abiFunction.params.serialization_type === 'json') {
         const params = abiFunction.params.args;
+        let validator: (schema: unknown) => ((value: unknown) => boolean) & { errors: ValidationError[] };
+        try {
+            ({ default: validator } = await import('is-my-json-valid'));
+        } catch {
+            // is-my-json-valid is an optional dependency; skip validation if not installed
+            return;
+        }
         for (const p of params) {
             const arg = args[p.name];
             const typeSchema = p.type_schema;

--- a/src/borsh.ts
+++ b/src/borsh.ts
@@ -1,0 +1,289 @@
+/**
+ * Lean Borsh serializer/deserializer for NEAR Protocol.
+ * Supports: u8, u16, u32, u64, u128, string, struct, enum, array (fixed + dynamic), option.
+ */
+
+type SchemaScalar = 'u8' | 'u16' | 'u32' | 'u64' | 'u128' | 'string';
+type SchemaOption = { option: Schema };
+type SchemaArray = { array: { type: Schema; len?: number } };
+type SchemaStruct = { struct: Record<string, Schema> };
+type SchemaEnum = { enum: SchemaStruct[] };
+export type Schema = SchemaScalar | SchemaOption | SchemaArray | SchemaStruct | SchemaEnum;
+
+class EncodeBuffer {
+    offset = 0;
+    bufferSize = 256;
+    buffer = new ArrayBuffer(this.bufferSize);
+    view = new DataView(this.buffer);
+
+    resize(needed: number) {
+        if (this.bufferSize - this.offset < needed) {
+            this.bufferSize = Math.max(this.bufferSize * 2, this.bufferSize + needed);
+            const next = new ArrayBuffer(this.bufferSize);
+            new Uint8Array(next).set(new Uint8Array(this.buffer));
+            this.buffer = next;
+            this.view = new DataView(next);
+        }
+    }
+    storeU8(v: number) {
+        this.resize(1);
+        this.view.setUint8(this.offset, v);
+        this.offset += 1;
+    }
+    storeU16(v: number) {
+        this.resize(2);
+        this.view.setUint16(this.offset, v, true);
+        this.offset += 2;
+    }
+    storeU32(v: number) {
+        this.resize(4);
+        this.view.setUint32(this.offset, v, true);
+        this.offset += 4;
+    }
+    storeBytes(from: Uint8Array) {
+        this.resize(from.length);
+        new Uint8Array(this.buffer).set(from, this.offset);
+        this.offset += from.length;
+    }
+    result() {
+        return new Uint8Array(this.buffer).slice(0, this.offset);
+    }
+}
+
+class DecodeBuffer {
+    offset = 0;
+    view: DataView;
+    bytes: Uint8Array;
+
+    constructor(buf: Uint8Array) {
+        const ab = new ArrayBuffer(buf.length);
+        new Uint8Array(ab).set(buf);
+        this.view = new DataView(ab);
+        this.bytes = new Uint8Array(ab);
+    }
+    assert(size: number) {
+        if (this.offset + size > this.bytes.length) {
+            throw new Error('Borsh: buffer overrun');
+        }
+    }
+    readU8() {
+        this.assert(1);
+        const v = this.view.getUint8(this.offset);
+        this.offset += 1;
+        return v;
+    }
+    readU16() {
+        this.assert(2);
+        const v = this.view.getUint16(this.offset, true);
+        this.offset += 2;
+        return v;
+    }
+    readU32() {
+        this.assert(4);
+        const v = this.view.getUint32(this.offset, true);
+        this.offset += 4;
+        return v;
+    }
+    readBytes(len: number) {
+        this.assert(len);
+        const slice = this.bytes.slice(this.offset, this.offset + len);
+        this.offset += len;
+        return slice;
+    }
+}
+
+function encodeBigint(buf: EncodeBuffer, value: bigint, byteLen: number) {
+    const out = new Uint8Array(byteLen);
+    let v = value;
+    for (let i = 0; i < byteLen; i++) {
+        out[i] = Number(v & 0xffn);
+        v >>= 8n;
+    }
+    buf.storeBytes(out);
+}
+
+function decodeBigint(buf: DecodeBuffer, byteLen: number) {
+    const bytes = buf.readBytes(byteLen);
+    const hex = bytes.reduceRight((r, x) => r + x.toString(16).padStart(2, '0'), '');
+    return BigInt(`0x${hex}`);
+}
+
+function utf8Encode(str: string) {
+    const bytes: number[] = [];
+    for (let i = 0; i < str.length; i++) {
+        let c = str.charCodeAt(i);
+        if (c < 0x80) {
+            bytes.push(c);
+        } else if (c < 0x800) {
+            bytes.push(0xc0 | (c >> 6), 0x80 | (c & 0x3f));
+        } else if (c < 0xd800 || c >= 0xe000) {
+            bytes.push(0xe0 | (c >> 12), 0x80 | ((c >> 6) & 0x3f), 0x80 | (c & 0x3f));
+        } else {
+            i++;
+            c = 0x10000 + (((c & 0x3ff) << 10) | (str.charCodeAt(i) & 0x3ff));
+            bytes.push(0xf0 | (c >> 18), 0x80 | ((c >> 12) & 0x3f), 0x80 | ((c >> 6) & 0x3f), 0x80 | (c & 0x3f));
+        }
+    }
+    return new Uint8Array(bytes);
+}
+
+function utf8Decode(bytes: Uint8Array) {
+    const codePoints: number[] = [];
+    for (let i = 0; i < bytes.length; i++) {
+        const b = bytes[i]!;
+        if (b < 0x80) {
+            codePoints.push(b);
+        } else if (b < 0xe0) {
+            codePoints.push(((b & 0x1f) << 6) | (bytes[++i]! & 0x3f));
+        } else if (b < 0xf0) {
+            codePoints.push(((b & 0x0f) << 12) | ((bytes[++i]! & 0x3f) << 6) | (bytes[++i]! & 0x3f));
+        } else {
+            codePoints.push(
+                ((b & 0x07) << 18) | ((bytes[++i]! & 0x3f) << 12) | ((bytes[++i]! & 0x3f) << 6) | (bytes[++i]! & 0x3f)
+            );
+        }
+    }
+    return String.fromCodePoint(...codePoints);
+}
+
+function encodeValue(buf: EncodeBuffer, value: unknown, schema: Schema): void {
+    if (typeof schema === 'string') {
+        switch (schema) {
+            case 'u8':
+                buf.storeU8(value as number);
+                return;
+            case 'u16':
+                buf.storeU16(value as number);
+                return;
+            case 'u32':
+                buf.storeU32(value as number);
+                return;
+            case 'u64':
+                encodeBigint(buf, BigInt(value as number | bigint), 8);
+                return;
+            case 'u128':
+                encodeBigint(buf, BigInt(value as number | bigint), 16);
+                return;
+            case 'string': {
+                const encoded = utf8Encode(value as string);
+                buf.storeU32(encoded.length);
+                buf.storeBytes(encoded);
+                return;
+            }
+        }
+    }
+    if (typeof schema === 'object') {
+        if ('option' in schema) {
+            if (value === null || value === undefined) {
+                buf.storeU8(0);
+            } else {
+                buf.storeU8(1);
+                encodeValue(buf, value, schema.option);
+            }
+            return;
+        }
+        if ('enum' in schema) {
+            const obj = value as Record<string, unknown>;
+            const valueKey = Object.keys(obj)[0];
+            const variants = schema.enum;
+            for (let i = 0; i < variants.length; i++) {
+                const variant = variants[i]!;
+                const variantKey = Object.keys(variant.struct)[0];
+                if (valueKey === variantKey) {
+                    buf.storeU8(i);
+                    encodeStruct(buf, obj, variant);
+                    return;
+                }
+            }
+            throw new Error(`Borsh: enum key "${valueKey}" not found in schema`);
+        }
+        if ('array' in schema) {
+            const arr = value as unknown[];
+            if (schema.array.len == null) {
+                buf.storeU32(arr.length);
+            }
+            for (let i = 0; i < arr.length; i++) {
+                encodeValue(buf, arr[i], schema.array.type);
+            }
+            return;
+        }
+        if ('struct' in schema) {
+            encodeStruct(buf, value as Record<string, unknown>, schema);
+            return;
+        }
+    }
+}
+
+function encodeStruct(buf: EncodeBuffer, value: Record<string, unknown>, schema: SchemaStruct) {
+    for (const key of Object.keys(schema.struct)) {
+        encodeValue(buf, value[key], schema.struct[key]!);
+    }
+}
+
+function decodeValue(buf: DecodeBuffer, schema: Schema): unknown {
+    if (typeof schema === 'string') {
+        switch (schema) {
+            case 'u8':
+                return buf.readU8();
+            case 'u16':
+                return buf.readU16();
+            case 'u32':
+                return buf.readU32();
+            case 'u64':
+                return decodeBigint(buf, 8);
+            case 'u128':
+                return decodeBigint(buf, 16);
+            case 'string': {
+                const len = buf.readU32();
+                return utf8Decode(buf.readBytes(len));
+            }
+        }
+    }
+    if (typeof schema === 'object') {
+        if ('option' in schema) {
+            const flag = buf.readU8();
+            if (flag === 1) return decodeValue(buf, schema.option);
+            if (flag === 0) return null;
+            throw new Error(`Borsh: invalid option flag ${flag}`);
+        }
+        if ('enum' in schema) {
+            const idx = buf.readU8();
+            if (idx >= schema.enum.length) {
+                throw new Error(`Borsh: enum index ${idx} out of range`);
+            }
+            const variant = schema.enum[idx]!;
+            const result: Record<string, unknown> = {};
+            for (const key of Object.keys(variant.struct)) {
+                result[key] = decodeValue(buf, variant.struct[key]!);
+            }
+            return result;
+        }
+        if ('array' in schema) {
+            const len = schema.array.len ?? buf.readU32();
+            const result: unknown[] = [];
+            for (let i = 0; i < len; i++) {
+                result.push(decodeValue(buf, schema.array.type));
+            }
+            return result;
+        }
+        if ('struct' in schema) {
+            const result: Record<string, unknown> = {};
+            for (const key in schema.struct) {
+                result[key] = decodeValue(buf, schema.struct[key]!);
+            }
+            return result;
+        }
+    }
+    throw new Error(`Borsh: unsupported schema: ${JSON.stringify(schema)}`);
+}
+
+export function serialize(schema: Schema, value: unknown): Uint8Array {
+    const buf = new EncodeBuffer();
+    encodeValue(buf, value, schema);
+    return buf.result();
+}
+
+export function deserialize(schema: Schema, buffer: Uint8Array): unknown {
+    const buf = new DecodeBuffer(buffer);
+    return decodeValue(buf, schema);
+}

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -5,3 +5,14 @@ export type { Signature } from './key_pair_base.js';
 export { KeyPairEd25519 } from './key_pair_ed25519.js';
 export { KeyPairSecp256k1 } from './key_pair_secp256k1.js';
 export { keyToImplicitAddress, PublicKey } from './public_key.js';
+export type { KeyCurve } from './utils.js';
+export {
+    sha256,
+    curveFromKey,
+    keyFromString,
+    keyToString,
+    publicKeyFromPrivate,
+    privateKeyFromRandom,
+    signHash,
+    signBytes,
+} from './utils.js';

--- a/src/crypto/utils.ts
+++ b/src/crypto/utils.ts
@@ -1,0 +1,116 @@
+import { ed25519 } from '@noble/curves/ed25519.js';
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+import { sha256 } from '@noble/hashes/sha2.js';
+import { baseDecode, baseEncode } from '../utils/format.js';
+
+import type { KeyPairString } from './constants.js';
+
+export { sha256 };
+
+export type KeyCurve = 'ed25519' | 'secp256k1';
+
+/**
+ * Extract the curve type from a key string like "ed25519:..." or "secp256k1:..."
+ * Defaults to ed25519 if no prefix is present.
+ */
+export function curveFromKey(key: string): KeyCurve {
+    if (!key.includes(':')) return 'ed25519';
+    const curve = key.split(':')[0];
+    if (curve === 'ed25519' || curve === 'secp256k1') return curve;
+    throw new Error(`Unsupported curve: ${curve}`);
+}
+
+/**
+ * Decode the base58 portion of a key string (after the "curve:" prefix).
+ */
+export function keyFromString(key: string): Uint8Array {
+    const raw = key.includes(':') ? key.split(':')[1]! : key;
+    return baseDecode(raw);
+}
+
+/**
+ * Encode a raw key byte array into a prefixed key string like "ed25519:base58key".
+ */
+export function keyToString(key: Uint8Array, curve: KeyCurve = 'ed25519'): KeyPairString {
+    return `${curve}:${baseEncode(key)}` as KeyPairString;
+}
+
+/**
+ * Derive the public key string from a private key string.
+ * Supports both ed25519 and secp256k1 curves.
+ *
+ * @param privateKey Key string like "ed25519:base58..." or "secp256k1:base58..."
+ * @returns Public key string like "ed25519:base58..." or "secp256k1:base58..."
+ */
+export function publicKeyFromPrivate(privateKey: string): KeyPairString {
+    const curve = curveFromKey(privateKey);
+    if (curve === 'secp256k1') {
+        const secret = keyFromString(privateKey);
+        const fullPk = secp256k1.getPublicKey(secret, false);
+        const publicKey = fullPk.slice(1); // strip 0x04 prefix — NEAR stores 64 bytes (x‖y)
+        return keyToString(publicKey, 'secp256k1');
+    }
+    const secret = keyFromString(privateKey).slice(0, 32);
+    const publicKey = ed25519.getPublicKey(secret);
+    return keyToString(publicKey);
+}
+
+/**
+ * Generate a random private key string for the given curve.
+ *
+ * @param curve Key curve, defaults to 'ed25519'
+ * @returns Private key string like "ed25519:base58..."
+ */
+export function privateKeyFromRandom(curve: KeyCurve = 'ed25519'): KeyPairString {
+    const size = curve === 'secp256k1' ? 32 : 64;
+    const privateKey = crypto.getRandomValues(new Uint8Array(size));
+    return keyToString(privateKey, curve);
+}
+
+/**
+ * Sign a hash (pre-hashed message) with a private key string.
+ * For ed25519, the hash is signed directly.
+ * For secp256k1, produces a 65-byte signature in NEAR's [r, s, v] format.
+ *
+ * @param hashBytes The hash bytes to sign
+ * @param privateKey Key string like "ed25519:base58..." or "secp256k1:base58..."
+ * @returns The signature as Uint8Array (or base58 string if opts.returnBase58 is true)
+ */
+export function signHash(
+    hashBytes: Uint8Array,
+    privateKey: string,
+    opts?: { returnBase58?: boolean }
+): Uint8Array | string {
+    const curve = curveFromKey(privateKey);
+
+    let signature: Uint8Array;
+    if (curve === 'secp256k1') {
+        const secret = keyFromString(privateKey);
+        const raw = secp256k1.sign(hashBytes, secret, { prehash: false, format: 'recovered' });
+        // 'recovered' format: [v(1), r(32), s(32)] → NEAR expects [r(32), s(32), v(1)]
+        signature = new Uint8Array(65);
+        signature.set(raw.slice(1, 33), 0); // r
+        signature.set(raw.slice(33, 65), 32); // s
+        signature[64] = raw[0]!; // v
+    } else {
+        const secret = keyFromString(privateKey).slice(0, 32);
+        signature = ed25519.sign(hashBytes, secret);
+    }
+
+    if (opts?.returnBase58) {
+        return baseEncode(signature);
+    }
+    return signature;
+}
+
+/**
+ * Hash bytes with sha256 then sign with the private key.
+ *
+ * @param bytes The raw bytes to hash and sign
+ * @param privateKey Key string like "ed25519:base58..." or "secp256k1:base58..."
+ * @returns The signature as Uint8Array
+ */
+export function signBytes(bytes: Uint8Array, privateKey: string): Uint8Array | string {
+    const hash = sha256(bytes);
+    return signHash(hash, privateKey);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,10 @@ export * from './transactions/index.js';
 export * from './types/index.js';
 export { gigaToGas, nearToYocto, teraToGas, yoctoToNear } from './units/index.js';
 // ============================================================================
+// Serialization (Borsh)
+// ============================================================================
+export { serialize, deserialize, type Schema } from './borsh.js';
+// ============================================================================
 // Utilities
 // ============================================================================
 export * from './utils/index.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@
 export * from './accounts/index.js';
 export type {
     CurveType,
+    KeyCurve,
     KeyPairString,
     Signature as CryptoSignature,
 } from './crypto/index.js';
@@ -22,6 +23,14 @@ export {
     KeyType,
     keyToImplicitAddress,
     PublicKey,
+    sha256,
+    curveFromKey,
+    keyFromString,
+    keyToString,
+    publicKeyFromPrivate,
+    privateKeyFromRandom,
+    signHash,
+    signBytes,
 } from './crypto/index.js';
 // ============================================================================
 // Providers

--- a/src/nep413/schema.ts
+++ b/src/nep413/schema.ts
@@ -1,5 +1,5 @@
 import { sha256 } from '@noble/hashes/sha2.js';
-import { type Schema, serialize } from 'borsh';
+import { type Schema, serialize } from '../borsh.js';
 
 export interface MessagePayload {
     message: string; // The message that wants to be transmitted.

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,3 +1,4 @@
+export { parseRpcError } from './errors/parse.js';
 export { exponentialBackoff } from './exponential-backoff.js';
 export { FailoverRpcProvider } from './failover-rpc-provider.js';
 export { JsonRpcProvider } from './json-rpc-provider.js';

--- a/src/transactions/action_creators.ts
+++ b/src/transactions/action_creators.ts
@@ -239,6 +239,10 @@ function useGlobalContract(contractIdentifier: { accountId: string } | { codeHas
     return new Action({ useGlobalContract: new UseGlobalContract({ contractIdentifier: identifier }) });
 }
 
+/**
+ * Action creator functions for building NEAR transaction actions.
+ * @alias actionCreators
+ */
 export const actions = {
     addFullAccessKey,
     addFunctionCallAccessKey,
@@ -255,3 +259,6 @@ export const actions = {
     deployGlobalContract,
     useGlobalContract,
 };
+
+/** @deprecated Use {@link actions} instead. Alias for backwards compatibility with @near-js/transactions. */
+export const actionCreators = actions;

--- a/src/transactions/index.ts
+++ b/src/transactions/index.ts
@@ -1,6 +1,7 @@
 export * from './action_creators.js';
-export type * from './actions.js';
+export * from './actions.js';
 export * from './create_transaction.js';
 export * from './delegate.js';
+export * from './plain.js';
 export * from './schema.js';
 export * from './signature.js';

--- a/src/transactions/plain.ts
+++ b/src/transactions/plain.ts
@@ -1,0 +1,158 @@
+import { curveFromKey, keyFromString } from '../crypto/utils.js';
+import { base64Decode, baseDecode } from '../utils/format.js';
+
+/**
+ * A plain JSON-friendly transaction object that can be easily constructed
+ * without needing to import classes. Use {@link mapTransaction} to convert
+ * to a borsh-serializable format compatible with {@link SCHEMA}.
+ */
+export interface PlainTransaction {
+    signerId: string;
+    publicKey: string;
+    nonce: string | bigint | number;
+    receiverId: string;
+    blockHash: string;
+    actions: PlainAction[];
+}
+
+export interface PlainSignedTransaction {
+    transaction: object;
+    signature: object;
+}
+
+export type PlainAction =
+    | { type: 'CreateAccount' }
+    | { type: 'DeployContract'; codeBase64: string }
+    | {
+          type: 'FunctionCall';
+          methodName: string;
+          args?: object;
+          argsBase64?: string;
+          gas?: string | number;
+          deposit?: string | number;
+      }
+    | { type: 'Transfer'; deposit: string | number }
+    | { type: 'Stake'; stake: string | number; publicKey: string }
+    | { type: 'AddKey'; publicKey: string; accessKey: PlainAccessKey }
+    | { type: 'DeleteKey'; publicKey: string }
+    | { type: 'DeleteAccount'; beneficiaryId: string }
+    | { type: 'SignedDelegate'; delegateAction: PlainAction; signature: string; publicKey: string };
+
+export interface PlainAccessKey {
+    nonce: string | bigint | number;
+    permission:
+        | 'FullAccess'
+        | {
+              receiverId: string;
+              methodNames: string[];
+              allowance?: string | number | null;
+          };
+}
+
+function mapPublicKey(keyString: string) {
+    const curve = curveFromKey(keyString);
+    const data = keyFromString(keyString);
+    return curve === 'secp256k1' ? { secp256k1Key: { data } } : { ed25519Key: { data } };
+}
+
+function mapSignature(sigBase58: string, signerKeyString: string) {
+    const curve = curveFromKey(signerKeyString);
+    const data = baseDecode(sigBase58);
+    return curve === 'secp256k1' ? { secp256k1Signature: { data } } : { ed25519Signature: { data } };
+}
+
+/**
+ * Convert a {@link PlainTransaction} (plain JSON object) into a borsh-serializable
+ * object matching the transaction SCHEMA. Use with `serialize(SCHEMA.Transaction, ...)`.
+ */
+export function mapTransaction(jsonTransaction: PlainTransaction) {
+    return {
+        signerId: jsonTransaction.signerId,
+        publicKey: mapPublicKey(jsonTransaction.publicKey),
+        nonce: BigInt(jsonTransaction.nonce),
+        receiverId: jsonTransaction.receiverId,
+        blockHash: baseDecode(jsonTransaction.blockHash),
+        actions: jsonTransaction.actions.map(mapAction),
+    };
+}
+
+/**
+ * Convert a {@link PlainTransaction} and base58 signature into a borsh-serializable
+ * signed transaction object matching SCHEMA.SignedTransaction.
+ */
+export function mapSignedTransaction(jsonTransaction: PlainTransaction, signature: string): PlainSignedTransaction {
+    return {
+        transaction: mapTransaction(jsonTransaction),
+        signature: mapSignature(signature, jsonTransaction.publicKey),
+    };
+}
+
+const textEncoder = new TextEncoder();
+
+/**
+ * Convert a plain action object (with `type` discriminator) into the borsh-serializable
+ * format expected by the transaction SCHEMA.
+ */
+export function mapAction(action: PlainAction): object {
+    switch (action.type) {
+        case 'CreateAccount':
+            return { createAccount: {} };
+        case 'DeployContract':
+            return { deployContract: { code: base64Decode(action.codeBase64) } };
+        case 'FunctionCall':
+            return {
+                functionCall: {
+                    methodName: action.methodName,
+                    args:
+                        action.argsBase64 != null
+                            ? base64Decode(action.argsBase64)
+                            : textEncoder.encode(JSON.stringify(action.args)),
+                    gas: BigInt(action.gas ?? '300000000000000'),
+                    deposit: BigInt(action.deposit ?? '0'),
+                },
+            };
+        case 'Transfer':
+            return { transfer: { deposit: BigInt(action.deposit) } };
+        case 'Stake':
+            return {
+                stake: {
+                    stake: BigInt(action.stake),
+                    publicKey: mapPublicKey(action.publicKey),
+                },
+            };
+        case 'AddKey':
+            return {
+                addKey: {
+                    publicKey: mapPublicKey(action.publicKey),
+                    accessKey: {
+                        nonce: BigInt(action.accessKey.nonce),
+                        permission:
+                            action.accessKey.permission === 'FullAccess'
+                                ? { fullAccess: {} }
+                                : {
+                                      functionCall: {
+                                          allowance: action.accessKey.permission.allowance
+                                              ? BigInt(action.accessKey.permission.allowance)
+                                              : null,
+                                          receiverId: action.accessKey.permission.receiverId,
+                                          methodNames: action.accessKey.permission.methodNames,
+                                      },
+                                  },
+                    },
+                },
+            };
+        case 'DeleteKey':
+            return { deleteKey: { publicKey: mapPublicKey(action.publicKey) } };
+        case 'DeleteAccount':
+            return { deleteAccount: { beneficiaryId: action.beneficiaryId } };
+        case 'SignedDelegate':
+            return {
+                signedDelegate: {
+                    delegateAction: mapAction(action.delegateAction),
+                    signature: mapSignature(action.signature, action.publicKey),
+                },
+            };
+        default:
+            throw new Error(`Not implemented action: ${(action as PlainAction).type}`);
+    }
+}

--- a/src/transactions/schema.ts
+++ b/src/transactions/schema.ts
@@ -1,4 +1,4 @@
-import { deserialize, type Schema, serialize } from 'borsh';
+import { deserialize, type Schema, serialize } from '../borsh.js';
 import { PublicKey } from '../crypto/index.js';
 
 import type { Action, SignedDelegate } from './actions.js';

--- a/test/unit/signers/key_pair_signer.test.ts
+++ b/test/unit/signers/key_pair_signer.test.ts
@@ -1,6 +1,6 @@
 import { sha256 } from '@noble/hashes/sha2.js';
-import { serialize } from 'borsh';
 import { expect, test } from 'vitest';
+import { serialize } from '../../../src/borsh.js';
 import {
     actions as actionCreators,
     buildDelegateAction,

--- a/test/unit/transactions/serialize.test.ts
+++ b/test/unit/transactions/serialize.test.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs';
 import { sha256 } from '@noble/hashes/sha2.js';
-import { deserialize, serialize } from 'borsh';
 import { describe, expect, test } from 'vitest';
+import { deserialize, serialize } from '../../../src/borsh.js';
 
 import {
     actions,


### PR DESCRIPTION
Addressing #1876 and utilizing the efficiencies of the flat utilities we created in FastNearJS and bringing it in as a new package. The results of compilation sizes is what's driving the reason behind this. So it's effectively a duplicate workspace package, but would be great if I sunset FastNearJS and we just have it here, in the OG repo

## Summary

New public API surface enabling downstream consumers (near-connect wallets) to import crypto + transaction helpers directly from near-api-js instead of @fastnear/utils.

- **Crypto utils** — `sha256`, `curveFromKey`, `keyFromString`, `keyToString`, `publicKeyFromPrivate`, `privateKeyFromRandom`, `signHash`, `signBytes`
- **Plain transaction types** — `PlainTransaction`, `PlainAction`, `PlainAccessKey` + `mapTransaction`, `mapAction`, `mapSignedTransaction` for converting JSON-friendly objects to borsh-serializable format
- **Re-exports** — `parseRpcError` from providers, `actionCreators` alias for backwards compat with @near-js/transactions

**Depends on:** #1894 (inline borsh). Merge #1894 first, then rebase this.

## Changes

| File | Change |
|------|--------|
| `src/crypto/utils.ts` | New — standalone crypto utilities |
| `src/crypto/index.ts` | Re-export new utils |
| `src/transactions/plain.ts` | New — PlainTransaction types + mappers |
| `src/transactions/index.ts` | Add `export * from './plain.js'`; `export type *` → `export *` for actions |
| `src/transactions/action_creators.ts` | Add `actionCreators` alias |
| `src/providers/index.ts` | Add `export { parseRpcError }` |
| `src/index.ts` | Re-export crypto utils + KeyCurve type |

## Test plan

- [x] `pnpm compile` (tsc) — no errors
- [x] `pnpm test` — all 27 test files, 346 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)