### PR TITLE
Switch build from tsc to tsup (ESM + CJS + IIFE)

### DIFF
--- a/.changeset/iife-browser-shims.md
+++ b/.changeset/iife-browser-shims.md
@@ -1,0 +1,5 @@
+---
+"near-api-js": minor
+---
+
+Add lightweight browser shims for the IIFE bundle: `error-parse-lite.ts` replaces the ~62KB error class hierarchy with a generic `RpcError` parser (preserving `InvalidNonceError` for nonce retry logic), `json-validator-noop.ts` stubs out the ~44KB `is-my-json-valid` dependency, and `util.ts` provides a minimal `util.format` shim. These save ~116KB in the browser bundle while maintaining full functionality in ESM/CJS builds.

--- a/.changeset/inline-borsh-serializer.md
+++ b/.changeset/inline-borsh-serializer.md
@@ -1,0 +1,5 @@
+---
+"near-api-js": minor
+---
+
+Inline borsh serializer: replace the `borsh` npm dependency with a lean 289-line zero-dep serializer/deserializer tailored to NEAR's schema needs. The `serialize` and `deserialize` functions maintain the same API. This eliminates a transitive dependency tree and reduces install footprint.

--- a/.changeset/optional-json-validator.md
+++ b/.changeset/optional-json-validator.md
@@ -1,0 +1,5 @@
+---
+"near-api-js": minor
+---
+
+Make `is-my-json-valid` an optional dependency: ABI schema validation via `validateArguments` is now async and dynamically imports `is-my-json-valid` with a try/catch fallback. Environments without it installed will skip validation silently. The `ValidationError` type is inlined in `src/accounts/errors.ts`. Consumers using typed contracts with ABI validation should add `is-my-json-valid` to their own dependencies.

--- a/.changeset/plain-transaction-builder.md
+++ b/.changeset/plain-transaction-builder.md
@@ -1,0 +1,5 @@
+---
+"near-api-js": minor
+---
+
+Add plain transaction builder types and mappers: `PlainTransaction`, `PlainAction`, `PlainAccessKey`, `PlainSignedTransaction` interfaces for JSON-friendly transaction construction, plus `mapTransaction`, `mapAction`, and `mapSignedTransaction` functions to convert them into borsh-serializable format. This enables wallet implementations to build and serialize transactions without importing class-based APIs.

--- a/.changeset/standalone-crypto-utils.md
+++ b/.changeset/standalone-crypto-utils.md
@@ -1,0 +1,5 @@
+---
+"near-api-js": minor
+---
+
+Add standalone crypto utilities: `sha256`, `curveFromKey`, `keyFromString`, `keyToString`, `publicKeyFromPrivate`, `privateKeyFromRandom`, `signHash`, `signBytes`, and the `KeyCurve` type. These are exported from the top-level `near-api-js` entry point, enabling downstream consumers to use lightweight crypto helpers without constructing `KeyPair` class instances. Also adds `parseRpcError` re-export from providers and `actionCreators` alias for backwards compatibility with `@near-js/transactions`.

--- a/.changeset/tsup-triple-build.md
+++ b/.changeset/tsup-triple-build.md
@@ -1,0 +1,5 @@
+---
+"near-api-js": minor
+---
+
+Switch build from tsc to tsup, producing three output formats: ESM (unbundled, tree-shakeable), CJS (unbundled with `.cjs` extensions), and IIFE (fully bundled 252KB browser build). The `exports` field now provides proper `import`/`require`/`types` conditions for all subpath exports. Output moves from `lib/` to `dist/`. Consumers using deep imports from `lib/` should update to the documented subpath exports (`.`, `./tokens`, `./nep413`, `./seed-phrase`, `./rpc-errors`).

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 #IDE
 .idea
 .vscode
+.claude/
 
 storage
 node_modules

--- a/package.json
+++ b/package.json
@@ -13,34 +13,80 @@
     "packageManager": "pnpm@10.28.0",
     "homepage": "https://github.com/near/near-api-js",
     "type": "module",
+    "types": "./dist/esm/index.d.ts",
+    "main": "./dist/cjs/index.cjs",
+    "module": "./dist/esm/index.js",
+    "browser": "./dist/umd/browser.global.js",
     "exports": {
         ".": {
-            "import": "./lib/index.js",
-            "types": "./lib/index.d.ts"
+            "import": {
+                "types": "./dist/esm/index.d.ts",
+                "default": "./dist/esm/index.js"
+            },
+            "require": {
+                "types": "./dist/cjs/index.d.cts",
+                "default": "./dist/cjs/index.cjs"
+            }
         },
         "./tokens": {
-            "import": "./lib/tokens/index.js",
-            "types": "./lib/tokens/index.d.ts"
+            "import": {
+                "types": "./dist/esm/tokens/index.d.ts",
+                "default": "./dist/esm/tokens/index.js"
+            },
+            "require": {
+                "types": "./dist/cjs/tokens/index.d.cts",
+                "default": "./dist/cjs/tokens/index.cjs"
+            }
         },
         "./tokens/mainnet": {
-            "import": "./lib/tokens/mainnet/index.js",
-            "types": "./lib/tokens/mainnet/index.d.ts"
+            "import": {
+                "types": "./dist/esm/tokens/mainnet/index.d.ts",
+                "default": "./dist/esm/tokens/mainnet/index.js"
+            },
+            "require": {
+                "types": "./dist/cjs/tokens/mainnet/index.d.cts",
+                "default": "./dist/cjs/tokens/mainnet/index.cjs"
+            }
         },
         "./tokens/testnet": {
-            "import": "./lib/tokens/testnet/index.js",
-            "types": "./lib/tokens/testnet/index.d.ts"
+            "import": {
+                "types": "./dist/esm/tokens/testnet/index.d.ts",
+                "default": "./dist/esm/tokens/testnet/index.js"
+            },
+            "require": {
+                "types": "./dist/cjs/tokens/testnet/index.d.cts",
+                "default": "./dist/cjs/tokens/testnet/index.cjs"
+            }
         },
         "./nep413": {
-            "import": "./lib/nep413/index.js",
-            "types": "./lib/nep413/index.d.ts"
+            "import": {
+                "types": "./dist/esm/nep413/index.d.ts",
+                "default": "./dist/esm/nep413/index.js"
+            },
+            "require": {
+                "types": "./dist/cjs/nep413/index.d.cts",
+                "default": "./dist/cjs/nep413/index.cjs"
+            }
         },
         "./seed-phrase": {
-            "import": "./lib/seed-phrase/index.js",
-            "types": "./lib/seed-phrase/index.d.ts"
+            "import": {
+                "types": "./dist/esm/seed-phrase/index.d.ts",
+                "default": "./dist/esm/seed-phrase/index.js"
+            },
+            "require": {
+                "types": "./dist/cjs/seed-phrase/index.d.cts",
+                "default": "./dist/cjs/seed-phrase/index.cjs"
+            }
         },
         "./rpc-errors": {
-            "import": "./lib/rpc-errors/index.js",
-            "types": "./lib/rpc-errors/index.d.ts"
+            "import": {
+                "types": "./dist/esm/rpc-errors/index.d.ts",
+                "default": "./dist/esm/rpc-errors/index.js"
+            },
+            "require": {
+                "types": "./dist/cjs/rpc-errors/index.d.cts",
+                "default": "./dist/cjs/rpc-errors/index.cjs"
+            }
         }
     },
     "dependencies": {
@@ -70,37 +116,48 @@
         "rimraf": "6.1.2",
         "semver": "7.7.3",
         "ts-node": "10.9.2",
+        "tsup": "^8.5.1",
         "typedoc": "0.28.16",
         "typescript": "5.9.3",
         "vitest": "4.0.17"
     },
-    "keywords": [],
+    "keywords": [
+        "near-protocol",
+        "blockchain",
+        "web3",
+        "rpc",
+        "crypto",
+        "transactions"
+    ],
     "license": "(MIT AND Apache-2.0)",
     "scripts": {
         "compile": "tsc -p ./tsconfig.build.json",
         "dev": "pnpm compile -w",
         "prebuild": "pnpm clean",
-        "build": "tsc -p ./tsconfig.build.json",
+        "build": "tsup && node scripts/fix-cjs-imports.js",
+        "build:tsc": "tsc -p ./tsconfig.build.json",
         "test": "vitest run test",
         "typecheck": "tsc --noEmit -p ./tsconfig.json",
         "lint": "biome check",
         "prefuzz": "pnpm build",
         "fuzz": "jsfuzz test/fuzz/borsh-roundtrip.js test/fuzz/corpus/",
-        "clean": "pnpm rimraf lib",
-        "check-exports": "attw --pack . --ignore-rules cjs-resolves-to-esm no-resolution",
+        "clean": "pnpm rimraf lib dist",
+        "check-exports": "attw --pack . --ignore-rules no-resolution",
         "docs:generate": "typedoc",
-        "autoclave": "rimraf lib && rimraf node_modules && rimraf coverage && rimraf node_modules && rimraf e2e/node_modules && rimraf e2e/coverage && rimraf e2e/tests/node_modules",
+        "autoclave": "rimraf lib && rimraf dist && rimraf node_modules && rimraf coverage && rimraf node_modules && rimraf e2e/node_modules && rimraf e2e/coverage && rimraf e2e/tests/node_modules",
         "release": "changeset publish",
         "rpc:generate": "pnpm openapi-ts",
         "postrpc:generate": "biome check --fix"
     },
     "files": [
-        "lib",
         "dist"
     ],
     "author": "NEAR Inc",
     "sideEffects": false,
     "resolutions": {
         "near-sandbox": "0.0.18"
+    },
+    "pnpm": {
+        "onlyBuiltDependencies": ["esbuild"]
     }
 }

--- a/package.json
+++ b/package.json
@@ -19,74 +19,32 @@
     "browser": "./dist/umd/browser.global.js",
     "exports": {
         ".": {
-            "import": {
-                "types": "./dist/esm/index.d.ts",
-                "default": "./dist/esm/index.js"
-            },
-            "require": {
-                "types": "./dist/cjs/index.d.cts",
-                "default": "./dist/cjs/index.cjs"
-            }
+            "require": "./dist/cjs/index.cjs",
+            "import": "./dist/esm/index.js"
         },
         "./tokens": {
-            "import": {
-                "types": "./dist/esm/tokens/index.d.ts",
-                "default": "./dist/esm/tokens/index.js"
-            },
-            "require": {
-                "types": "./dist/cjs/tokens/index.d.cts",
-                "default": "./dist/cjs/tokens/index.cjs"
-            }
+            "require": "./dist/cjs/tokens/index.cjs",
+            "import": "./dist/esm/tokens/index.js"
         },
         "./tokens/mainnet": {
-            "import": {
-                "types": "./dist/esm/tokens/mainnet/index.d.ts",
-                "default": "./dist/esm/tokens/mainnet/index.js"
-            },
-            "require": {
-                "types": "./dist/cjs/tokens/mainnet/index.d.cts",
-                "default": "./dist/cjs/tokens/mainnet/index.cjs"
-            }
+            "require": "./dist/cjs/tokens/mainnet/index.cjs",
+            "import": "./dist/esm/tokens/mainnet/index.js"
         },
         "./tokens/testnet": {
-            "import": {
-                "types": "./dist/esm/tokens/testnet/index.d.ts",
-                "default": "./dist/esm/tokens/testnet/index.js"
-            },
-            "require": {
-                "types": "./dist/cjs/tokens/testnet/index.d.cts",
-                "default": "./dist/cjs/tokens/testnet/index.cjs"
-            }
+            "require": "./dist/cjs/tokens/testnet/index.cjs",
+            "import": "./dist/esm/tokens/testnet/index.js"
         },
         "./nep413": {
-            "import": {
-                "types": "./dist/esm/nep413/index.d.ts",
-                "default": "./dist/esm/nep413/index.js"
-            },
-            "require": {
-                "types": "./dist/cjs/nep413/index.d.cts",
-                "default": "./dist/cjs/nep413/index.cjs"
-            }
+            "require": "./dist/cjs/nep413/index.cjs",
+            "import": "./dist/esm/nep413/index.js"
         },
         "./seed-phrase": {
-            "import": {
-                "types": "./dist/esm/seed-phrase/index.d.ts",
-                "default": "./dist/esm/seed-phrase/index.js"
-            },
-            "require": {
-                "types": "./dist/cjs/seed-phrase/index.d.cts",
-                "default": "./dist/cjs/seed-phrase/index.cjs"
-            }
+            "require": "./dist/cjs/seed-phrase/index.cjs",
+            "import": "./dist/esm/seed-phrase/index.js"
         },
         "./rpc-errors": {
-            "import": {
-                "types": "./dist/esm/rpc-errors/index.d.ts",
-                "default": "./dist/esm/rpc-errors/index.js"
-            },
-            "require": {
-                "types": "./dist/cjs/rpc-errors/index.d.cts",
-                "default": "./dist/cjs/rpc-errors/index.cjs"
-            }
+            "require": "./dist/cjs/rpc-errors/index.cjs",
+            "import": "./dist/esm/rpc-errors/index.js"
         }
     },
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -47,9 +47,10 @@
         "@noble/curves": "2.0.1",
         "@noble/hashes": "2.0.1",
         "@scure/base": "2.0.0",
-        "borsh": "2.0.0",
-        "is-my-json-valid": "2.20.6",
         "near-seed-phrase": "0.2.1"
+    },
+    "optionalDependencies": {
+        "is-my-json-valid": "2.20.6"
     },
     "devDependencies": {
         "@arethetypeswrong/cli": "0.18.2",

--- a/package.json
+++ b/package.json
@@ -158,6 +158,8 @@
         "near-sandbox": "0.0.18"
     },
     "pnpm": {
-        "onlyBuiltDependencies": ["esbuild"]
+        "onlyBuiltDependencies": [
+            "esbuild"
+        ]
     }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       ts-node:
         specifier: 10.9.2
         version: 10.9.2(@types/node@25.0.9)(typescript@5.9.3)
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(typescript@5.9.3)(yaml@2.8.1)
       typedoc:
         specifier: 0.28.16
         version: 0.28.16(typescript@5.9.3)
@@ -351,8 +354,20 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.27.3':
+    resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.25.12':
     resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.27.3':
+    resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -363,8 +378,20 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.27.3':
+    resolution: {integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.25.12':
     resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.3':
+    resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -375,8 +402,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.27.3':
+    resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.25.12':
     resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.3':
+    resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -387,8 +426,20 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.27.3':
+    resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.25.12':
     resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.3':
+    resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -399,8 +450,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.27.3':
+    resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.25.12':
     resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.3':
+    resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -411,8 +474,20 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.27.3':
+    resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.25.12':
     resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.3':
+    resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -423,8 +498,20 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.27.3':
+    resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.25.12':
     resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.3':
+    resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -435,8 +522,20 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.27.3':
+    resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.25.12':
     resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.3':
+    resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -447,8 +546,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.27.3':
+    resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.25.12':
     resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -459,8 +570,20 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.27.3':
+    resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.25.12':
     resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -471,8 +594,20 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.27.3':
+    resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.25.12':
     resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -483,8 +618,20 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.27.3':
+    resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.25.12':
     resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.27.3':
+    resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -495,8 +642,20 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.27.3':
+    resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.25.12':
     resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.3':
+    resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -537,6 +696,9 @@ packages:
   '@isaacs/brace-expansion@5.0.0':
     resolution: {integrity: sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==}
     engines: {node: 20 || >=22}
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
@@ -949,6 +1111,11 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  acorn@8.16.0:
+    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
   ajv@8.17.1:
     resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
 
@@ -1048,6 +1215,12 @@ packages:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
 
+  bundle-require@5.1.0:
+    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    peerDependencies:
+      esbuild: '>=0.18'
+
   c12@3.3.3:
     resolution: {integrity: sha512-750hTRvgBy5kcMNPdh95Qo+XUBeGo8C7nsKSmedDmaQI+E0r82DwHeM6vBewDe4rGFbnxoa4V9pw+sPh5+Iz8Q==}
     peerDependencies:
@@ -1115,6 +1288,10 @@ packages:
     resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
     engines: {node: '>= 16'}
 
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
@@ -1175,6 +1352,10 @@ packages:
     resolution: {integrity: sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ==}
     engines: {node: '>=20'}
 
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
+
   commitlint@20.3.1:
     resolution: {integrity: sha512-E5VhXRrKjVGpehHOhTzSBwI3x3Uefnf5KSPggiJfKUMFyXZetZimVMEJYqa66JPRLDF/Ewgw0qbWXXz+eqdM1Q==}
     engines: {node: '>=v18'}
@@ -1182,6 +1363,9 @@ packages:
 
   compare-func@2.0.0:
     resolution: {integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==}
+
+  confbox@0.1.8:
+    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
 
   confbox@0.2.2:
     resolution: {integrity: sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==}
@@ -1373,6 +1557,11 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  esbuild@0.27.3:
+    resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -1437,6 +1626,9 @@ packages:
   find-up@7.0.0:
     resolution: {integrity: sha512-YyZM99iHrqLKjmt4LJDj58KI+fYyufRLBSYcqycxf//KpBk9FoewoGX0450m9nB44qrZnovzC2oeP5hUibxc/g==}
     engines: {node: '>=18'}
+
+  fix-dts-default-cjs-exports@1.0.1:
+    resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
 
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
@@ -1702,6 +1894,10 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
+
   js-sha256@0.9.0:
     resolution: {integrity: sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==}
 
@@ -1745,11 +1941,19 @@ packages:
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
   linkify-it@5.0.0:
     resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
+
+  load-tsconfig@0.2.5:
+    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
@@ -1901,6 +2105,9 @@ packages:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
     engines: {node: '>=10'}
     hasBin: true
+
+  mlly@1.8.1:
+    resolution: {integrity: sha512-SnL6sNutTwRWWR/vcmCYHSADjiEesp5TGQQ0pXyLhW5IoeibRlF/CbSLailbB3CNqJUk9cVJ9dUDnbD7GrcHBQ==}
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -2121,12 +2328,37 @@ packages:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
 
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
+
+  pkg-types@1.3.1:
+    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
+
   pkg-types@2.3.0:
     resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
+
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: '>=8.0.9'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
 
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
@@ -2184,6 +2416,10 @@ packages:
 
   readable-stream@2.3.8:
     resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
 
   readdirp@5.0.0:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
@@ -2304,6 +2540,10 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  source-map@0.7.6:
+    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
+    engines: {node: '>= 12'}
+
   spawndamnit@3.0.1:
     resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
 
@@ -2341,6 +2581,11 @@ packages:
 
   strip-literal@3.1.0:
     resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -2425,6 +2670,13 @@ packages:
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
   ts-node@10.9.2:
     resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
     hasBin: true
@@ -2437,6 +2689,25 @@ packages:
       '@swc/core':
         optional: true
       '@swc/wasm':
+        optional: true
+
+  tsup@8.5.1:
+    resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      '@microsoft/api-extractor': ^7.36.0
+      '@swc/core': ^1
+      postcss: ^8.4.12
+      typescript: '>=4.5.0'
+    peerDependenciesMeta:
+      '@microsoft/api-extractor':
+        optional: true
+      '@swc/core':
+        optional: true
+      postcss:
+        optional: true
+      typescript:
         optional: true
 
   tweetnacl@1.0.3:
@@ -2470,6 +2741,9 @@ packages:
 
   uc.micro@2.1.0:
     resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
+
+  ufo@1.6.3:
+    resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
@@ -3076,79 +3350,157 @@ snapshots:
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
+  '@esbuild/aix-ppc64@0.27.3':
+    optional: true
+
   '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.3':
     optional: true
 
   '@esbuild/android-arm@0.25.12':
     optional: true
 
+  '@esbuild/android-arm@0.27.3':
+    optional: true
+
   '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.27.3':
     optional: true
 
   '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
+  '@esbuild/darwin-arm64@0.27.3':
+    optional: true
+
   '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.3':
     optional: true
 
   '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.27.3':
+    optional: true
+
   '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.3':
     optional: true
 
   '@esbuild/linux-arm64@0.25.12':
     optional: true
 
+  '@esbuild/linux-arm64@0.27.3':
+    optional: true
+
   '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.3':
     optional: true
 
   '@esbuild/linux-ia32@0.25.12':
     optional: true
 
+  '@esbuild/linux-ia32@0.27.3':
+    optional: true
+
   '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.3':
     optional: true
 
   '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
+  '@esbuild/linux-mips64el@0.27.3':
+    optional: true
+
   '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.3':
     optional: true
 
   '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
+  '@esbuild/linux-riscv64@0.27.3':
+    optional: true
+
   '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.3':
     optional: true
 
   '@esbuild/linux-x64@0.25.12':
     optional: true
 
+  '@esbuild/linux-x64@0.27.3':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.3':
     optional: true
 
   '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
+  '@esbuild/netbsd-x64@0.27.3':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.3':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.12':
     optional: true
 
+  '@esbuild/openbsd-x64@0.27.3':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.3':
     optional: true
 
   '@esbuild/sunos-x64@0.25.12':
     optional: true
 
+  '@esbuild/sunos-x64@0.27.3':
+    optional: true
+
   '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.3':
     optional: true
 
   '@esbuild/win32-ia32@0.25.12':
     optional: true
 
+  '@esbuild/win32-ia32@0.27.3':
+    optional: true
+
   '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.3':
     optional: true
 
   '@gerrit0/mini-shiki@3.19.0':
@@ -3198,6 +3550,11 @@ snapshots:
   '@isaacs/brace-expansion@5.0.0':
     dependencies:
       '@isaacs/balanced-match': 4.0.1
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/resolve-uri@3.1.2': {}
 
@@ -3683,6 +4040,8 @@ snapshots:
 
   acorn@8.15.0: {}
 
+  acorn@8.16.0: {}
+
   ajv@8.17.1:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -3778,6 +4137,11 @@ snapshots:
     dependencies:
       run-applescript: 7.1.0
 
+  bundle-require@5.1.0(esbuild@0.27.3):
+    dependencies:
+      esbuild: 0.27.3
+      load-tsconfig: 0.2.5
+
   c12@3.3.3(magicast@0.5.1):
     dependencies:
       chokidar: 5.0.0
@@ -3853,6 +4217,10 @@ snapshots:
 
   check-error@2.1.1: {}
 
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
   chokidar@5.0.0:
     dependencies:
       readdirp: 5.0.0
@@ -3916,6 +4284,8 @@ snapshots:
 
   commander@14.0.2: {}
 
+  commander@4.1.1: {}
+
   commitlint@20.3.1(@types/node@25.0.9)(typescript@5.9.3):
     dependencies:
       '@commitlint/cli': 20.3.1(@types/node@25.0.9)(typescript@5.9.3)
@@ -3928,6 +4298,8 @@ snapshots:
     dependencies:
       array-ify: 1.0.0
       dot-prop: 5.3.0
+
+  confbox@0.1.8: {}
 
   confbox@0.2.2: {}
 
@@ -4124,6 +4496,35 @@ snapshots:
       '@esbuild/win32-ia32': 0.25.12
       '@esbuild/win32-x64': 0.25.12
 
+  esbuild@0.27.3:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.3
+      '@esbuild/android-arm': 0.27.3
+      '@esbuild/android-arm64': 0.27.3
+      '@esbuild/android-x64': 0.27.3
+      '@esbuild/darwin-arm64': 0.27.3
+      '@esbuild/darwin-x64': 0.27.3
+      '@esbuild/freebsd-arm64': 0.27.3
+      '@esbuild/freebsd-x64': 0.27.3
+      '@esbuild/linux-arm': 0.27.3
+      '@esbuild/linux-arm64': 0.27.3
+      '@esbuild/linux-ia32': 0.27.3
+      '@esbuild/linux-loong64': 0.27.3
+      '@esbuild/linux-mips64el': 0.27.3
+      '@esbuild/linux-ppc64': 0.27.3
+      '@esbuild/linux-riscv64': 0.27.3
+      '@esbuild/linux-s390x': 0.27.3
+      '@esbuild/linux-x64': 0.27.3
+      '@esbuild/netbsd-arm64': 0.27.3
+      '@esbuild/netbsd-x64': 0.27.3
+      '@esbuild/openbsd-arm64': 0.27.3
+      '@esbuild/openbsd-x64': 0.27.3
+      '@esbuild/openharmony-arm64': 0.27.3
+      '@esbuild/sunos-x64': 0.27.3
+      '@esbuild/win32-arm64': 0.27.3
+      '@esbuild/win32-ia32': 0.27.3
+      '@esbuild/win32-x64': 0.27.3
+
   escalade@3.2.0: {}
 
   esprima@4.0.1: {}
@@ -4178,6 +4579,12 @@ snapshots:
       locate-path: 7.2.0
       path-exists: 5.0.0
       unicorn-magic: 0.1.0
+
+  fix-dts-default-cjs-exports@1.0.1:
+    dependencies:
+      magic-string: 0.30.21
+      mlly: 1.8.1
+      rollup: 4.53.3
 
   flatted@3.3.3: {}
 
@@ -4451,6 +4858,8 @@ snapshots:
 
   jiti@2.6.1: {}
 
+  joycon@3.1.1: {}
+
   js-sha256@0.9.0: {}
 
   js-tokens@4.0.0: {}
@@ -4490,11 +4899,15 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
+  lilconfig@3.1.3: {}
+
   lines-and-columns@1.2.4: {}
 
   linkify-it@5.0.0:
     dependencies:
       uc.micro: 2.1.0
+
+  load-tsconfig@0.2.5: {}
 
   locate-path@5.0.0:
     dependencies:
@@ -4623,6 +5036,13 @@ snapshots:
       yallist: 4.0.0
 
   mkdirp@1.0.4: {}
+
+  mlly@1.8.1:
+    dependencies:
+      acorn: 8.16.0
+      pathe: 2.0.3
+      pkg-types: 1.3.1
+      ufo: 1.6.3
 
   mri@1.2.0: {}
 
@@ -4857,6 +5277,14 @@ snapshots:
 
   pify@4.0.1: {}
 
+  pirates@4.0.7: {}
+
+  pkg-types@1.3.1:
+    dependencies:
+      confbox: 0.1.8
+      mlly: 1.8.1
+      pathe: 2.0.3
+
   pkg-types@2.3.0:
     dependencies:
       confbox: 0.2.2
@@ -4864,6 +5292,14 @@ snapshots:
       pathe: 2.0.3
 
   possible-typed-array-names@1.1.0: {}
+
+  postcss-load-config@6.0.1(jiti@2.6.1)(postcss@8.5.6)(yaml@2.8.1):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      jiti: 2.6.1
+      postcss: 8.5.6
+      yaml: 2.8.1
 
   postcss@8.5.6:
     dependencies:
@@ -4925,6 +5361,8 @@ snapshots:
       safe-buffer: 5.1.2
       string_decoder: 1.1.1
       util-deprecate: 1.0.2
+
+  readdirp@4.1.2: {}
 
   readdirp@5.0.0: {}
 
@@ -5047,6 +5485,8 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  source-map@0.7.6: {}
+
   spawndamnit@3.0.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -5081,6 +5521,16 @@ snapshots:
   strip-literal@3.1.0:
     dependencies:
       js-tokens: 9.0.1
+
+  sucrase@3.35.1:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      tinyglobby: 0.2.15
+      ts-interface-checker: 0.1.13
 
   supports-color@7.2.0:
     dependencies:
@@ -5151,6 +5601,10 @@ snapshots:
 
   tr46@0.0.3: {}
 
+  tree-kill@1.2.2: {}
+
+  ts-interface-checker@0.1.13: {}
+
   ts-node@10.9.2(@types/node@25.0.9)(typescript@5.9.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -5168,6 +5622,34 @@ snapshots:
       typescript: 5.9.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
+
+  tsup@8.5.1(jiti@2.6.1)(postcss@8.5.6)(typescript@5.9.3)(yaml@2.8.1):
+    dependencies:
+      bundle-require: 5.1.0(esbuild@0.27.3)
+      cac: 6.7.14
+      chokidar: 4.0.3
+      consola: 3.4.2
+      debug: 4.4.3
+      esbuild: 0.27.3
+      fix-dts-default-cjs-exports: 1.0.1
+      joycon: 3.1.1
+      picocolors: 1.1.1
+      postcss-load-config: 6.0.1(jiti@2.6.1)(postcss@8.5.6)(yaml@2.8.1)
+      resolve-from: 5.0.0
+      rollup: 4.53.3
+      source-map: 0.7.6
+      sucrase: 3.35.1
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tree-kill: 1.2.2
+    optionalDependencies:
+      postcss: 8.5.6
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - jiti
+      - supports-color
+      - tsx
+      - yaml
 
   tweetnacl@1.0.3: {}
 
@@ -5193,6 +5675,8 @@ snapshots:
   typescript@5.9.3: {}
 
   uc.micro@2.1.0: {}
+
+  ufo@1.6.3: {}
 
   undici-types@7.16.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,12 +20,6 @@ importers:
       '@scure/base':
         specifier: 2.0.0
         version: 2.0.0
-      borsh:
-        specifier: 2.0.0
-        version: 2.0.0
-      is-my-json-valid:
-        specifier: 2.20.6
-        version: 2.20.6
       near-seed-phrase:
         specifier: 0.2.1
         version: 0.2.1
@@ -90,6 +84,10 @@ importers:
       vitest:
         specifier: 4.0.17
         version: 4.0.17(@types/node@25.0.9)(@vitest/ui@4.0.17)(jiti@2.6.1)(yaml@2.8.1)
+    optionalDependencies:
+      is-my-json-valid:
+        specifier: 2.20.6
+        version: 2.20.6
 
   e2e:
     dependencies:

--- a/scripts/fix-cjs-imports.js
+++ b/scripts/fix-cjs-imports.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+/**
+ * Post-build script to fix CJS import paths.
+ *
+ * tsup with bundle:false outputs .cjs files but internal require() calls
+ * still reference .js extensions from the TypeScript source. This script
+ * rewrites those to .cjs so that CJS resolution works correctly.
+ */
+import { readdir, readFile, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const CJS_DIR = join(import.meta.dirname, '..', 'dist', 'cjs');
+
+async function walk(dir) {
+    const entries = await readdir(dir, { withFileTypes: true });
+    const files = [];
+    for (const entry of entries) {
+        const full = join(dir, entry.name);
+        if (entry.isDirectory()) {
+            files.push(...(await walk(full)));
+        } else if (entry.name.endsWith('.cjs')) {
+            files.push(full);
+        }
+    }
+    return files;
+}
+
+async function fix() {
+    const files = await walk(CJS_DIR);
+    let fixed = 0;
+    for (const file of files) {
+        const content = await readFile(file, 'utf8');
+        // Match require("./path.js") and replace .js with .cjs
+        const updated = content.replace(/require\("(\.[^"]*?)\.js"\)/g, 'require("$1.cjs")');
+        if (updated !== content) {
+            await writeFile(file, updated);
+            fixed++;
+        }
+    }
+    console.log(`Fixed ${fixed} CJS files (${files.length} total)`);
+}
+
+fix().catch((err) => {
+    console.error(err);
+    process.exit(1);
+});

--- a/scripts/fix-cjs-imports.js
+++ b/scripts/fix-cjs-imports.js
@@ -2,9 +2,22 @@
 /**
  * Post-build script to fix CJS import paths.
  *
- * tsup with bundle:false outputs .cjs files but internal require() calls
- * still reference .js extensions from the TypeScript source. This script
- * rewrites those to .cjs so that CJS resolution works correctly.
+ * Root cause: when package.json has "type": "module" and tsup runs with
+ * bundle:false, esbuild outputs each file as .cjs but does NOT rewrite
+ * the internal require() paths. The source files use .js extensions
+ * (standard ESM convention), so the CJS output ends up with:
+ *
+ *   require("./accounts/index.js")   // file is actually index.cjs
+ *
+ * This is a known tsup/esbuild limitation -- esbuild only resolves imports
+ * when bundling. With bundle:false it transpiles each file independently
+ * and preserves the original import specifiers verbatim.
+ *
+ * Note: the js-monorepo (@fastnear/*) has the same issue but hasn't fixed
+ * it because consumers primarily use the ESM or IIFE builds.
+ *
+ * This script rewrites require("./path.js") -> require("./path.cjs") in
+ * all .cjs output files so that Node's CJS resolver finds them correctly.
  */
 import { readdir, readFile, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';

--- a/src/accounts/errors.ts
+++ b/src/accounts/errors.ts
@@ -1,4 +1,10 @@
-import type { ValidationError } from 'is-my-json-valid';
+/** Validation error shape from is-my-json-valid (optional dependency). */
+export interface ValidationError {
+    field: string;
+    message: string;
+    value: unknown;
+    type: string;
+}
 
 export class UnsupportedSerializationError extends Error {
     constructor(methodName: string, serializationType: string) {

--- a/src/accounts/typed_contract.ts
+++ b/src/accounts/typed_contract.ts
@@ -2,7 +2,6 @@
 /* eslint-disable @typescript-eslint/no-unnecessary-type-constraint */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
-import validator from 'is-my-json-valid';
 import type { Provider } from '../providers/index.js';
 import type { BlockReference, TxExecutionStatus } from '../types/index.js';
 import type {
@@ -16,7 +15,7 @@ import type {
     SchemaObject,
 } from './abi_types.js';
 import type { Account } from './account.js';
-import { ArgumentSchemaError, UnknownArgumentError } from './errors.js';
+import { ArgumentSchemaError, UnknownArgumentError, type ValidationError } from './errors.js';
 
 type IsNullable<T> = [null] extends [T] ? true : false;
 
@@ -333,7 +332,7 @@ class RawContract<const abi extends AbiRoot, contractId extends string> {
                             const args = params.args ?? {};
 
                             if (abiFunction && abi) {
-                                validateArguments(args, abiFunction, abi);
+                                await validateArguments(args, abiFunction, abi);
                             }
 
                             return provider.callFunction({
@@ -365,7 +364,7 @@ class RawContract<const abi extends AbiRoot, contractId extends string> {
                             const args = params.args ?? {};
 
                             if (abiFunction && abi) {
-                                validateArguments(args, abiFunction, abi);
+                                await validateArguments(args, abiFunction, abi);
                             }
 
                             return params.account.callFunction({
@@ -390,11 +389,18 @@ class RawContract<const abi extends AbiRoot, contractId extends string> {
 
 export const Contract = RawContract as ContractConstructor;
 
-function validateArguments(args: object, abiFunction: AbiFunction, abiRoot: AbiRoot) {
+async function validateArguments(args: object, abiFunction: AbiFunction, abiRoot: AbiRoot) {
     if (typeof args !== 'object' || typeof abiFunction.params !== 'object') return;
 
     if (abiFunction.params.serialization_type === 'json') {
         const params = abiFunction.params.args;
+        let validator: (schema: unknown) => ((value: unknown) => boolean) & { errors: ValidationError[] };
+        try {
+            ({ default: validator } = await import('is-my-json-valid'));
+        } catch {
+            // is-my-json-valid is an optional dependency; skip validation if not installed
+            return;
+        }
         for (const p of params) {
             const arg = args[p.name];
             const typeSchema = p.type_schema;

--- a/src/borsh.ts
+++ b/src/borsh.ts
@@ -1,0 +1,289 @@
+/**
+ * Lean Borsh serializer/deserializer for NEAR Protocol.
+ * Supports: u8, u16, u32, u64, u128, string, struct, enum, array (fixed + dynamic), option.
+ */
+
+type SchemaScalar = 'u8' | 'u16' | 'u32' | 'u64' | 'u128' | 'string';
+type SchemaOption = { option: Schema };
+type SchemaArray = { array: { type: Schema; len?: number } };
+type SchemaStruct = { struct: Record<string, Schema> };
+type SchemaEnum = { enum: SchemaStruct[] };
+export type Schema = SchemaScalar | SchemaOption | SchemaArray | SchemaStruct | SchemaEnum;
+
+class EncodeBuffer {
+    offset = 0;
+    bufferSize = 256;
+    buffer = new ArrayBuffer(this.bufferSize);
+    view = new DataView(this.buffer);
+
+    resize(needed: number) {
+        if (this.bufferSize - this.offset < needed) {
+            this.bufferSize = Math.max(this.bufferSize * 2, this.bufferSize + needed);
+            const next = new ArrayBuffer(this.bufferSize);
+            new Uint8Array(next).set(new Uint8Array(this.buffer));
+            this.buffer = next;
+            this.view = new DataView(next);
+        }
+    }
+    storeU8(v: number) {
+        this.resize(1);
+        this.view.setUint8(this.offset, v);
+        this.offset += 1;
+    }
+    storeU16(v: number) {
+        this.resize(2);
+        this.view.setUint16(this.offset, v, true);
+        this.offset += 2;
+    }
+    storeU32(v: number) {
+        this.resize(4);
+        this.view.setUint32(this.offset, v, true);
+        this.offset += 4;
+    }
+    storeBytes(from: Uint8Array) {
+        this.resize(from.length);
+        new Uint8Array(this.buffer).set(from, this.offset);
+        this.offset += from.length;
+    }
+    result() {
+        return new Uint8Array(this.buffer).slice(0, this.offset);
+    }
+}
+
+class DecodeBuffer {
+    offset = 0;
+    view: DataView;
+    bytes: Uint8Array;
+
+    constructor(buf: Uint8Array) {
+        const ab = new ArrayBuffer(buf.length);
+        new Uint8Array(ab).set(buf);
+        this.view = new DataView(ab);
+        this.bytes = new Uint8Array(ab);
+    }
+    assert(size: number) {
+        if (this.offset + size > this.bytes.length) {
+            throw new Error('Borsh: buffer overrun');
+        }
+    }
+    readU8() {
+        this.assert(1);
+        const v = this.view.getUint8(this.offset);
+        this.offset += 1;
+        return v;
+    }
+    readU16() {
+        this.assert(2);
+        const v = this.view.getUint16(this.offset, true);
+        this.offset += 2;
+        return v;
+    }
+    readU32() {
+        this.assert(4);
+        const v = this.view.getUint32(this.offset, true);
+        this.offset += 4;
+        return v;
+    }
+    readBytes(len: number) {
+        this.assert(len);
+        const slice = this.bytes.slice(this.offset, this.offset + len);
+        this.offset += len;
+        return slice;
+    }
+}
+
+function encodeBigint(buf: EncodeBuffer, value: bigint, byteLen: number) {
+    const out = new Uint8Array(byteLen);
+    let v = value;
+    for (let i = 0; i < byteLen; i++) {
+        out[i] = Number(v & 0xffn);
+        v >>= 8n;
+    }
+    buf.storeBytes(out);
+}
+
+function decodeBigint(buf: DecodeBuffer, byteLen: number) {
+    const bytes = buf.readBytes(byteLen);
+    const hex = bytes.reduceRight((r, x) => r + x.toString(16).padStart(2, '0'), '');
+    return BigInt(`0x${hex}`);
+}
+
+function utf8Encode(str: string) {
+    const bytes: number[] = [];
+    for (let i = 0; i < str.length; i++) {
+        let c = str.charCodeAt(i);
+        if (c < 0x80) {
+            bytes.push(c);
+        } else if (c < 0x800) {
+            bytes.push(0xc0 | (c >> 6), 0x80 | (c & 0x3f));
+        } else if (c < 0xd800 || c >= 0xe000) {
+            bytes.push(0xe0 | (c >> 12), 0x80 | ((c >> 6) & 0x3f), 0x80 | (c & 0x3f));
+        } else {
+            i++;
+            c = 0x10000 + (((c & 0x3ff) << 10) | (str.charCodeAt(i) & 0x3ff));
+            bytes.push(0xf0 | (c >> 18), 0x80 | ((c >> 12) & 0x3f), 0x80 | ((c >> 6) & 0x3f), 0x80 | (c & 0x3f));
+        }
+    }
+    return new Uint8Array(bytes);
+}
+
+function utf8Decode(bytes: Uint8Array) {
+    const codePoints: number[] = [];
+    for (let i = 0; i < bytes.length; i++) {
+        const b = bytes[i]!;
+        if (b < 0x80) {
+            codePoints.push(b);
+        } else if (b < 0xe0) {
+            codePoints.push(((b & 0x1f) << 6) | (bytes[++i]! & 0x3f));
+        } else if (b < 0xf0) {
+            codePoints.push(((b & 0x0f) << 12) | ((bytes[++i]! & 0x3f) << 6) | (bytes[++i]! & 0x3f));
+        } else {
+            codePoints.push(
+                ((b & 0x07) << 18) | ((bytes[++i]! & 0x3f) << 12) | ((bytes[++i]! & 0x3f) << 6) | (bytes[++i]! & 0x3f)
+            );
+        }
+    }
+    return String.fromCodePoint(...codePoints);
+}
+
+function encodeValue(buf: EncodeBuffer, value: unknown, schema: Schema): void {
+    if (typeof schema === 'string') {
+        switch (schema) {
+            case 'u8':
+                buf.storeU8(value as number);
+                return;
+            case 'u16':
+                buf.storeU16(value as number);
+                return;
+            case 'u32':
+                buf.storeU32(value as number);
+                return;
+            case 'u64':
+                encodeBigint(buf, BigInt(value as number | bigint), 8);
+                return;
+            case 'u128':
+                encodeBigint(buf, BigInt(value as number | bigint), 16);
+                return;
+            case 'string': {
+                const encoded = utf8Encode(value as string);
+                buf.storeU32(encoded.length);
+                buf.storeBytes(encoded);
+                return;
+            }
+        }
+    }
+    if (typeof schema === 'object') {
+        if ('option' in schema) {
+            if (value === null || value === undefined) {
+                buf.storeU8(0);
+            } else {
+                buf.storeU8(1);
+                encodeValue(buf, value, schema.option);
+            }
+            return;
+        }
+        if ('enum' in schema) {
+            const obj = value as Record<string, unknown>;
+            const valueKey = Object.keys(obj)[0];
+            const variants = schema.enum;
+            for (let i = 0; i < variants.length; i++) {
+                const variant = variants[i]!;
+                const variantKey = Object.keys(variant.struct)[0];
+                if (valueKey === variantKey) {
+                    buf.storeU8(i);
+                    encodeStruct(buf, obj, variant);
+                    return;
+                }
+            }
+            throw new Error(`Borsh: enum key "${valueKey}" not found in schema`);
+        }
+        if ('array' in schema) {
+            const arr = value as unknown[];
+            if (schema.array.len == null) {
+                buf.storeU32(arr.length);
+            }
+            for (let i = 0; i < arr.length; i++) {
+                encodeValue(buf, arr[i], schema.array.type);
+            }
+            return;
+        }
+        if ('struct' in schema) {
+            encodeStruct(buf, value as Record<string, unknown>, schema);
+            return;
+        }
+    }
+}
+
+function encodeStruct(buf: EncodeBuffer, value: Record<string, unknown>, schema: SchemaStruct) {
+    for (const key of Object.keys(schema.struct)) {
+        encodeValue(buf, value[key], schema.struct[key]!);
+    }
+}
+
+function decodeValue(buf: DecodeBuffer, schema: Schema): unknown {
+    if (typeof schema === 'string') {
+        switch (schema) {
+            case 'u8':
+                return buf.readU8();
+            case 'u16':
+                return buf.readU16();
+            case 'u32':
+                return buf.readU32();
+            case 'u64':
+                return decodeBigint(buf, 8);
+            case 'u128':
+                return decodeBigint(buf, 16);
+            case 'string': {
+                const len = buf.readU32();
+                return utf8Decode(buf.readBytes(len));
+            }
+        }
+    }
+    if (typeof schema === 'object') {
+        if ('option' in schema) {
+            const flag = buf.readU8();
+            if (flag === 1) return decodeValue(buf, schema.option);
+            if (flag === 0) return null;
+            throw new Error(`Borsh: invalid option flag ${flag}`);
+        }
+        if ('enum' in schema) {
+            const idx = buf.readU8();
+            if (idx >= schema.enum.length) {
+                throw new Error(`Borsh: enum index ${idx} out of range`);
+            }
+            const variant = schema.enum[idx]!;
+            const result: Record<string, unknown> = {};
+            for (const key of Object.keys(variant.struct)) {
+                result[key] = decodeValue(buf, variant.struct[key]!);
+            }
+            return result;
+        }
+        if ('array' in schema) {
+            const len = schema.array.len ?? buf.readU32();
+            const result: unknown[] = [];
+            for (let i = 0; i < len; i++) {
+                result.push(decodeValue(buf, schema.array.type));
+            }
+            return result;
+        }
+        if ('struct' in schema) {
+            const result: Record<string, unknown> = {};
+            for (const key in schema.struct) {
+                result[key] = decodeValue(buf, schema.struct[key]!);
+            }
+            return result;
+        }
+    }
+    throw new Error(`Borsh: unsupported schema: ${JSON.stringify(schema)}`);
+}
+
+export function serialize(schema: Schema, value: unknown): Uint8Array {
+    const buf = new EncodeBuffer();
+    encodeValue(buf, value, schema);
+    return buf.result();
+}
+
+export function deserialize(schema: Schema, buffer: Uint8Array): unknown {
+    const buf = new DecodeBuffer(buffer);
+    return decodeValue(buf, schema);
+}

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -5,3 +5,14 @@ export type { Signature } from './key_pair_base.js';
 export { KeyPairEd25519 } from './key_pair_ed25519.js';
 export { KeyPairSecp256k1 } from './key_pair_secp256k1.js';
 export { keyToImplicitAddress, PublicKey } from './public_key.js';
+export type { KeyCurve } from './utils.js';
+export {
+    sha256,
+    curveFromKey,
+    keyFromString,
+    keyToString,
+    publicKeyFromPrivate,
+    privateKeyFromRandom,
+    signHash,
+    signBytes,
+} from './utils.js';

--- a/src/crypto/index.ts
+++ b/src/crypto/index.ts
@@ -7,12 +7,12 @@ export { KeyPairSecp256k1 } from './key_pair_secp256k1.js';
 export { keyToImplicitAddress, PublicKey } from './public_key.js';
 export type { KeyCurve } from './utils.js';
 export {
-    sha256,
     curveFromKey,
     keyFromString,
     keyToString,
-    publicKeyFromPrivate,
     privateKeyFromRandom,
-    signHash,
+    publicKeyFromPrivate,
+    sha256,
     signBytes,
+    signHash,
 } from './utils.js';

--- a/src/crypto/utils.ts
+++ b/src/crypto/utils.ts
@@ -1,0 +1,116 @@
+import { ed25519 } from '@noble/curves/ed25519.js';
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+import { sha256 } from '@noble/hashes/sha2.js';
+import { baseDecode, baseEncode } from '../utils/format.js';
+
+import type { KeyPairString } from './constants.js';
+
+export { sha256 };
+
+export type KeyCurve = 'ed25519' | 'secp256k1';
+
+/**
+ * Extract the curve type from a key string like "ed25519:..." or "secp256k1:..."
+ * Defaults to ed25519 if no prefix is present.
+ */
+export function curveFromKey(key: string): KeyCurve {
+    if (!key.includes(':')) return 'ed25519';
+    const curve = key.split(':')[0];
+    if (curve === 'ed25519' || curve === 'secp256k1') return curve;
+    throw new Error(`Unsupported curve: ${curve}`);
+}
+
+/**
+ * Decode the base58 portion of a key string (after the "curve:" prefix).
+ */
+export function keyFromString(key: string): Uint8Array {
+    const raw = key.includes(':') ? key.split(':')[1]! : key;
+    return baseDecode(raw);
+}
+
+/**
+ * Encode a raw key byte array into a prefixed key string like "ed25519:base58key".
+ */
+export function keyToString(key: Uint8Array, curve: KeyCurve = 'ed25519'): KeyPairString {
+    return `${curve}:${baseEncode(key)}` as KeyPairString;
+}
+
+/**
+ * Derive the public key string from a private key string.
+ * Supports both ed25519 and secp256k1 curves.
+ *
+ * @param privateKey Key string like "ed25519:base58..." or "secp256k1:base58..."
+ * @returns Public key string like "ed25519:base58..." or "secp256k1:base58..."
+ */
+export function publicKeyFromPrivate(privateKey: string): KeyPairString {
+    const curve = curveFromKey(privateKey);
+    if (curve === 'secp256k1') {
+        const secret = keyFromString(privateKey);
+        const fullPk = secp256k1.getPublicKey(secret, false);
+        const publicKey = fullPk.slice(1); // strip 0x04 prefix — NEAR stores 64 bytes (x‖y)
+        return keyToString(publicKey, 'secp256k1');
+    }
+    const secret = keyFromString(privateKey).slice(0, 32);
+    const publicKey = ed25519.getPublicKey(secret);
+    return keyToString(publicKey);
+}
+
+/**
+ * Generate a random private key string for the given curve.
+ *
+ * @param curve Key curve, defaults to 'ed25519'
+ * @returns Private key string like "ed25519:base58..."
+ */
+export function privateKeyFromRandom(curve: KeyCurve = 'ed25519'): KeyPairString {
+    const size = curve === 'secp256k1' ? 32 : 64;
+    const privateKey = crypto.getRandomValues(new Uint8Array(size));
+    return keyToString(privateKey, curve);
+}
+
+/**
+ * Sign a hash (pre-hashed message) with a private key string.
+ * For ed25519, the hash is signed directly.
+ * For secp256k1, produces a 65-byte signature in NEAR's [r, s, v] format.
+ *
+ * @param hashBytes The hash bytes to sign
+ * @param privateKey Key string like "ed25519:base58..." or "secp256k1:base58..."
+ * @returns The signature as Uint8Array (or base58 string if opts.returnBase58 is true)
+ */
+export function signHash(
+    hashBytes: Uint8Array,
+    privateKey: string,
+    opts?: { returnBase58?: boolean }
+): Uint8Array | string {
+    const curve = curveFromKey(privateKey);
+
+    let signature: Uint8Array;
+    if (curve === 'secp256k1') {
+        const secret = keyFromString(privateKey);
+        const raw = secp256k1.sign(hashBytes, secret, { prehash: false, format: 'recovered' });
+        // 'recovered' format: [v(1), r(32), s(32)] → NEAR expects [r(32), s(32), v(1)]
+        signature = new Uint8Array(65);
+        signature.set(raw.slice(1, 33), 0); // r
+        signature.set(raw.slice(33, 65), 32); // s
+        signature[64] = raw[0]!; // v
+    } else {
+        const secret = keyFromString(privateKey).slice(0, 32);
+        signature = ed25519.sign(hashBytes, secret);
+    }
+
+    if (opts?.returnBase58) {
+        return baseEncode(signature);
+    }
+    return signature;
+}
+
+/**
+ * Hash bytes with sha256 then sign with the private key.
+ *
+ * @param bytes The raw bytes to hash and sign
+ * @param privateKey Key string like "ed25519:base58..." or "secp256k1:base58..."
+ * @returns The signature as Uint8Array
+ */
+export function signBytes(bytes: Uint8Array, privateKey: string): Uint8Array | string {
+    const hash = sha256(bytes);
+    return signHash(hash, privateKey);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,20 +17,20 @@ export type {
 // Cryptography
 // ============================================================================
 export {
+    curveFromKey,
     KeyPair,
     KeyPairEd25519,
     KeyPairSecp256k1,
     KeyType,
-    keyToImplicitAddress,
-    PublicKey,
-    sha256,
-    curveFromKey,
     keyFromString,
+    keyToImplicitAddress,
     keyToString,
-    publicKeyFromPrivate,
+    PublicKey,
     privateKeyFromRandom,
-    signHash,
+    publicKeyFromPrivate,
+    sha256,
     signBytes,
+    signHash,
 } from './crypto/index.js';
 // ============================================================================
 // Providers

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,10 @@ export * from './transactions/index.js';
 export * from './types/index.js';
 export { gigaToGas, nearToYocto, teraToGas, yoctoToNear } from './units/index.js';
 // ============================================================================
+// Serialization (Borsh)
+// ============================================================================
+export { serialize, deserialize, type Schema } from './borsh.js';
+// ============================================================================
 // Utilities
 // ============================================================================
 export * from './utils/index.js';

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@
 export * from './accounts/index.js';
 export type {
     CurveType,
+    KeyCurve,
     KeyPairString,
     Signature as CryptoSignature,
 } from './crypto/index.js';
@@ -22,6 +23,14 @@ export {
     KeyType,
     keyToImplicitAddress,
     PublicKey,
+    sha256,
+    curveFromKey,
+    keyFromString,
+    keyToString,
+    publicKeyFromPrivate,
+    privateKeyFromRandom,
+    signHash,
+    signBytes,
 } from './crypto/index.js';
 // ============================================================================
 // Providers

--- a/src/nep413/schema.ts
+++ b/src/nep413/schema.ts
@@ -1,5 +1,5 @@
 import { sha256 } from '@noble/hashes/sha2.js';
-import { type Schema, serialize } from 'borsh';
+import { type Schema, serialize } from '../borsh.js';
 
 export interface MessagePayload {
     message: string; // The message that wants to be transmitted.

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,3 +1,4 @@
+export { parseRpcError } from './errors/parse.js';
 export { exponentialBackoff } from './exponential-backoff.js';
 export { FailoverRpcProvider } from './failover-rpc-provider.js';
 export { JsonRpcProvider } from './json-rpc-provider.js';

--- a/src/shims/error-parse-lite.ts
+++ b/src/shims/error-parse-lite.ts
@@ -1,0 +1,94 @@
+// Lightweight error parser for the IIFE browser bundle.
+// The full parse.ts pulls in 100+ error classes (~100KB). This shim provides
+// the same API but returns generic RpcError instances with descriptive messages
+// extracted from the raw RPC error JSON. The full error hierarchy is available
+// via ESM/CJS imports or the `near-api-js/rpc-errors` subpath.
+//
+// InvalidNonceError is preserved because account.ts uses instanceof to trigger
+// nonce retry logic.
+
+import { InternalRpcError, RpcError } from '../providers/errors/rpc.js';
+import { InvalidNonceError } from '../providers/errors/transaction_execution.js';
+
+function extractMessage(error: unknown): string {
+    if (error === null || error === undefined) return 'Unknown error';
+    if (typeof error === 'string') return error;
+    if (typeof error !== 'object') return String(error);
+
+    const e = error as Record<string, unknown>;
+
+    // Try common RPC error shapes
+    if ('error_message' in e && typeof e.error_message === 'string') return e.error_message;
+    if ('message' in e && typeof e.message === 'string') return e.message;
+    if ('name' in e && typeof e.name === 'string') {
+        const info = 'info' in e && typeof e.info === 'object' && e.info !== null ? e.info : {};
+        return `${e.name}: ${JSON.stringify(info)}`;
+    }
+
+    // Nested cause
+    if ('cause' in e && e.cause) return extractMessage(e.cause);
+
+    // Fallback
+    return JSON.stringify(error);
+}
+
+function extractTxErrorMessage(error: unknown): string {
+    if (error === null || error === undefined) return 'Unknown transaction error';
+    if (typeof error !== 'object') return String(error);
+
+    const e = error as Record<string, unknown>;
+
+    // TxExecutionError shape: { ActionError: {...} } or { InvalidTxError: {...} }
+    if ('ActionError' in e) {
+        const ae = e.ActionError as Record<string, unknown>;
+        const kind = ae?.kind;
+        if (typeof kind === 'string') return `ActionError: ${kind}`;
+        if (kind && typeof kind === 'object') {
+            const key = Object.keys(kind)[0];
+            return `ActionError: ${key}: ${JSON.stringify((kind as Record<string, unknown>)[key])}`;
+        }
+        return `ActionError: ${JSON.stringify(ae)}`;
+    }
+
+    if ('InvalidTxError' in e) {
+        const ite = e.InvalidTxError;
+        if (typeof ite === 'string') return `InvalidTxError: ${ite}`;
+        if (ite && typeof ite === 'object') {
+            const key = Object.keys(ite as object)[0];
+            return `InvalidTxError: ${key}: ${JSON.stringify((ite as Record<string, unknown>)[key])}`;
+        }
+        return `InvalidTxError: ${JSON.stringify(ite)}`;
+    }
+
+    return JSON.stringify(error);
+}
+
+type RawRpcError = { name: string; cause?: unknown; data?: unknown };
+
+export function parseRpcError(error: RawRpcError): RpcError {
+    switch (error.name) {
+        case 'INTERNAL_ERROR': {
+            const cause = error.cause as Record<string, { error_message: string }> | undefined;
+            return new InternalRpcError(cause?.info?.error_message ?? 'Internal error');
+        }
+        default:
+            return new RpcError(extractMessage(error));
+    }
+}
+
+export function parseTransactionExecutionError(error: unknown, txHash: string, _blockHash: string): RpcError {
+    // Preserve InvalidNonceError for nonce retry logic in account.ts
+    if (error && typeof error === 'object' && 'InvalidTxError' in error) {
+        const ite = (error as Record<string, unknown>).InvalidTxError;
+        if (ite && typeof ite === 'object' && 'InvalidNonce' in ite) {
+            const nonce = (ite as Record<string, { ak_nonce: number; tx_nonce: number }>).InvalidNonce;
+            return new InvalidNonceError(nonce.ak_nonce, nonce.tx_nonce, txHash, _blockHash);
+        }
+    }
+
+    return new RpcError(`Transaction ${txHash} failed: ${extractTxErrorMessage(error)}`);
+}
+
+export function parseRpcErrorMessage(errorMessage: string, _blockHash: string, _blockHeight: number): RpcError {
+    return new RpcError(errorMessage);
+}

--- a/src/shims/json-validator-noop.ts
+++ b/src/shims/json-validator-noop.ts
@@ -1,0 +1,16 @@
+// No-op stub for is-my-json-valid in the IIFE browser bundle.
+// ABI schema validation is a development-time feature that adds ~44KB of
+// dependencies (is-my-json-valid, generate-function, is-property, etc).
+// In the browser IIFE bundle, validation is skipped — all arguments pass.
+interface ValidateFunction {
+    (value: unknown): boolean;
+    errors: null;
+}
+
+function validator(_schema: unknown): ValidateFunction {
+    const fn = (_value: unknown) => true;
+    fn.errors = null;
+    return fn as ValidateFunction;
+}
+
+export default validator;

--- a/src/shims/util.ts
+++ b/src/shims/util.ts
@@ -1,0 +1,28 @@
+// Browser shim for Node's 'util' module.
+// Used by is-my-json-valid which only needs util.format for error messages.
+
+function format(fmt: string, ...args: unknown[]): string {
+    let i = 0;
+    return fmt.replace(/%[sdj%]/g, (match) => {
+        if (match === '%%') return '%';
+        if (i >= args.length) return match;
+        const val = args[i++];
+        switch (match) {
+            case '%s':
+                return String(val);
+            case '%d':
+                return String(Number(val));
+            case '%j':
+                try {
+                    return JSON.stringify(val);
+                } catch {
+                    return '[Circular]';
+                }
+            default:
+                return String(val);
+        }
+    });
+}
+
+export { format };
+export default { format };

--- a/src/transactions/action_creators.ts
+++ b/src/transactions/action_creators.ts
@@ -239,6 +239,10 @@ function useGlobalContract(contractIdentifier: { accountId: string } | { codeHas
     return new Action({ useGlobalContract: new UseGlobalContract({ contractIdentifier: identifier }) });
 }
 
+/**
+ * Action creator functions for building NEAR transaction actions.
+ * @alias actionCreators
+ */
 export const actions = {
     addFullAccessKey,
     addFunctionCallAccessKey,
@@ -255,3 +259,6 @@ export const actions = {
     deployGlobalContract,
     useGlobalContract,
 };
+
+/** @deprecated Use {@link actions} instead. Alias for backwards compatibility with @near-js/transactions. */
+export const actionCreators = actions;

--- a/src/transactions/index.ts
+++ b/src/transactions/index.ts
@@ -1,6 +1,7 @@
 export * from './action_creators.js';
-export type * from './actions.js';
+export * from './actions.js';
 export * from './create_transaction.js';
 export * from './delegate.js';
+export * from './plain.js';
 export * from './schema.js';
 export * from './signature.js';

--- a/src/transactions/plain.ts
+++ b/src/transactions/plain.ts
@@ -1,0 +1,158 @@
+import { curveFromKey, keyFromString } from '../crypto/utils.js';
+import { base64Decode, baseDecode } from '../utils/format.js';
+
+/**
+ * A plain JSON-friendly transaction object that can be easily constructed
+ * without needing to import classes. Use {@link mapTransaction} to convert
+ * to a borsh-serializable format compatible with {@link SCHEMA}.
+ */
+export interface PlainTransaction {
+    signerId: string;
+    publicKey: string;
+    nonce: string | bigint | number;
+    receiverId: string;
+    blockHash: string;
+    actions: PlainAction[];
+}
+
+export interface PlainSignedTransaction {
+    transaction: object;
+    signature: object;
+}
+
+export type PlainAction =
+    | { type: 'CreateAccount' }
+    | { type: 'DeployContract'; codeBase64: string }
+    | {
+          type: 'FunctionCall';
+          methodName: string;
+          args?: object;
+          argsBase64?: string;
+          gas?: string | number;
+          deposit?: string | number;
+      }
+    | { type: 'Transfer'; deposit: string | number }
+    | { type: 'Stake'; stake: string | number; publicKey: string }
+    | { type: 'AddKey'; publicKey: string; accessKey: PlainAccessKey }
+    | { type: 'DeleteKey'; publicKey: string }
+    | { type: 'DeleteAccount'; beneficiaryId: string }
+    | { type: 'SignedDelegate'; delegateAction: PlainAction; signature: string; publicKey: string };
+
+export interface PlainAccessKey {
+    nonce: string | bigint | number;
+    permission:
+        | 'FullAccess'
+        | {
+              receiverId: string;
+              methodNames: string[];
+              allowance?: string | number | null;
+          };
+}
+
+function mapPublicKey(keyString: string) {
+    const curve = curveFromKey(keyString);
+    const data = keyFromString(keyString);
+    return curve === 'secp256k1' ? { secp256k1Key: { data } } : { ed25519Key: { data } };
+}
+
+function mapSignature(sigBase58: string, signerKeyString: string) {
+    const curve = curveFromKey(signerKeyString);
+    const data = baseDecode(sigBase58);
+    return curve === 'secp256k1' ? { secp256k1Signature: { data } } : { ed25519Signature: { data } };
+}
+
+/**
+ * Convert a {@link PlainTransaction} (plain JSON object) into a borsh-serializable
+ * object matching the transaction SCHEMA. Use with `serialize(SCHEMA.Transaction, ...)`.
+ */
+export function mapTransaction(jsonTransaction: PlainTransaction) {
+    return {
+        signerId: jsonTransaction.signerId,
+        publicKey: mapPublicKey(jsonTransaction.publicKey),
+        nonce: BigInt(jsonTransaction.nonce),
+        receiverId: jsonTransaction.receiverId,
+        blockHash: baseDecode(jsonTransaction.blockHash),
+        actions: jsonTransaction.actions.map(mapAction),
+    };
+}
+
+/**
+ * Convert a {@link PlainTransaction} and base58 signature into a borsh-serializable
+ * signed transaction object matching SCHEMA.SignedTransaction.
+ */
+export function mapSignedTransaction(jsonTransaction: PlainTransaction, signature: string): PlainSignedTransaction {
+    return {
+        transaction: mapTransaction(jsonTransaction),
+        signature: mapSignature(signature, jsonTransaction.publicKey),
+    };
+}
+
+const textEncoder = new TextEncoder();
+
+/**
+ * Convert a plain action object (with `type` discriminator) into the borsh-serializable
+ * format expected by the transaction SCHEMA.
+ */
+export function mapAction(action: PlainAction): object {
+    switch (action.type) {
+        case 'CreateAccount':
+            return { createAccount: {} };
+        case 'DeployContract':
+            return { deployContract: { code: base64Decode(action.codeBase64) } };
+        case 'FunctionCall':
+            return {
+                functionCall: {
+                    methodName: action.methodName,
+                    args:
+                        action.argsBase64 != null
+                            ? base64Decode(action.argsBase64)
+                            : textEncoder.encode(JSON.stringify(action.args)),
+                    gas: BigInt(action.gas ?? '300000000000000'),
+                    deposit: BigInt(action.deposit ?? '0'),
+                },
+            };
+        case 'Transfer':
+            return { transfer: { deposit: BigInt(action.deposit) } };
+        case 'Stake':
+            return {
+                stake: {
+                    stake: BigInt(action.stake),
+                    publicKey: mapPublicKey(action.publicKey),
+                },
+            };
+        case 'AddKey':
+            return {
+                addKey: {
+                    publicKey: mapPublicKey(action.publicKey),
+                    accessKey: {
+                        nonce: BigInt(action.accessKey.nonce),
+                        permission:
+                            action.accessKey.permission === 'FullAccess'
+                                ? { fullAccess: {} }
+                                : {
+                                      functionCall: {
+                                          allowance: action.accessKey.permission.allowance
+                                              ? BigInt(action.accessKey.permission.allowance)
+                                              : null,
+                                          receiverId: action.accessKey.permission.receiverId,
+                                          methodNames: action.accessKey.permission.methodNames,
+                                      },
+                                  },
+                    },
+                },
+            };
+        case 'DeleteKey':
+            return { deleteKey: { publicKey: mapPublicKey(action.publicKey) } };
+        case 'DeleteAccount':
+            return { deleteAccount: { beneficiaryId: action.beneficiaryId } };
+        case 'SignedDelegate':
+            return {
+                signedDelegate: {
+                    delegateAction: mapAction(action.delegateAction),
+                    signature: mapSignature(action.signature, action.publicKey),
+                },
+            };
+        default:
+            throw new Error(`Not implemented action: ${(action as PlainAction).type}`);
+    }
+}

--- a/src/transactions/schema.ts
+++ b/src/transactions/schema.ts
@@ -1,4 +1,4 @@
-import { deserialize, type Schema, serialize } from 'borsh';
+import { deserialize, type Schema, serialize } from '../borsh.js';
 import { PublicKey } from '../crypto/index.js';
 
 import type { Action, SignedDelegate } from './actions.js';

--- a/test/unit/signers/key_pair_signer.test.ts
+++ b/test/unit/signers/key_pair_signer.test.ts
@@ -1,6 +1,6 @@
 import { sha256 } from '@noble/hashes/sha2.js';
-import { serialize } from 'borsh';
 import { expect, test } from 'vitest';
+import { serialize } from '../../../src/borsh.js';
 import {
     actions as actionCreators,
     buildDelegateAction,

--- a/test/unit/transactions/serialize.test.ts
+++ b/test/unit/transactions/serialize.test.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs';
 import { sha256 } from '@noble/hashes/sha2.js';
-import { deserialize, serialize } from 'borsh';
 import { describe, expect, test } from 'vitest';
+import { deserialize, serialize } from '../../../src/borsh.js';
 
 import {
     actions,

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -42,11 +42,16 @@ const globalName = 'nearApi';
  * @fastnear/utils, @fastnear/borsh, etc.
  */
 const footerRedefiningGlobal = `
-Object.defineProperty(globalThis, '${globalName}', {
-  value: ${globalName},
-  enumerable: true,
-  configurable: false,
-});
+try {
+  Object.defineProperty(globalThis, '${globalName}', {
+    value: ${globalName},
+    enumerable: true,
+    configurable: false,
+  });
+} catch (error) {
+  console.error('Could not define global "${globalName}" object', error);
+  throw error;
+}
 `;
 
 export default defineConfig([

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,0 +1,155 @@
+import path from 'node:path';
+import type { Plugin } from 'esbuild';
+import { defineConfig } from 'tsup';
+
+// @ts-expect-error — importing package.json for banner metadata
+import pkg from './package.json';
+
+/**
+ * esbuild plugin: redirect providers/errors/parse.ts to the lightweight shim
+ * in the IIFE bundle. The full parse module pulls in 100+ error classes (~62KB)
+ * that are only needed for typed catch() blocks. The shim returns generic
+ * RpcError instances with descriptive messages, preserving InvalidNonceError
+ * for the nonce-retry logic in account.ts.
+ */
+function errorParseLitePlugin(): Plugin {
+    const shimPath = path.resolve('src/shims/error-parse-lite.ts');
+    const parseFile = path.sep + path.join('providers', 'errors', 'parse');
+
+    return {
+        name: 'error-parse-lite',
+        setup(build) {
+            build.onResolve({ filter: /errors\/parse/ }, (args) => {
+                if (args.kind === 'import-statement') {
+                    const resolved = path.resolve(path.dirname(args.importer), args.path);
+                    // Normalise away the extension (.js / .ts) for matching
+                    const noExt = resolved.replace(/\.(js|ts)$/, '');
+                    if (noExt.endsWith(parseFile)) {
+                        return { path: shimPath };
+                    }
+                }
+                return undefined;
+            });
+        },
+    };
+}
+
+const globalName = 'nearApi';
+
+/**
+ * IIFE footer: freeze the global binding so downstream code cannot accidentally
+ * reassign `window.nearApi`. Matches the js-monorepo pattern used by
+ * @fastnear/utils, @fastnear/borsh, etc.
+ */
+const footerRedefiningGlobal = `
+Object.defineProperty(globalThis, '${globalName}', {
+  value: ${globalName},
+  enumerable: true,
+  configurable: false,
+});
+`;
+
+export default defineConfig([
+    // 1) CommonJS (CJS) build — unbundled, preserves module structure
+    {
+        entry: ['src/**/*.ts', '!src/**/*.test.ts', '!src/shims/**'],
+        outDir: 'dist/cjs',
+        format: ['cjs'],
+        bundle: false,
+        splitting: false,
+        clean: true,
+        keepNames: true,
+        dts: {
+            resolve: true,
+            entry: [
+                'src/index.ts',
+                'src/tokens/index.ts',
+                'src/tokens/mainnet/index.ts',
+                'src/tokens/testnet/index.ts',
+                'src/nep413/index.ts',
+                'src/seed-phrase/index.ts',
+                'src/rpc-errors/index.ts',
+            ],
+        },
+        sourcemap: true,
+        minify: false,
+        banner: {
+            js:
+                `/* near-api-js - CJS (${pkg.name} version ${pkg.version}) */\n` +
+                `/* https://www.npmjs.com/package/${pkg.name}/v/${pkg.version} */`,
+        },
+    },
+
+    // 2) ESM build — unbundled, preserves module structure
+    {
+        entry: ['src/**/*.ts', '!src/**/*.test.ts', '!src/shims/**'],
+        outDir: 'dist/esm',
+        format: ['esm'],
+        shims: true,
+        bundle: false,
+        splitting: false,
+        clean: true,
+        keepNames: true,
+        dts: {
+            resolve: true,
+            entry: [
+                'src/index.ts',
+                'src/tokens/index.ts',
+                'src/tokens/mainnet/index.ts',
+                'src/tokens/testnet/index.ts',
+                'src/nep413/index.ts',
+                'src/seed-phrase/index.ts',
+                'src/rpc-errors/index.ts',
+            ],
+        },
+        sourcemap: true,
+        minify: false,
+        banner: {
+            js:
+                `/* near-api-js - ESM (${pkg.name} version ${pkg.version}) */\n` +
+                `/* https://www.npmjs.com/package/${pkg.name}/v/${pkg.version} */`,
+        },
+    },
+
+    // 3) IIFE build — fully bundled for browser <script> tags
+    {
+        entry: {
+            browser: 'src/index.ts',
+        },
+        outDir: 'dist/umd',
+        format: ['iife'],
+        globalName,
+        bundle: true,
+        splitting: false,
+        clean: true,
+        keepNames: true,
+        dts: false,
+        sourcemap: true,
+        minify: false,
+        platform: 'browser',
+        banner: {
+            js:
+                `/* near-api-js - IIFE/UMD (${pkg.name} version ${pkg.version}) */\n` +
+                `/* https://www.npmjs.com/package/${pkg.name}/v/${pkg.version} */`,
+        },
+        // Browser shims: replace heavy Node-only deps with lightweight stubs
+        esbuildOptions(options) {
+            options.alias = {
+                ...options.alias,
+                // is-my-json-valid + transitive deps add ~44KB for ABI schema validation.
+                // In the browser IIFE, validation is a no-op — use the full library via ESM/CJS.
+                'is-my-json-valid': './src/shims/json-validator-noop.ts',
+                // is-my-json-valid uses Node's 'util' module (util.format for error messages)
+                util: './src/shims/util.ts',
+            };
+        },
+        esbuildPlugins: [
+            // Replaces the full error parser (~62KB of error class hierarchy) with a
+            // lightweight shim that returns generic RpcError with descriptive messages.
+            errorParseLitePlugin(),
+        ],
+        footer: {
+            js: footerRedefiningGlobal,
+        },
+    },
+]);


### PR DESCRIPTION
the big kahuna. closes #1876 
first, I know it's kind of rude or perhaps a bigger deal to suggestion replacing `tsc` with `tsup`, but it came after long and grueling hours. Originally with FastNearJS I had a combo of `tsc` using `no-emit` and `esbuild`, but found `tsup` is a superset of `esbuild` and just did everything in what felt like a bulletproof way.

What's not as obvious from the summary below, is that the IIFE bundle means `near-api-js` can and will work on a static HTML site. No `yarn start` it can just use a `<script>` tag and be pulled from a CDN if desired. Quite portable while still allowing for regular NodeJS apps to use the EcmaScript build.

This change allows these three target ouputs EcmaScript, CommonJS, and browser bundle IIFE to come from the same code, and leverage ESM's safety/efficiencies. So someone can build a React app like normal and another person can (literally) run `near-api-js` on a tiny IoT sensor talking to the blockchain.

I say this not to sway, but to celebrate as we look into this: we'll have the most efficient web3 library in the world, I'm willing to debate. the most efficient web3 lib for the most efficient blockchain in the world 💪🏻

## Summary

Replace the tsc-only build with tsup producing three output formats, matching the FastNear JS Monorepo build pattern:

- **ESM** (unbundled) — tree-shakeable, preserves module structure
- **CJS** (unbundled) — Node.js CommonJS with `.cjs` extensions
- **IIFE** (bundled) — 252KB browser bundle for `<script>` tags, with lightweight shims

Adds browser shims to keep the IIFE bundle small (~116KB saved):
- `error-parse-lite.ts` — lightweight error parser replacing ~62KB error class hierarchy
- `json-validator-noop.ts` — no-op ABI validator replacing ~44KB is-my-json-valid
- `util.ts` — browser shim for node:util

**Depends on:** #1894 (inline borsh) and #1895 (crypto utils). Merge those first, then rebase this.

## Changes

| File | Change |
|------|--------|
| `tsup.config.ts` | New — build config for ESM, CJS, IIFE |
| `scripts/fix-cjs-imports.js` | New — post-build CJS .js→.cjs path fixer |
| `src/shims/error-parse-lite.ts` | New — lightweight IIFE error parser |
| `src/shims/json-validator-noop.ts` | New — no-op IIFE validator shim |
| `src/shims/util.ts` | New — browser shim for node:util |
| `package.json` | `exports` (lib/→dist/), `main`/`module`/`browser`/`types`, `build` script (tsup), `tsup` devDep, `files` (dist), `keywords`, updated `clean`/`autoclave`/`check-exports` |

## Build output

| Format | Size | Notes |
|--------|------|-------|
| ESM | ~200KB | Unbundled, tree-shakeable |
| CJS | ~300KB | Unbundled, .cjs extensions |
| IIFE | 252KB | Single bundled file, browser-ready |

## Test plan

- [x] `pnpm build` (tsup) — no errors, all 3 formats produced
- [x] `pnpm test` — all 27 test files, 346 tests pass
- [x] `pnpm check-exports` (attw) — all 7 subpath exports green across node10/node16/bundler

🤖 Generated with [Claude Code](https://claude.com/claude-code)