### PR TITLE
fix: exclude e2e from root tsconfig typecheck

### DIFF
--- a/.changeset/exclude-e2e-from-typecheck.md
+++ b/.changeset/exclude-e2e-from-typecheck.md
@@ -1,0 +1,5 @@
+---
+"near-api-js": patch
+---
+
+Exclude `e2e` directory from root `tsconfig.json` typecheck. The e2e directory has its own tsconfig and its own dependency install step, so including it in the root typecheck caused spurious failures when e2e deps weren't installed.

--- a/.changeset/exclude-e2e-from-typecheck.md
+++ b/.changeset/exclude-e2e-from-typecheck.md
@@ -1,5 +1,0 @@
----
-"near-api-js": patch
----
-
-Exclude `e2e` directory from root `tsconfig.json` typecheck. The e2e directory has its own tsconfig and its own dependency install step, so including it in the root typecheck caused spurious failures when e2e deps weren't installed.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
         "noPropertyAccessFromIndexSignature": false,
         "noUncheckedIndexedAccess": false
     },
-    "include": ["src/**/*", "test", "e2e"],
+    "include": ["src/**/*", "test"],
     "exclude": ["node_modules", "lib", "dist", "**/node_modules"],
     "files": []
 }


### PR DESCRIPTION
It seems current state is having CI issues on the end-to-end testing code. So this just gets rid of the inclusion of `e2e` which could also be seen as a total hack just to get CI to work (happy to close) or a way to exclude this until there's a better time to address the e2e stuff and re-add it. I'm loosely held on this, just thought I'd pusn a quickie since I saw CI issues on my recent tranche of 3 PRs

## Summary
- Remove `e2e` from the root `tsconfig.json` `include` array
- The `e2e/` directory has its own `tsconfig.json` and its own dependency install step in CI (`pnpm it --ignore-workspace --dir e2e`), so including it in the root typecheck causes failures when e2e deps aren't installed
- This makes `pnpm typecheck` work locally without needing to run e2e install first

## Test plan
- [ ] `pnpm typecheck` passes locally without running e2e install
- [ ] CI pipeline passes (e2e tests still run via their own step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)