### PR TITLE
fix: stop failover retries for missing accounts

### DIFF
--- a/.changeset/quiet-buses-listen.md
+++ b/.changeset/quiet-buses-listen.md
@@ -1,0 +1,5 @@
+---
+"near-api-js": patch
+---
+
+Stop retrying failover RPC providers after an account-not-found response.

--- a/src/providers/failover-rpc-provider.ts
+++ b/src/providers/failover-rpc-provider.ts
@@ -18,6 +18,7 @@ import {
     type TxExecutionStatus,
     TypedError,
 } from '../types/index.js';
+import { AccountDoesNotExistError } from './errors/handler.js';
 import type {
     CallFunctionArgs,
     Provider,
@@ -80,6 +81,9 @@ export class FailoverRpcProvider implements Provider {
 
                 return result;
             } catch (e) {
+                if (e instanceof AccountDoesNotExistError) {
+                    throw e;
+                }
                 console.error(e);
                 this.switchToNextProvider();
             }

--- a/test/unit/providers/providers.test.ts
+++ b/test/unit/providers/providers.test.ts
@@ -2,6 +2,7 @@ import { Worker } from 'near-workspaces';
 import { TextEncoder } from 'util';
 import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 import { FailoverRpcProvider, getTransactionLastResult, JsonRpcProvider, type Provider } from '../../../src/index.js';
+import { AccountDoesNotExistError } from '../../../src/providers/errors/handler.js';
 
 global.TextEncoder = TextEncoder;
 
@@ -223,6 +224,39 @@ describe('failover provider', () => {
         const provider = new FailoverRpcProvider(jsonProviders);
 
         expect(await provider.viewNodeStatus()).toBe('second');
+    });
+
+    test('FailoverRpc does not retry account-not-found errors', async () => {
+        let secondProviderCalls = 0;
+        const accountNotFound = new AccountDoesNotExistError('missing.near', 'block-hash', 1);
+        const jsonProviders = [
+            Object.setPrototypeOf(
+                {
+                    viewAccount() {
+                        throw accountNotFound;
+                    },
+                },
+                JsonRpcProvider.prototype
+            ),
+            Object.setPrototypeOf(
+                {
+                    viewAccount() {
+                        secondProviderCalls += 1;
+                        return {
+                            amount: '0',
+                        };
+                    },
+                },
+                JsonRpcProvider.prototype
+            ),
+        ];
+
+        const provider = new FailoverRpcProvider(jsonProviders);
+
+        await expect(
+            provider.viewAccount({ accountId: 'missing.near', blockQuery: { finality: 'final' } })
+        ).rejects.toThrow(AccountDoesNotExistError);
+        expect(secondProviderCalls).toBe(0);
     });
 
     test('FailoverRpc returns error if all providers are unavailable', async () => {


### PR DESCRIPTION
## Pre-flight checklist

- [x] I have read the [Contributing Guidelines on pull requests](https://github.com/near/near-api-js/blob/master/CONTRIBUTING.md).
- [x] Commit messages follow the [conventional commits](https://www.conventionalcommits.org/) spec
- [x] **If this is a code change**: I have written unit tests.
- [x] **If this changes code in a published package**: I have added a `changeset` document appropriate for this change.
- [ ] **If this is a new API or substantial change**: the PR has an accompanying issue (closes #0000) and the maintainers have approved on my working plan. Not applicable; this is a narrow bug fix for #1647.

## Motivation

Closes #1647.

`FailoverRpcProvider` currently catches `AccountDoesNotExistError` from `viewAccount` and treats it like a provider failure. That lets a later provider mask the deterministic account-not-found response.

This change rethrows `AccountDoesNotExistError` before switching providers, while leaving failover behavior unchanged for provider/network errors.

## Test Plan

- `npx -y node@20.18.3 node_modules/vitest/vitest.mjs run`
- `pnpm lint`
- `pnpm build`
- `npm_config_cache=/private/tmp/near-npm-cache pnpm check-exports`

## Related issues/PRs

Closes #1647
